### PR TITLE
fix: close #91

### DIFF
--- a/src/web.config.ts
+++ b/src/web.config.ts
@@ -619,12 +619,12 @@ export default defineConfig({
               }),
               components.switch.create('tip', {
                 label: '解析提示',
-                description: '抖音解析提示，发送提示信息：“检测到快手链接，开始解析”',
+                description: '快手解析提示，发送提示信息：“检测到快手链接，开始解析”',
                 defaultSelected: all.kuaishou.tip
               }),
               components.switch.create('comment', {
                 label: '评论解析',
-                description: '快手评论解析，开启后可发送抖音作品评论图',
+                description: '快手评论解析，开启后可发送快手作品评论图',
                 defaultSelected: all.kuaishou.comment
               }),
               components.input.number('numcomment', {


### PR DESCRIPTION
修复一些拼写错误，详见https://github.com/ikenxuan/karin-plugin-kkk/issues/91

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

修复快手插件配置描述中的拼写错误

Bug 修复：
- 将“解析提示”开关描述更正为引用快手而不是抖音
- 更新“评论解析”开关描述，以提及快手评论而不是抖音

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix typos in the Kuaishou plugin configuration descriptions

Bug Fixes:
- Correct the '解析提示' switch description to reference Kuaishou instead of Douyin
- Update the '评论解析' switch description to mention Kuaishou comments instead of Douyin

</details>