### PR TITLE
fix: uploadFile API uses local absolute paths

### DIFF
--- a/.github/workflows/publish-temp.yml
+++ b/.github/workflows/publish-temp.yml
@@ -99,7 +99,6 @@ jobs:
           # 在工作流摘要中添加信息 (使用正确的命令)
           echo "## Published Packages :package:" >> $GITHUB_STEP_SUMMARY
           echo "version: \`${{ env.PKG_VERSION }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "commit: [\`${{ env.SHORT_COMMIT_HASH }}\`](${{ env.REPO_URL }})" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "use pnpm:" >> $GITHUB_STEP_SUMMARY
           echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
@@ -170,17 +169,16 @@ jobs:
             now.setHours(now.getHours() + 8);
             const cstTime = now.toISOString().replace('T', ' ').substring(0, 19);
             
-            // 构建与摘要类似的评论内容 (确保使用从 output.json 获取的 installUrl)
+            // 构建与摘要类似的评论内容 (使用简化后的URL)
             const body = `## Published Packages :package:
             
             version: \`${process.env.PKG_VERSION}\`
-            commit: [\`${shortSha}\`](${commitUrl})
             
             ${stackblitzUrl ? `[Open in Stackblitz](${stackblitzUrl})` : ''}
             
             use pnpm:
             \`\`\`
-            pnpm add ${installUrl || '无法获取安装 URL'} -w 
+            pnpm add ${simplifiedUrl || '无法获取安装 URL'} -w 
             \`\`\`
             
             pack time: <code>${cstTime} (CST)</code>`;

--- a/.github/workflows/publish-temp.yml
+++ b/.github/workflows/publish-temp.yml
@@ -148,28 +148,11 @@ jobs:
                installUrl = '无法获取安装 URL'; // 提供错误信息
             }
             
-            // 获取Stackblitz链接
-            let stackblitzUrl = '';
-            try {
-              const output = JSON.parse(fs.readFileSync('output.json', 'utf8'));
-              for (const template of output.templates) {
-                stackblitzUrl = template.url;
-                break; // 只取第一个模板的URL
-              }
-            } catch (error) {
-               console.error('无法读取或解析 output.json 获取 Stackblitz URL:', error);
-            }
-            
             // 简化安装URL格式为 包名@短哈希
             const repoName = context.repo.repo; // 获取仓库名
             const simplifiedUrl = `https://pkg.pr.new/${repoName}@${shortSha}`;
             
-            // 获取Stackblitz链接
-            let stackblitzUrl = '';
-            for (const template of output.templates) {
-              stackblitzUrl = template.url;
-              break; // 只取第一个模板的URL
-            }
+            // 注意：这里删除了重复声明的stackblitzUrl代码块
             
             // 获取当前中国标准时间
             const now = new Date();

--- a/.github/workflows/publish-temp.yml
+++ b/.github/workflows/publish-temp.yml
@@ -152,7 +152,17 @@ jobs:
             const repoName = context.repo.repo; // 获取仓库名
             const simplifiedUrl = `https://pkg.pr.new/${repoName}@${shortSha}`;
             
-            // 注意：这里删除了重复声明的stackblitzUrl代码块
+            // 获取Stackblitz链接
+            let stackblitzUrl = '';
+            try {
+              const output = JSON.parse(fs.readFileSync('output.json', 'utf8'));
+              for (const template of output.templates) {
+                stackblitzUrl = template.url;
+                break; // 只取第一个模板的URL
+              }
+            } catch (error) {
+               console.error('无法读取或解析 output.json 获取 Stackblitz URL:', error);
+            }
             
             // 获取当前中国标准时间
             const now = new Date();

--- a/src/module/utils/Common.ts
+++ b/src/module/utils/Common.ts
@@ -2,12 +2,12 @@ import fs from 'node:fs'
 import path from 'node:path'
 
 import { createNotFoundResponse, logger, Message } from 'node-karin'
-import express from 'node-karin/express'
 import { karinPathTemp } from 'node-karin/root'
 
 import { Config } from '@/module/utils'
 
 import { Version } from '../../Version'
+import { Response } from 'node-karin/express'
 
 /** 常用工具合集 */
 class Tools {
@@ -23,7 +23,7 @@ class Tools {
     images: string
   }
 
-  constructor () {
+  constructor() {
     this.tempDri = {
       /** 插件缓存目录 */
       default: `${karinPathTemp}/${Version.pluginName}/`.replace(/\\/g, '/'),
@@ -39,7 +39,7 @@ class Tools {
    * @param e event 消息事件
    * @returns 被引用的消息
    */
-  async getReplyMessage (e: Message): Promise<string> {
+  async getReplyMessage(e: Message): Promise<string> {
     if (e.replyId) {
       const reply = await e.bot.getMsg(e.contact, e.replyId)
       for (const v of reply.elements) {
@@ -58,7 +58,7 @@ class Tools {
  * @param chineseNumber 数字的中文
  * @returns 中文数字对应的阿拉伯数字映射
  */
-  chineseToArabic (chineseNumber: string): number {
+  chineseToArabic(chineseNumber: string): number {
     // 映射表，定义基础的中文数字
     const chineseToArabicMap: Record<string, number> = {
       零: 0, 一: 1, 二: 2, 三: 3, 四: 4, 五: 5, 六: 6, 七: 7, 八: 8, 九: 9
@@ -100,7 +100,7 @@ class Tools {
  * @param cookies cookie数组
  * @returns 格式化后的cookie字符串
  */
-  formatCookies (cookies: any[]): string {
+  formatCookies(cookies: any[]): string {
     return cookies.map(cookie => {
       // 分割每个cookie字符串以获取名称和值
       const [nameValue] = cookie.split(';').map((part: string) => part.trim())
@@ -117,7 +117,7 @@ class Tools {
  * @param duration 视频时长（秒）
  * @returns
  */
-  calculateBitrate (targetSizeMB: number, duration: number): number {
+  calculateBitrate(targetSizeMB: number, duration: number): number {
     // 将目标大小转换为字节
     const targetSizeBytes = targetSizeMB * 1024 * 1024 // 转换为字节
     // 计算比特率并返回单位 Mbps
@@ -129,7 +129,7 @@ class Tools {
    * @param filePath 视频文件绝对路径
    * @returns
    */
-  async getVideoFileSize (filePath: string): Promise<number> {
+  async getVideoFileSize(filePath: string): Promise<number> {
     try {
       const stats = await fs.promises.stat(filePath) // 获取文件信息
       const fileSizeInBytes = stats.size // 文件大小（字节）
@@ -147,7 +147,7 @@ class Tools {
    * @param force 是否强制删除，默认 `false`
    * @returns
    */
-  async removeFile (path: string, force = false): Promise<boolean> {
+  async removeFile(path: string, force = false): Promise<boolean> {
     path = path.replace(/\\/g, '/')
     if (Config.app.rmmp4) {
       try {
@@ -176,7 +176,7 @@ class Tools {
  * @param timestamp 时间戳
  * @returns 格式为YYYY-MM-DD HH:MM的日期时间字符串
  */
-  convertTimestampToDateTime (timestamp: number): string {
+  convertTimestampToDateTime(timestamp: number): string {
     // 创建一个Date对象，时间戳乘以1000是为了转换为毫秒
     const date = new Date(timestamp * 1000)
     const year = date.getFullYear() // 获取年份
@@ -192,7 +192,7 @@ class Tools {
  * 获取当前时间：年-月-日 时:分:秒
  * @returns
  */
-  getCurrentTime () {
+  getCurrentTime() {
     // 创建一个Date对象以获取当前时间
     const now = new Date()
     // 获取年、月、日、时、分、秒
@@ -215,7 +215,7 @@ class Tools {
  * 评论图、推送图是否使用深色模式
  * @returns
  */
-  useDarkTheme (): boolean {
+  useDarkTheme(): boolean {
     let dark = true
     const configTheme = Config.app.Theme
     if (configTheme === 0) { // 自动
@@ -236,7 +236,7 @@ class Tools {
  * @param timestamp 时间戳
  * @returns 距离这个时间戳过去的多久的字符串
  */
-  timeSince (timestamp: number): string {
+  timeSince(timestamp: number): string {
     const now = Date.now()
     const elapsed = now - timestamp
 
@@ -262,7 +262,7 @@ class Tools {
    * @param res 响应对象
    * @returns 返回安全解析后的路径
    */
-  validateVideoRequest (filename: string | undefined, res: express.Response): string | null {
+  validateVideoRequest(filename: string | undefined, res: Response): string | null {
     // 1. 基础校验
     if (!filename) {
       createNotFoundResponse(res, '无效的文件名')


### PR DESCRIPTION
好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

修复 `uploadFile` 函数，通过重命名内部变量、统一 base64 与路径赋值方式，并确保视频片段正确使用 `file://` 前缀；重构 `Common.ts` 的导入和格式，以保持一致性。

Bug 修复：
- 将 `File` 变量重命名为 `filePath`，并更新 `uploadFile` 逻辑，以便为 `bot.uploadFile` 调用使用 `filePath`。
- 确保 `segment.video` 调用仅在需要时才添加 `file://` 前缀，并正确处理 base64 URI，避免重复添加前缀。

增强功能：
- 移除 `Common.ts` 中未使用的 `express` 导入，并为 `validateVideoRequest` 导入 `Response` 类型。
- 标准化 `Common.ts` 实用程序方法的方法签名和间距。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix uploadFile function by renaming the internal variable, unifying base64 vs path assignment, and ensuring correct file:// prefix usage for video segments; refactor Common.ts imports and formatting for consistency.

Bug Fixes:
- Rename File variable to filePath and update uploadFile logic to use filePath for bot.uploadFile calls.
- Ensure segment.video calls prepend file:// only when needed and correctly handle base64 URIs instead of duplicating prefixes.

Enhancements:
- Remove unused express import in Common.ts and import Response type for validateVideoRequest.
- Standardize method signatures and spacing across Common.ts utility methods.

</details>