### PR TITLE
fix: mkdir-db

### DIFF
--- a/packages/core/src/module/db/bilibili.ts
+++ b/packages/core/src/module/db/bilibili.ts
@@ -1,4 +1,5 @@
-import { join } from 'node:path'
+import fs from 'node:fs'
+import path from 'node:path'
 
 import { logger } from 'node-karin'
 import { karinPathBase } from 'node-karin/root'
@@ -123,7 +124,7 @@ export class BilibiliDBBase {
   private dbPath: string
 
   constructor () {
-    this.dbPath = join(`${karinPathBase}/${Root.pluginName}/data`, 'bilibili.db')
+    this.dbPath = path.join(`${karinPathBase}/${Root.pluginName}/data`, 'bilibili.db')
   }
 
   /**
@@ -135,6 +136,7 @@ export class BilibiliDBBase {
       logger.debug('[BilibiliDB] 正在连接数据库...')
 
       // 创建数据库连接
+      await fs.promises.mkdir(path.dirname(this.dbPath), { recursive: true })
       this.db = new sqlite3.Database(this.dbPath)
 
       // 创建表结构

--- a/packages/core/src/module/db/douyin.ts
+++ b/packages/core/src/module/db/douyin.ts
@@ -1,4 +1,5 @@
-import { join } from 'node:path'
+import fs from 'node:fs'
+import path from 'node:path'
 
 import { logger } from 'node-karin'
 import { karinPathBase } from 'node-karin/root'
@@ -125,7 +126,8 @@ export class DouyinDBBase {
   private dbPath: string
 
   constructor () {
-    this.dbPath = join(`${karinPathBase}/${Root.pluginName}/data`, 'douyin.db')
+    this.dbPath = path.join(`${karinPathBase}/${Root.pluginName}/data`, 'douyin.db')
+
   }
 
   /**
@@ -137,6 +139,7 @@ export class DouyinDBBase {
       logger.debug('[DouyinDB] 正在连接数据库...')
 
       // 创建数据库连接
+      await fs.promises.mkdir(path.dirname(this.dbPath), { recursive: true })
       this.db = new sqlite3.Database(this.dbPath)
 
       // 创建表结构


### PR DESCRIPTION
## Sourcery 总结

确保在初始化 SQLite 数据库之前创建数据库目录，并在 Douyin 和 Bilibili 模块中使用一致的路径拼接方式。

改进点：
- 在 Douyin 和 Bilibili 模块中，在打开数据库之前递归地创建数据库目录
- 将直接的路径拼接替换为 `path.join`，以实现一致的路径拼接

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure database directories are created before initializing the SQLite databases and use consistent path joining in Douyin and Bilibili modules

Enhancements:
- Create database directories recursively before opening the database in Douyin and Bilibili modules
- Replace bare join with path.join for consistent path concatenation

</details>