### PR TITLE
fix: 兼容性提高

### DIFF
--- a/packages/core/src/module/utils/Base.ts
+++ b/packages/core/src/module/utils/Base.ts
@@ -3,7 +3,7 @@ import fs from 'node:fs'
 import karin, { type Contact, logger, Message, segment } from 'node-karin'
 import type { AxiosHeaders, AxiosRequestConfig, Method, RawAxiosRequestHeaders } from 'node-karin/axios'
 
-import { baseHeaders, Common, compressVideo, getMediaDuration, Networks } from '@/module/utils'
+import { baseHeaders, Common, compressVideo, extractTotalSizeFromHeaders, getMediaDuration, Networks } from '@/module/utils'
 import { Config } from '@/module/utils/Config'
 import type { pushlistConfig } from '@/types/config/pushlist'
 
@@ -36,6 +36,8 @@ type title = {
 type downloadFileOptions = {
   /** 视频链接 */
   video_url: string
+  /** 已知的视频大小（字节），优先用于下载前大小判断 */
+  expectedSizeBytes?: number
   /** 文件名 */
   title: title
   /** 下载文件类型，默认为'.mp4'。 */
@@ -299,14 +301,36 @@ export const uploadFile = async (event: Message, file: fileInfo, videoUrl: strin
  * @returns
  */
 export const downloadVideo = async (event: Message, downloadOpt: downloadFileOptions, uploadOpt?: uploadFileOptions): Promise<boolean> => {
-  /** 获取文件大小 */
-  const fileHeaders = await new Networks({ url: downloadOpt.video_url, headers: downloadOpt.headers ?? baseHeaders }).getHeaders()
-  const fileSizeContent = fileHeaders['content-range']?.match(/\/(\d+)/) ? parseInt(fileHeaders['content-range']?.match(/\/(\d+)/)[1], 10) : 0
-  const fileSizeInMB = (fileSizeContent / (1024 * 1024)).toFixed(2)
-  const fileSize = parseInt(parseFloat(fileSizeInMB).toFixed(2))
-  if (Config.upload.usefilelimit && fileSize > Config.upload.filelimit) {
+  let fileSizeInMB: number | null = null
+
+  if (
+    typeof downloadOpt.expectedSizeBytes === 'number' &&
+    Number.isFinite(downloadOpt.expectedSizeBytes) &&
+    downloadOpt.expectedSizeBytes > 0
+  ) {
+    fileSizeInMB = downloadOpt.expectedSizeBytes / (1024 * 1024)
+  } else {
+    try {
+      const fileHeaders = await new Networks({
+        url: downloadOpt.video_url,
+        headers: downloadOpt.headers ?? baseHeaders
+      }).getHeaders()
+      const totalBytes = extractTotalSizeFromHeaders(fileHeaders)
+
+      if (totalBytes !== null) {
+        fileSizeInMB = totalBytes / (1024 * 1024)
+      } else {
+        logger.warn(`[karin-plugin-kkk] 无法从响应头解析视频大小，跳过下载前大小限制校验: ${downloadOpt.video_url}`)
+      }
+    } catch (error) {
+      logger.warn(`[karin-plugin-kkk] 下载前获取视频大小失败，将继续直接下载: ${error instanceof Error ? error.message : String(error)}`)
+    }
+  }
+
+  if (Config.upload.usefilelimit && fileSizeInMB !== null && fileSizeInMB > Config.upload.filelimit) {
+    const fileSizeText = fileSizeInMB.toFixed(2)
     const message = segment.text(`视频：「${downloadOpt.title.originTitle ??
-      'Error: 文件名获取失败'}」大小 (${fileSizeInMB} MB) 超出最大限制（设定值：${Config.upload.filelimit} MB），已取消上传`)
+      'Error: 文件名获取失败'}」大小 (${fileSizeText} MB) 超出最大限制（设定值：${Config.upload.filelimit} MB），已取消上传`)
     const selfId = event.selfId || uploadOpt?.activeOption?.uin as string
     const contact = event.contact || karin.contactGroup(uploadOpt?.activeOption?.group_id as string) || karin.contactFriend(selfId)
 

--- a/packages/core/src/module/utils/Network/Downloader.ts
+++ b/packages/core/src/module/utils/Network/Downloader.ts
@@ -8,6 +8,7 @@ import { AxiosError } from 'node-karin/axios'
 
 import {
   calculateBackoffDelay,
+  extractTotalSizeFromHeaders,
   formatBytes,
   getErrorDescription,
   isRecoverableNetworkError,
@@ -122,25 +123,40 @@ export class Downloader {
       // 检查 HTTP 状态码
       // 416 Range Not Satisfiable
       if (response.status === 416) {
-        logger.warn('服务器返回 416，文件可能已下载完成，验证文件大小...')
-        
+        logger.warn('服务器返回 416，开始严格校验本地文件是否真的完整...')
+
         if (fs.existsSync(this.filepath)) {
           const stats = fs.statSync(this.filepath)
-          logger.debug(`当前文件大小: ${formatBytes(stats.size)}`)
-          
-          // 如果文件大小合理（大于 1KB），认为下载完成
-          if (stats.size > 1024) {
-            logger.debug('文件大小合理，认为下载已完成')
+          const localSize = stats.size
+          const remoteTotalSize = extractTotalSizeFromHeaders(response.headers)
+          logger.debug(`当前文件大小: ${formatBytes(localSize)}`)
+
+          if (remoteTotalSize !== null && localSize === remoteTotalSize) {
+            logger.debug('416 校验通过，本地文件已完整下载')
             return {
               filepath: this.filepath,
-              totalBytes: stats.size
+              totalBytes: localSize
             }
+          }
+
+          if (remoteTotalSize !== null) {
+            logger.warn(`416 校验失败: 本地 ${formatBytes(localSize)}, 远端 ${formatBytes(remoteTotalSize)}，将删除残缺文件并重新下载`)
           } else {
-            // 文件太小，删除并重新下载
-            logger.warn('文件太小，删除并重新下载')
+            logger.warn('416 响应未提供可验证的远端总大小，不能将现有文件视为完整，准备重新下载')
+          }
+
+          if (fs.existsSync(this.filepath)) {
             fs.unlinkSync(this.filepath)
+          }
+
+          if (retryCount < this.maxRetries) {
+            const nextDelay = calculateBackoffDelay(retryCount)
+            logger.warn(`正在重试完整下载... (${retryCount + 1}/${this.maxRetries})，将在 ${nextDelay / 1000} 秒后重新开始`)
+            await new Promise(resolve => setTimeout(resolve, nextDelay))
             return this.download(progressCallback, retryCount + 1)
           }
+
+          throw new Error('服务器返回 416，但本地文件未通过完整性校验')
         }
       }
       
@@ -163,6 +179,26 @@ export class Downloader {
 
       // 检查服务器是否支持断点续传
       const supportsRange = response.status === 206
+      const contentRange = typeof response.headers['content-range'] === 'string'
+        ? response.headers['content-range']
+        : ''
+
+      if (startByte > 0 && supportsRange) {
+        const rangeStart = contentRange.match(/^bytes\s+(\d+)-/i)
+        const resumedFrom = rangeStart ? Number.parseInt(rangeStart[1], 10) : null
+
+        if (resumedFrom === null || resumedFrom !== startByte) {
+          logger.warn(`断点续传响应区间异常，期望从 ${formatBytes(startByte)} 继续，实际 Content-Range 为 "${contentRange || '缺失'}"，将重新下载整个文件`)
+          if (fs.existsSync(this.filepath)) {
+            fs.unlinkSync(this.filepath)
+          }
+          if (retryCount >= this.maxRetries) {
+            throw new Error(`断点续传响应区间异常，且已达到最大重试次数: ${contentRange || '缺失'}`)
+          }
+          return this.download(progressCallback, retryCount + 1)
+        }
+      }
+
       if (startByte > 0 && !supportsRange) {
         logger.warn('服务器不支持断点续传，将重新下载整个文件')
         if (fs.existsSync(this.filepath)) {

--- a/packages/core/src/module/utils/Network/Network.ts
+++ b/packages/core/src/module/utils/Network/Network.ts
@@ -14,6 +14,25 @@ import { Downloader } from './Downloader'
 import { getErrorDescription, isRecoverableNetworkError, sanitizeHeaders } from './helpers'
 import type { CustomAxiosRequestConfig, DownloadResult, ProgressCallback, ThrottleConfig } from './types'
 
+const isSuccessfulProbeStatus = (status: number): boolean => status >= 200 && status < 400
+
+const releaseResponseData = (response?: AxiosResponse): void => {
+  const data = response?.data as { destroy?: () => void, resume?: () => void } | undefined
+  if (!data) return
+
+  try {
+    data.resume?.()
+  } catch {
+    // ignore stream cleanup failure
+  }
+
+  try {
+    data.destroy?.()
+  } catch {
+    // ignore stream cleanup failure
+  }
+}
+
 /**
  * 网络请求类
  * 支持常规请求、文件下载（带限速和断点续传）、重定向跟踪等功能
@@ -182,7 +201,8 @@ export class Network {
           url: targetUrl,
           method,
           maxRedirects: 5,
-          validateStatus: (status) => status >= 200 && status < 400,
+          validateStatus: isSuccessfulProbeStatus,
+          responseType: 'stream',
           headers: method === 'get' ? { ...this.headers, Range: 'bytes=0-0' } : this.headers,
           skipRetry: true
         } as CustomAxiosRequestConfig)
@@ -191,9 +211,11 @@ export class Network {
           (response.request as any)?.res?.responseUrl ??
           (response.config as any)?.url ??
           targetUrl
+        releaseResponseData(response)
         return finalUrl
       } catch (error) {
         const axiosError = error as AxiosError
+        releaseResponseData(axiosError.response as AxiosResponse | undefined)
 
         // 处理所有重定向状态码
         const redirectStatuses = [301, 302, 303, 307, 308]
@@ -276,27 +298,87 @@ export class Network {
    * 适用于获取视频流的完整大小
    */
   async getHeaders (): Promise<AxiosResponse['headers']> {
-    try {
-      const response = await this.axiosInstance({
-        ...this.config,
-        method: 'GET',
-        headers: {
-          ...this.config.headers,
-          Range: 'bytes=0-0'
+    const probeConfigs: Array<{ label: string, config: CustomAxiosRequestConfig }> = [
+      {
+        label: 'HEAD',
+        config: {
+          ...this.config,
+          method: 'HEAD',
+          responseType: 'stream',
+          skipRetry: true
         }
-      })
-      return response.headers
-    } catch (error) {
-      if (error instanceof AxiosError) {
-        const sanitized = sanitizeHeaders(this.headers)
-        const errorDesc = getErrorDescription(error)
-        const errorMsg = `获取响应头失败: ${errorDesc}, URL: ${this.url}, Headers: ${JSON.stringify(sanitized)}`
-        logger.error(errorMsg)
-        throw new Error(errorMsg)
+      },
+      {
+        label: 'GET_RANGE',
+        config: {
+          ...this.config,
+          method: 'GET',
+          responseType: 'stream',
+          headers: {
+            ...this.config.headers,
+            Range: 'bytes=0-0'
+          },
+          skipRetry: true
+        }
+      },
+      {
+        label: 'GET_FULL',
+        config: {
+          ...this.config,
+          method: 'GET',
+          responseType: 'stream',
+          skipRetry: true
+        }
       }
-      logger.error(error)
-      throw error
+    ]
+
+    let lastError: unknown = null
+
+    for (const probe of probeConfigs) {
+      try {
+        const response = await this.axiosInstance(probe.config)
+        if (isSuccessfulProbeStatus(response.status)) {
+          releaseResponseData(response)
+          return response.headers
+        }
+
+        releaseResponseData(response)
+        lastError = new Error(`${probe.label} 返回了 HTTP ${response.status}`)
+        logger.debug(`[karin-plugin-kkk] ${probe.label} 获取响应头返回 HTTP ${response.status}，继续尝试备用探测方案`)
+      } catch (error) {
+        if (error instanceof AxiosError) {
+          const status = error.response?.status
+          if (
+            status &&
+            isSuccessfulProbeStatus(status) &&
+            error.response?.headers &&
+            Object.keys(error.response.headers).length > 0
+          ) {
+            releaseResponseData(error.response as AxiosResponse)
+            logger.warn(`[karin-plugin-kkk] ${probe.label} 在读取响应体时被中断，已回退为直接使用已收到的响应头`)
+            return error.response.headers
+          }
+        }
+
+        if (error instanceof AxiosError) {
+          releaseResponseData(error.response as AxiosResponse | undefined)
+          logger.debug(`[karin-plugin-kkk] ${probe.label} 获取响应头失败: ${getErrorDescription(error)}`)
+        }
+
+        lastError = error
+      }
     }
+
+    if (lastError instanceof AxiosError) {
+      const sanitized = sanitizeHeaders(this.headers)
+      const errorDesc = getErrorDescription(lastError)
+      const errorMsg = `获取响应头失败: ${errorDesc}, URL: ${this.url}, Headers: ${JSON.stringify(sanitized)}`
+      logger.error(errorMsg)
+      throw new Error(errorMsg)
+    }
+
+    logger.error(lastError)
+    throw lastError
   }
 
   /**
@@ -306,11 +388,14 @@ export class Network {
     try {
       const response = await this.axiosInstance({
         ...this.config,
-        method: 'GET'
+        method: 'GET',
+        responseType: 'stream'
       })
+      releaseResponseData(response)
       return response.headers
     } catch (error) {
       if (error instanceof AxiosError) {
+        releaseResponseData(error.response as AxiosResponse | undefined)
         const sanitized = sanitizeHeaders(this.headers)
         const errorDesc = getErrorDescription(error)
         const errorMsg = `获取完整响应头失败: ${errorDesc}, URL: ${this.url}, Headers: ${JSON.stringify(sanitized)}`

--- a/packages/core/src/module/utils/Network/helpers.ts
+++ b/packages/core/src/module/utils/Network/helpers.ts
@@ -71,6 +71,42 @@ export const sanitizeHeaders = (
 }
 
 /**
+ * 从响应头中提取资源总大小（字节）
+ * @param headers 响应头
+ * @returns 资源总大小，无法解析时返回 null
+ */
+export const extractTotalSizeFromHeaders = (
+  headers: Record<string, unknown> | AxiosRequestConfig['headers'] | undefined
+): number | null => {
+  if (!headers) return null
+
+  const normalizedHeaders = Object.fromEntries(
+    Object.entries(headers).map(([key, value]) => [key.toLowerCase(), value])
+  )
+
+  const contentRange = normalizedHeaders['content-range']
+  if (typeof contentRange === 'string') {
+    const matched = contentRange.match(/\/(\d+)$/)
+    if (matched) {
+      const totalBytes = Number.parseInt(matched[1], 10)
+      if (Number.isFinite(totalBytes) && totalBytes > 0) {
+        return totalBytes
+      }
+    }
+  }
+
+  const contentLength = normalizedHeaders['content-length']
+  if (typeof contentLength === 'string' || typeof contentLength === 'number') {
+    const totalBytes = Number.parseInt(String(contentLength), 10)
+    if (Number.isFinite(totalBytes) && totalBytes > 0) {
+      return totalBytes
+    }
+  }
+
+  return null
+}
+
+/**
  * 判断错误是否为可恢复的网络错误
  * @param error 错误对象
  * @returns 是否为可恢复错误

--- a/packages/core/src/module/utils/Network/index.ts
+++ b/packages/core/src/module/utils/Network/index.ts
@@ -7,6 +7,7 @@ export { BASE_HEADERS } from './constants'
 export { Downloader } from './Downloader'
 export {
   calculateBackoffDelay,
+  extractTotalSizeFromHeaders,
   formatBytes,
   getErrorDescription,
   isRecoverableNetworkError,

--- a/packages/core/src/module/utils/Networks.ts
+++ b/packages/core/src/module/utils/Networks.ts
@@ -13,6 +13,7 @@ export {
   baseHeaders,
   DEFAULT_THROTTLE_CONFIG,
   Downloader,
+  extractTotalSizeFromHeaders,
   formatBytes,
   getErrorDescription,
   isRecoverableNetworkError,

--- a/packages/core/src/platform/douyin/douyin.ts
+++ b/packages/core/src/platform/douyin/douyin.ts
@@ -586,6 +586,8 @@ export class DouYin extends Base {
         const sendvideofile = true
         type VideoType = DyVideoWork['aweme_detail']['video']
         let video: VideoType | null = null
+        const douyinMediaReferer = VideoData.data.aweme_detail.share_url ||
+          `https://www.douyin.com/video/${VideoData.data.aweme_detail.aweme_id}`
         if (isVideo) {
           // 视频地址特殊判断：play_addr_h264、play_addr、
           video = VideoData.data.aweme_detail.video as VideoType
@@ -605,7 +607,7 @@ export class DouYin extends Base {
             url: video.bit_rate[0].play_addr.url_list[2],
             headers: {
               ...this.headers,
-              Referer: video.bit_rate[0].play_addr.url_list[0]
+              Referer: douyinMediaReferer
             }
           }).getLongLink()
           const title = VideoData.data.aweme_detail.preview_title.substring(0, 80).replace(/[\\/:*?"<>|\r\n]/g, ' ') // video title
@@ -788,7 +790,7 @@ export class DouYin extends Base {
           if ((this.forceBurnDanmaku || Config.douyin.burnDanmaku) && danmakuList.length > 0) {
             const videoFile = await downloadFile(g_video_url, {
               title: `Douyin_V_tmp_${Date.now()}.mp4`,
-              headers: { ...baseHeaders, Referer: g_video_url }
+              headers: { ...baseHeaders, Referer: douyinMediaReferer }
             })
             if (videoFile.filepath) {
               const resultPath = Common.tempDri.video + `Douyin_Result_${Date.now()}.mp4`
@@ -821,13 +823,14 @@ export class DouYin extends Base {
               this.e,
               {
                 video_url: g_video_url,
+                expectedSizeBytes: video?.bit_rate[0]?.play_addr.data_size,
                 title: {
                   timestampTitle: `tmp_${Date.now()}.mp4`,
                   originTitle: `${g_title}.mp4`
                 },
                 headers: {
                   ...baseHeaders,
-                  Referer: g_video_url
+                  Referer: douyinMediaReferer
                 }
               },
               {

--- a/packages/core/src/platform/douyin/push.ts
+++ b/packages/core/src/platform/douyin/push.ts
@@ -460,7 +460,11 @@ export class DouYinpush extends Base {
                     视频ID：${logger.green(Detail_Data.aweme_id)}\n
                     分享链接：${logger.green(Detail_Data.share_url)}
                     `)
-                const videoObj = douyinProcessVideos(Detail_Data.video.bit_rate, Config.douyin.videoQuality)
+                const videoObj = douyinProcessVideos(
+                  Detail_Data.video.bit_rate,
+                  Config.douyin.videoQuality,
+                  Config.douyin.maxAutoVideoSize
+                )
                 logger.debug('获取精确下载地址')
                 downloadUrl = await new Networks({
                   url: videoObj[0].play_addr.url_list[0],
@@ -469,7 +473,9 @@ export class DouYinpush extends Base {
                 // 下载视频
                 await downloadVideo(this.e, {
                   video_url: downloadUrl,
-                  title: { timestampTitle: `tmp_${Date.now()}.mp4`, originTitle: `${Detail_Data.desc}.mp4` }
+                  expectedSizeBytes: videoObj[0].play_addr.data_size,
+                  title: { timestampTitle: `tmp_${Date.now()}.mp4`, originTitle: `${Detail_Data.desc}.mp4` },
+                  headers: douyinBaseHeaders
                 }, { active: true, activeOption: { uin: botId, group_id: groupId } })
               } catch (error) {
                 throw new Error(`下载视频失败: ${error}`)


### PR DESCRIPTION
## Summary by Sourcery

Improve network request compatibility and video download size handling across core utilities and Douyin integrations.

New Features:
- Allow callers of video download to provide an expected file size to pre-check against upload limits.

Bug Fixes:
- Prevent potential stream resource leaks by explicitly resuming and destroying Axios stream responses in network helpers.
- Improve robustness of header probing by falling back across multiple HTTP methods and reusing partial responses when body reads fail.
- Fix incorrect Douyin Referer usage by consistently using the share URL or canonical video URL as the media referer.

Enhancements:
- Add a generic helper to extract total content size from HTTP headers using Content-Range or Content-Length and reuse it in download size checks.
- Expand header retrieval logic to try HEAD, ranged GET, and full GET with better logging and error reporting for edge cases.
- Refine video size limit checks to tolerate missing or failed header size lookups and log when pre-checks are skipped.
- Expose new network utilities like total-size extraction through public Network exports for reuse.