### PR TITLE
refactor: 替换二维码生成实现

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -65,6 +65,7 @@
     "watch": "cross-env EBV_FILE=\"development.env\" tsx watch --include \"src/**/*.ts\" --include \"../template/src/dev/mock-server.ts\" --include \"../template/src/main.ts\" src/app.ts --trace-deprecation"
   },
   "dependencies": {
+    "@ikenxuan/qrcode": "^1.1.0",
     "@ikenxuan/watermark": "1.1.5",
     "fingerprint-injector": "^2.1.82"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -80,13 +80,11 @@
     "@types/pngjs": "^6.0.5",
     "cookie": "^1.1.1",
     "date-fns": "^4.3.0",
-    "happy-dom": "^20.9.0",
     "heic-decode": "^2.1.0",
     "http-proxy-middleware": "4.0.0",
     "jpeg-js": "^0.4.4",
     "jsqr": "^1.4.0",
     "pngjs": "^7.0.0",
-    "qr-code-styling": "^1.9.2",
     "template": "workspace:*",
     "tsdown": "^0.22.0",
     "vite-plugin-top-level-await": "^1.6.0",
@@ -124,5 +122,5 @@
     "web": "./lib/web.config.js",
     "ts-web": "./src/web.config.ts"
   },
-  "timestamp": "2026-05-25T17:07:05.459Z"
+  "timestamp": "2026-05-27T00:00:10.462Z"
 }

--- a/packages/core/src/module/utils/Render/index.ts
+++ b/packages/core/src/module/utils/Render/index.ts
@@ -14,7 +14,7 @@ import { Common, Root } from '@/module'
 import { Config } from '@/module/utils/Config'
 
 import { isSemverGreater } from '../semver'
-import { createPosterPalettePlugin, createQrCodePlugin } from './plugins'
+import { createPosterPalettePlugin } from './plugins'
 import { embedWatermark } from './wm'
 
 type ImageMetadata = {
@@ -36,12 +36,12 @@ type ImageMetadata = {
 export const Render = async <P extends DynamicRenderPath> (
   event: Message,
   path: P,
-  data?: ExtractDataTypeFromPath<P>,
-  options?: { 
+  data?: Omit<ExtractDataTypeFromPath<P>, 'useDarkTheme'>,
+  options?: {
     /**
      * 是否跳过水印嵌入
      */
-    skipWatermark?: boolean 
+    skipWatermark?: boolean
   }
 ): Promise<ImageElement[]> => {
   const pathParts = path.split('/')
@@ -110,7 +110,6 @@ export const Render = async <P extends DynamicRenderPath> (
     request: renderRequest,
     outputDir,
     plugins: [
-      createQrCodePlugin(),
       createPosterPalettePlugin()
     ]
   }).then((res) => {

--- a/packages/core/src/module/utils/Render/plugins.ts
+++ b/packages/core/src/module/utils/Render/plugins.ts
@@ -1,93 +1,11 @@
-import { Window } from 'happy-dom'
 import jpeg from 'jpeg-js'
 import { logger } from 'node-karin'
 import { PNG } from 'pngjs'
-import QRCodeStyling from 'qr-code-styling'
 import type { Plugin } from 'template'
 import type { BilibiliPosterPalette } from 'template/types/platforms/bilibili/dynamic/live'
 
 type BeforeRenderContext = Parameters<NonNullable<Plugin['beforeRender']>>[0]
 type ApplyRequest = Parameters<NonNullable<Plugin['apply']>>[0]
-
-/**
- * 二维码插件工厂
- * 为指定字段生成二维码数据 URL
- * @param options 插件配置选项
- * @returns 二维码插件实例
- */
-export const createQrCodePlugin = (): Plugin => {
-  return {
-    name: '生成二维码',
-    enforce: 'pre',
-    async beforeRender (ctx: BeforeRenderContext) {
-      const data = ctx.request.data || {}
-      const useDarkTheme = Boolean(data.useDarkTheme)
-
-      const toDataUrl = async (url: string): Promise<string> => {
-        const qrCode = new QRCodeStyling({
-          // @ts-ignore
-          jsdom: Window,
-          type: 'svg',
-          shape: 'square',
-          width: 2000,
-          height: 2000,
-          data: url,
-          margin: 0,
-          qrOptions: {
-            typeNumber: 0,
-            mode: 'Byte',
-            errorCorrectionLevel: 'L'
-          },
-          imageOptions: {
-            hideBackgroundDots: false,
-            imageSize: 0.4,
-            margin: 0
-          },
-          dotsOptions: {
-            type: 'rounded',
-            color: useDarkTheme ? '#C3C3C3' : '#3A3A3A',
-            roundSize: false
-          },
-          backgroundOptions: {
-            color: 'transparent'
-          },
-          cornersSquareOptions: {
-            type: 'extra-rounded',
-            color: useDarkTheme ? '#C3C3C3' : '#3A3A3A'
-          },
-          cornersDotOptions: {
-            color: useDarkTheme ? '#C3C3C3' : '#3A3A3A'
-          }
-        })
-
-        const buffer = await qrCode.getRawData('svg')
-        if (!buffer) {
-          throw new Error('Failed to generate QR code')
-        }
-        return `data:image/svg+xml;base64,${buffer.toString('base64')}`
-      }
-
-      const props = ctx.state.props || {}
-      if (!props.qrCodes) {
-        props.qrCodes = {}
-      }
-      if (!props.qrCodeDataUrl) {
-        props.qrCodeDataUrl = undefined
-      }
-
-      if (typeof data.share_url === 'string' && data.share_url.length > 0) {
-        const dataUrl = await toDataUrl(data.share_url)
-        const qrCodes = props.qrCodes as Record<string, string>
-        qrCodes.share_url = dataUrl
-        if (!props.qrCodeDataUrl) {
-          props.qrCodeDataUrl = dataUrl
-        }
-      }
-
-      ctx.state.props = props
-    }
-  }
-}
 
 type RGB = {
   r: number

--- a/packages/core/src/platform/bilibili/bilibili.ts
+++ b/packages/core/src/platform/bilibili/bilibili.ts
@@ -817,7 +817,7 @@ export class Bilibili extends Base {
                   dynamicTYPE: '视频动态解析',
                   dynamic_id: dynamicInfo.data.data.item.id_str,
                   staff
-                } )
+                })
               this.e.reply(img)
             }
             break

--- a/packages/core/src/platform/douyin/douyin.ts
+++ b/packages/core/src/platform/douyin/douyin.ts
@@ -5,7 +5,7 @@ import { Result } from '@ikenxuan/amagi'
 import { format, fromUnixTime } from 'date-fns'
 import karin, { type Elements, Message, SendMessage } from 'node-karin'
 import { common, logger, mkdirSync, segment } from 'node-karin'
-import { UserVideoListData } from 'template/types/platforms/douyin/UserVideoList'
+import { DouyinUserVideoListProps } from 'template/types/platforms/douyin/UserVideoList'
 
 import {
   Base,
@@ -855,7 +855,7 @@ export class DouYin extends Base {
         const user = userProfileData.data.user
 
         // 转换视频列表数据
-        const videos: UserVideoListData['videos'] = rawData.data.aweme_list.map((aweme, index) => {
+        const videos: DouyinUserVideoListProps['data']['videos'] = rawData.data.aweme_list.map((aweme, index) => {
           const isVideo = aweme.aweme_type === 0 || aweme.media_type === 0
 
           return {
@@ -906,8 +906,8 @@ export class DouYin extends Base {
         await this.e.reply(img)
 
         logger.debug(`等待用户选择视频，开始计时，${timeoutSeconds}秒后终止等待...`)
-        const context = await karin.ctx(this.e, { 
-          throwOnTimeout: false, 
+        const context = await karin.ctx(this.e, {
+          throwOnTimeout: false,
           time: timeoutSeconds
         })
         if (!context) {

--- a/packages/core/src/platform/douyin/login.ts
+++ b/packages/core/src/platform/douyin/login.ts
@@ -180,8 +180,8 @@ export const douyinLogin = async (e: Message) => {
   try {
     // 根据解码结果选择传递方式
     const renderData = qrCodeData.url
-      ? { share_url: qrCodeData.url } // 解码成功，传递URL让插件生成自定义二维码
-      : { qrCodeDataUrl: qrCodeData.originalImage } // 解码失败，直接使用原始图片
+      ? { share_url: qrCodeData.url } // 解码成功，传递URL让组件内部生成自定义二维码
+      : { share_url: qrCodeData.originalImage } // 解码失败，直接使用原始图片URL
 
     const loginQRcode = await Render(e, 'douyin/qrcodeImg', renderData)
 

--- a/packages/core/vite.config.ts
+++ b/packages/core/vite.config.ts
@@ -48,6 +48,7 @@ export default defineConfig({
   },
   assetsInclude: ['**/*.wasm'],
   build: {
+    assetsInlineLimit: 10 * 1024 * 1024,
     target: 'node22',
     lib: {
       formats: ['es'],

--- a/packages/core/vite.config.ts
+++ b/packages/core/vite.config.ts
@@ -66,7 +66,8 @@ export default defineConfig({
         ...[/^@karinjs\//],
         'fingerprint-injector',
         '@snapka/puppeteer',
-        '@ikenxuan/watermark'
+        '@ikenxuan/watermark',
+        '@ikenxuan/qrcode'
       ],
       output: {
         format: 'esm',

--- a/packages/template/package.json
+++ b/packages/template/package.json
@@ -55,8 +55,9 @@
     "react-resizable-panels": "^4.11.2",
     "react-zoom-pan-pinch": "^4.0.3",
     "rehype-highlight": "^7.0.2",
-    "tailwind-merge": "^3.6.0",
-    "victory": "^37.3.6"
+    "tailwind-merge": "3.6.0",
+    "victory": "^37.3.6",
+    "@ikenxuan/qrcode": "^1.1.0"
   },
   "devDependencies": {
     "@types/express": "5.0.6",

--- a/packages/template/src/components/platforms/bilibili/Comment.tsx
+++ b/packages/template/src/components/platforms/bilibili/Comment.tsx
@@ -9,6 +9,7 @@ import type {
 } from '../../../types/platforms/bilibili'
 import type { FansDetail } from '../../../types/platforms/bilibili/comment'
 import { cn } from '../../../utils/cn'
+import { generateQRCode } from '../../../utils/QRcode'
 import { DefaultLayout } from '../../layouts/DefaultLayout'
 import { ThumbUpIcon } from './Icons'
 
@@ -238,20 +239,13 @@ const BilibiliLogo: React.FC = () => {
  * @returns JSX元素
  */
 const QRCodeSection: React.FC<QRCodeSectionProps> = ({
-  qrCodeDataUrl
+  share_url,
+  useDarkTheme
 }) => {
   return (
     <div className='flex flex-col items-center'>
       <div className='flex justify-center items-center w-100 h-100 p-4'>
-        {qrCodeDataUrl
-          ? (
-            <img src={qrCodeDataUrl} alt='二维码' className='object-contain w-full h-full rounded-lg' />
-          )
-          : (
-            <div className='flex flex-col justify-center items-center text-muted'>
-              <span className='text-lg'>二维码生成失败</span>
-            </div>
-          )}
+        <img src={generateQRCode(share_url, useDarkTheme)} alt='二维码' className='object-contain w-full h-full rounded-lg' />
       </div>
     </div>
   )
@@ -262,7 +256,7 @@ const QRCodeSection: React.FC<QRCodeSectionProps> = ({
  * @param props 组件属性
  * @returns JSX元素
  */
-const VideoInfoHeader: React.FC<Omit<BilibiliCommentProps['data'], 'CommentsData'> & { qrCodeDataUrl: string }> = (props) => {
+const VideoInfoHeader: React.FC<Omit<BilibiliCommentProps['data'], 'CommentsData'>> = (props) => {
   return (
     <div className='max-w-350 mx-auto px-10 py-8'>
       <div className='flex gap-16 justify-between items-start'>
@@ -317,7 +311,7 @@ const VideoInfoHeader: React.FC<Omit<BilibiliCommentProps['data'], 'CommentsData
 
         {/* 右侧二维码区域 */}
         <div className='shrink-0'>
-          <QRCodeSection qrCodeDataUrl={props.qrCodeDataUrl} />
+          <QRCodeSection share_url={props.share_url} useDarkTheme={props.useDarkTheme} />
         </div>
       </div>
     </div>
@@ -746,7 +740,6 @@ export const BilibiliComment: React.FC<Omit<BilibiliCommentProps, 'templateType'
         {/* 视频信息头部 */}
         <VideoInfoHeader
           {...processedData}
-          qrCodeDataUrl={props.qrCodeDataUrl}
         />
 
         {/* 评论列表 */}

--- a/packages/template/src/components/platforms/bilibili/dynamic/CommonComponents.tsx
+++ b/packages/template/src/components/platforms/bilibili/dynamic/CommonComponents.tsx
@@ -6,6 +6,7 @@ import type {
   BilibiliDynamicBaseData,
   BilibiliDynamicFooterProps
 } from '../../../../types/platforms/bilibili'
+import { generateQRCode } from '../../../../utils/QRcode'
 import { CommentIcon, ShareIcon, ThumbUpIcon, ViewIcon } from '../Icons'
 import { DecorationCard, EnhancedImage, UsernameDisplay } from '../shared'
 
@@ -87,14 +88,7 @@ export const BilibiliDynamicStatus: React.FC<BilibiliDynamicBaseData> = (props) 
 /**
  * B站动态底部信息组件
  */
-export const BilibiliDynamicFooter: React.FC<
-  BilibiliDynamicFooterProps & {
-    avatar_url: string
-    frame?: string
-    usernameMeta: { name: string; vipStatus: number; nicknameColor: string | null }
-    showUidHash?: boolean
-  }
-> = (props) => {
+export const BilibiliDynamicFooter: React.FC<BilibiliDynamicFooterProps> = (props) => {
   return (
     <div className='flex justify-between items-start px-20 pb-20'>
       {/* 左侧：用户信息 */}
@@ -124,7 +118,6 @@ export const BilibiliDynamicFooter: React.FC<
               <UsernameDisplay metadata={props.usernameMeta} />
             </div>
             <div className='flex gap-2 items-center text-4xl text-muted'>
-              {props.showUidHash && <span className='text-muted'>#</span>}
               <span className='text-muted select-text'>UID: {props.user_shortid}</span>
             </div>
           </div>
@@ -161,19 +154,11 @@ export const BilibiliDynamicFooter: React.FC<
 
       {/* 右侧：二维码 */}
       <div className='flex flex-col items-center gap-4'>
-        {props.qrCodeDataUrl
-          ? (
-            <img
-              src={props.qrCodeDataUrl}
-              alt='二维码'
-              className='h-auto w-75 rounded-2xl'
-            />
-          )
-          : (
-            <div className='flex justify-center items-center rounded-2xl bg-surface w-100 h-100'>
-              <span className='text-muted'>二维码</span>
-            </div>
-          )}
+        <img
+          src={generateQRCode(props.share_url, props.useDarkTheme)}
+          alt='二维码'
+          className='h-auto w-75 rounded-2xl'
+        />
       </div>
     </div>
   )

--- a/packages/template/src/components/platforms/bilibili/dynamic/DYNAMIC_TYPE_ARTICLE.tsx
+++ b/packages/template/src/components/platforms/bilibili/dynamic/DYNAMIC_TYPE_ARTICLE.tsx
@@ -3,6 +3,7 @@ import { Bookmark, Clock, Eye, Hash, UsersRound } from 'lucide-react'
 import React from 'react'
 
 import type { BilibiliArticleDynamicProps } from '../../../../types/platforms/bilibili/dynamic/article'
+import { generateQRCode } from '../../../../utils/QRcode'
 import { DefaultLayout } from '../../../layouts/DefaultLayout'
 import { CommentIcon, ShareIcon, ThumbUpIcon } from '../Icons'
 import { CommentText, DecorationCard, EnhancedImage, UsernameDisplay } from '../shared'
@@ -227,19 +228,11 @@ const BilibiliArticleFooter: React.FC<BilibiliArticleDynamicProps> = React.memo(
 
       {/* 右侧：二维码 */}
       <div className='flex flex-col items-center gap-4'>
-        {props.qrCodeDataUrl
-          ? (
-            <img
-              src={props.qrCodeDataUrl}
-              alt='二维码'
-              className='h-auto w-75 rounded-2xl'
-            />
-          )
-          : (
-            <div className='flex justify-center items-center rounded-2xl bg-surface w-100 h-100'>
-              <span className='text-muted'>二维码</span>
-            </div>
-          )}
+        <img
+          src={generateQRCode(props.data.share_url, props.data.useDarkTheme)}
+          alt='二维码'
+          className='h-auto w-75 rounded-2xl'
+        />
       </div>
     </div>
   )

--- a/packages/template/src/components/platforms/bilibili/dynamic/DYNAMIC_TYPE_AV.tsx
+++ b/packages/template/src/components/platforms/bilibili/dynamic/DYNAMIC_TYPE_AV.tsx
@@ -243,18 +243,7 @@ export const BilibiliVideoDynamic: React.FC<Omit<BilibiliVideoDynamicProps, 'tem
         <BilibiliVideoStaff {...props} />
 
         {/* 底部信息 */}
-        <BilibiliDynamicFooter
-          avatar_url={props.data.avatar_url}
-          frame={props.data.frame}
-          usernameMeta={props.data.usernameMeta}
-          user_shortid={props.data.user_shortid}
-          total_favorited={props.data.total_favorited}
-          following_count={props.data.following_count}
-          fans={props.data.fans}
-          dynamicTYPE={props.data.dynamicTYPE}
-          share_url={props.data.share_url}
-          qrCodeDataUrl={props.qrCodeDataUrl}
-        />
+        <BilibiliDynamicFooter {...props.data} />
       </div>
     </DefaultLayout>
   )

--- a/packages/template/src/components/platforms/bilibili/dynamic/DYNAMIC_TYPE_DRAW.tsx
+++ b/packages/template/src/components/platforms/bilibili/dynamic/DYNAMIC_TYPE_DRAW.tsx
@@ -206,18 +206,7 @@ export const BilibiliDrawDynamic: React.FC<Omit<BilibiliDynamicProps, 'templateT
         <div className='h-40' />
 
         {/* 底部信息 */}
-        <BilibiliDynamicFooter
-          avatar_url={props.data.avatar_url}
-          frame={props.data.frame}
-          usernameMeta={props.data.usernameMeta}
-          user_shortid={props.data.user_shortid}
-          total_favorited={props.data.total_favorited}
-          following_count={props.data.following_count}
-          fans={props.data.fans}
-          dynamicTYPE={props.data.dynamicTYPE}
-          share_url={props.data.share_url}
-          qrCodeDataUrl={props.qrCodeDataUrl}
-        />
+        <BilibiliDynamicFooter {...props.data} />
       </div>
     </DefaultLayout>
   )

--- a/packages/template/src/components/platforms/bilibili/dynamic/DYNAMIC_TYPE_FORWARD.tsx
+++ b/packages/template/src/components/platforms/bilibili/dynamic/DYNAMIC_TYPE_FORWARD.tsx
@@ -360,19 +360,7 @@ export const BilibiliForwardDynamic: React.FC<BilibiliForwardDynamicProps> = Rea
         <div className='h-40' />
 
         {/* 底部信息 */}
-        <BilibiliDynamicFooter
-          avatar_url={props.data.avatar_url}
-          frame={props.data.frame}
-          usernameMeta={props.data.usernameMeta}
-          user_shortid={props.data.user_shortid}
-          total_favorited={props.data.total_favorited}
-          following_count={props.data.following_count}
-          fans={props.data.fans}
-          dynamicTYPE={props.data.dynamicTYPE}
-          share_url={props.data.share_url}
-          qrCodeDataUrl={props.qrCodeDataUrl}
-          showUidHash
-        />
+        <BilibiliDynamicFooter {...props.data} />
       </div>
     </DefaultLayout>
   )

--- a/packages/template/src/components/platforms/bilibili/dynamic/DYNAMIC_TYPE_LIVE_RCMD.tsx
+++ b/packages/template/src/components/platforms/bilibili/dynamic/DYNAMIC_TYPE_LIVE_RCMD.tsx
@@ -5,6 +5,7 @@ import React from 'react'
 import type {
   BilibiliLiveDynamicProps,
   BilibiliPosterPalette } from '../../../../types/platforms/bilibili'
+import { generateQRCode } from '../../../../utils/QRcode'
 import { DefaultLayout } from '../../../layouts/DefaultLayout'
 import { EnhancedImage, UsernameDisplay } from '../shared'
 
@@ -71,7 +72,7 @@ const getSingleLineFontSize = (content: string, base: number, min: number): numb
 }
 
 export const BilibiliLiveDynamic: React.FC<Omit<BilibiliLiveDynamicProps, 'templateType' | 'templateName'>> = React.memo((props) => {
-  const { data, qrCodeDataUrl } = props
+  const { data } = props
   const isDark = data.useDarkTheme === true
   const palette = props.posterPalettes
     ? (isDark ? props.posterPalettes.dark : props.posterPalettes.light)
@@ -491,10 +492,10 @@ export const BilibiliLiveDynamic: React.FC<Omit<BilibiliLiveDynamicProps, 'templ
                 className='absolute right-22 top-1/2 h-52 w-52 -translate-y-1/2 rounded-full blur-[48px]'
                 style={{ backgroundColor: withAlphaFromCss(accentColor, isDark ? 0.16 : 0.10) }}
               />
-              {qrCodeDataUrl
+              {data.share_url
                 ? (
                   <img
-                    src={qrCodeDataUrl}
+                    src={generateQRCode(data.share_url, isDark)}
                     alt='二维码'
                     className='relative h-100 w-100 object-contain drop-shadow-[0_20px_38px_rgba(0,0,0,0.18)]'
                   />

--- a/packages/template/src/components/platforms/bilibili/dynamic/DYNAMIC_TYPE_WORD.tsx
+++ b/packages/template/src/components/platforms/bilibili/dynamic/DYNAMIC_TYPE_WORD.tsx
@@ -61,18 +61,7 @@ export const BilibiliWordDynamic: React.FC<Omit<BilibiliWordDynamicProps, 'templ
         <BilibiliDynamicStatus {...props.data} />
 
         <div className='h-23' />
-        <BilibiliDynamicFooter
-          avatar_url={props.data.avatar_url}
-          frame={props.data.frame}
-          usernameMeta={props.data.usernameMeta}
-          user_shortid={props.data.user_shortid}
-          total_favorited={props.data.total_favorited}
-          following_count={props.data.following_count}
-          fans={props.data.fans}
-          dynamicTYPE={props.data.dynamicTYPE}
-          share_url={props.data.share_url}
-          qrCodeDataUrl={props.qrCodeDataUrl}
-        />
+        <BilibiliDynamicFooter {...props.data} />
       </div>
     </DefaultLayout>
   )

--- a/packages/template/src/components/platforms/bilibili/qrcodeImg.tsx
+++ b/packages/template/src/components/platforms/bilibili/qrcodeImg.tsx
@@ -4,6 +4,7 @@ import React from 'react'
 import { RiArrowRightFill } from 'react-icons/ri'
 
 import type { BilibiliQrcodeImgProps } from '../../../types/platforms/bilibili'
+import { generateQRCode } from '../../../utils/QRcode'
 import { DefaultLayout } from '../../layouts/DefaultLayout'
 
 /**
@@ -13,7 +14,7 @@ import { DefaultLayout } from '../../layouts/DefaultLayout'
  */
 export const BilibiliQrcodeImg: React.FC<BilibiliQrcodeImgProps> = React.memo((props) => {
   const isDark = props.data?.useDarkTheme ?? false
-  const { qrCodeDataUrl } = props
+  const qrCodeDataUrl = generateQRCode(props.data.share_url, isDark)
 
   const theme = {
     bg: isDark ? '#000000' : '#FFFFFF',

--- a/packages/template/src/components/platforms/douyin/ArticleWork.tsx
+++ b/packages/template/src/components/platforms/douyin/ArticleWork.tsx
@@ -4,6 +4,7 @@ import React from 'react'
 import ReactMarkdown from 'react-markdown'
 
 import type { DouyinArticleWorkProps } from '../../../types/platforms/douyin'
+import { generateQRCode } from '../../../utils/QRcode'
 import { DefaultLayout } from '../../layouts/DefaultLayout'
 
 /**
@@ -267,19 +268,11 @@ export const DouyinArticleWork: React.FC<Omit<DouyinArticleWorkProps, 'templateT
 
             {/* 右侧：二维码 */}
             <div className='flex flex-col items-center gap-4'>
-              {props.qrCodeDataUrl
-                ? (
-                  <img
-                    src={props.qrCodeDataUrl}
-                    alt='二维码'
-                    className='h-auto w-75 rounded-xl'
-                  />
-                )
-                : (
-                  <div className='flex justify-center items-center rounded-2xl bg-surface w-100 h-100'>
-                    <span className='text-muted'>二维码</span>
-                  </div>
-                )}
+              <img
+                src={generateQRCode(props.data.share_url, props.data.useDarkTheme)}
+                alt='二维码'
+                className='h-auto w-75 rounded-xl'
+              />
             </div>
           </div>
         </div>

--- a/packages/template/src/components/platforms/douyin/Comment.tsx
+++ b/packages/template/src/components/platforms/douyin/Comment.tsx
@@ -2,15 +2,15 @@ import { createRichTextDocument, renderRichTextToReact } from '@kkk/richtext'
 import { PlayIcon } from '@phosphor-icons/react'
 import { differenceInSeconds, format, formatDistanceToNow, fromUnixTime } from 'date-fns'
 import { zhCN } from 'date-fns/locale'
-import { CircleEllipsis, Heart, MessageCircle, QrCode, Search, Share2, Star } from 'lucide-react'
+import { CircleEllipsis, Heart, MessageCircle, Search, Share2, Star } from 'lucide-react'
 import React, { type ReactNode } from 'react'
 
-import type { QRCodeSectionProps } from '../../../types'  
 import type {
   DouyinCommentProps,
   DouyinSubComment
 } from '../../../types/platforms/douyin'
 import { cn } from '../../../utils/cn'
+import { generateQRCode } from '../../../utils/QRcode'
 import { DefaultLayout } from '../../layouts/DefaultLayout'
 
 const douyinMentionClassName = 'text-[#04498d] dark:text-[#face15]'
@@ -86,22 +86,11 @@ const formatPublishTime = (timestamp: number): string => {
  * @param props 组件属性
  * @returns JSX元素
  */
-const QRCodeSection: React.FC<QRCodeSectionProps> = ({
-  qrCodeDataUrl
-}) => {
+const QRCodeSection: React.FC<Omit<DouyinCommentProps['data'], 'CommentsData'>> = (props) => {
   return (
     <div className='flex flex-col items-center'>
       <div className='flex justify-center items-center w-100 h-100 p-4'>
-        {qrCodeDataUrl
-          ? (
-            <img src={qrCodeDataUrl} alt='二维码' className='object-contain w-full h-full rounded-lg' />
-          )
-          : (
-            <div className='flex flex-col justify-center items-center text-muted'>
-              <QrCode width={80} className='mb-4' />
-              <span className='text-lg'>二维码生成失败</span>
-            </div>
-          )}
+        <img src={generateQRCode(props.share_url, props.useDarkTheme)} alt='二维码' className='object-contain w-full h-full rounded-lg' />
       </div>
     </div>
   )
@@ -112,7 +101,7 @@ const QRCodeSection: React.FC<QRCodeSectionProps> = ({
  * @param props 组件属性
  * @returns JSX元素
  */
-const VideoInfoHeader: React.FC<Omit<DouyinCommentProps['data'], 'CommentsData'> & { qrCodeDataUrl: string }> = (props) => {
+const VideoInfoHeader: React.FC<Omit<DouyinCommentProps['data'], 'CommentsData'>> = (props) => {
   return (
     <div className='max-w-350 mx-auto px-10 pt-14'>
       <div className='flex items-start justify-between gap-10'>
@@ -203,7 +192,7 @@ const VideoInfoHeader: React.FC<Omit<DouyinCommentProps['data'], 'CommentsData'>
 
         {/* 右侧二维码 */}
         <div className='shrink-0'>
-          <QRCodeSection qrCodeDataUrl={props.qrCodeDataUrl} />
+          <QRCodeSection {...props} />
         </div>
       </div>
     </div>
@@ -629,7 +618,6 @@ export const DouyinComment: React.FC<Omit<DouyinCommentProps, 'templateType' | '
         {/* 视频信息头部 */}
         <VideoInfoHeader
           {...props.data}
-          qrCodeDataUrl={props.qrCodeDataUrl}
         />
 
         {/* 推荐搜索词 */}

--- a/packages/template/src/components/platforms/douyin/Dynamic.tsx
+++ b/packages/template/src/components/platforms/douyin/Dynamic.tsx
@@ -5,6 +5,7 @@ import React from 'react'
 import type {
   DouyinDynamicProps
 } from '../../../types/platforms/douyin'
+import { generateQRCode } from '../../../utils/QRcode'
 import { DefaultLayout } from '../../layouts/DefaultLayout'
 
 /**
@@ -290,19 +291,11 @@ export const DouyinDynamic: React.FC<Omit<DouyinDynamicProps, 'templateType' | '
 
             {/* 右侧：二维码 */}
             <div className='flex flex-col items-center gap-4'>
-              {props.qrCodeDataUrl
-                ? (
-                  <img
-                    src={props.qrCodeDataUrl}
-                    alt='二维码'
-                    className='h-auto w-75 rounded-xl'
-                  />
-                )
-                : (
-                  <div className='flex justify-center items-center rounded-2xl bg-surface w-100 h-100'>
-                    <span className='text-muted'>二维码</span>
-                  </div>
-                )}
+              <img
+                src={generateQRCode(props.data.share_url, props.data.useDarkTheme)}
+                alt='二维码'
+                className='h-auto w-75 rounded-xl'
+              />
             </div>
           </div>
         </div>

--- a/packages/template/src/components/platforms/douyin/FavoriteList.tsx
+++ b/packages/template/src/components/platforms/douyin/FavoriteList.tsx
@@ -4,6 +4,7 @@ import React from 'react'
 import { RiHeart3Fill, RiMessage3Fill, RiShareForwardFill, RiStarFill, RiThumbUpFill } from 'react-icons/ri'
 
 import type { DouyinFavoriteListProps } from '../../../types/platforms/douyin'
+import { generateQRCode } from '../../../utils/QRcode'
 import { DefaultLayout } from '../../layouts/DefaultLayout'
 
 /**
@@ -125,9 +126,7 @@ export const DouyinFavoriteList: React.FC<DouyinFavoriteListProps> = (props) => 
             
             <div className="h-px w-full bg-linear-to-r from-surface-secondary via-border to-transparent"></div>
             <div className="flex items-end gap-6">
-              {props.qrCodeDataUrl && (
-                <img src={props.qrCodeDataUrl} className="w-65 h-auto rounded-2xl mix-blend-multiply" alt="QR" />
-              )}
+              <img src={generateQRCode(props.data.share_url, props.data.useDarkTheme)} className="w-65 h-auto rounded-2xl mix-blend-multiply" alt="QR" />
               <div className="flex flex-col justify-end h-56 pb-2">
                 <span className="text-muted text-sm font-mono mb-2">SCAN TO VIEW</span>
                 <span className="text-3xl font-bold text-foreground/80 leading-none">

--- a/packages/template/src/components/platforms/douyin/ImageWork.tsx
+++ b/packages/template/src/components/platforms/douyin/ImageWork.tsx
@@ -3,6 +3,7 @@ import { Bookmark, Clock, Eye, Hash, Heart, Maximize, MessageCircle, Share2, Use
 import React from 'react'
 
 import type { DouyinImageWorkProps } from '../../../types/platforms/douyin'
+import { generateQRCode } from '../../../utils/QRcode'
 import { DefaultLayout } from '../../layouts/DefaultLayout'
 
 /**
@@ -276,19 +277,11 @@ export const DouyinImageWork: React.FC<Omit<DouyinImageWorkProps, 'templateType'
 
             {/* 右侧：二维码 */}
             <div className='flex flex-col items-center gap-4'>
-              {props.qrCodeDataUrl
-                ? (
-                  <img
-                    src={props.qrCodeDataUrl}
-                    alt='二维码'
-                    className='h-auto w-75 rounded-xl'
-                  />
-                )
-                : (
-                  <div className='flex justify-center items-center rounded-2xl bg-surface w-100 h-100'>
-                    <span className='text-muted'>二维码</span>
-                  </div>
-                )}
+              <img
+                src={generateQRCode(props.data.share_url, props.data.useDarkTheme)}
+                alt='二维码'
+                className='h-auto w-75 rounded-xl'
+              />
             </div>
           </div>
         </div>

--- a/packages/template/src/components/platforms/douyin/Live.tsx
+++ b/packages/template/src/components/platforms/douyin/Live.tsx
@@ -4,6 +4,7 @@ import React from 'react'
 import type {
   DouyinLiveProps
 } from '../../../types/platforms/douyin'
+import { generateQRCode } from '../../../utils/QRcode'
 import { DefaultLayout } from '../../layouts/DefaultLayout'
 
 const coverMaskStyle: React.CSSProperties = {
@@ -151,7 +152,7 @@ const InfoSection: React.FC<{ data: DouyinLiveProps['data'] }> = ({ data }) => {
 /**
  * 底部区域 - 主播信息 + 二维码 + 抖音Logo
  */
-const BottomSection: React.FC<{ data: DouyinLiveProps['data']; qrCodeDataUrl: string }> = ({ data, qrCodeDataUrl }) => {
+const BottomSection: React.FC<{ data: DouyinLiveProps['data'] }> = ({ data }) => {
   return (
     <div className="flex justify-between items-end px-16 pt-24 pb-16">
       {/* 左侧：主播信息 */}
@@ -211,9 +212,9 @@ const BottomSection: React.FC<{ data: DouyinLiveProps['data']; qrCodeDataUrl: st
           alt="抖音"
           className="w-60 h-auto opacity-80 dark:opacity-70"
         />
-        {qrCodeDataUrl ? (
+        {generateQRCode(data.share_url, data.useDarkTheme) ? (
           <img
-            src={qrCodeDataUrl}
+            src={generateQRCode(data.share_url, data.useDarkTheme)}
             alt="二维码"
             className="h-auto w-75"
           />
@@ -232,7 +233,6 @@ const BottomSection: React.FC<{ data: DouyinLiveProps['data']; qrCodeDataUrl: st
  * 抖音直播组件
  */
 export const DouyinLive: React.FC<Omit<DouyinLiveProps, 'templateType' | 'templateName'>> = (props) => {
-  const { qrCodeDataUrl } = props
   const d = props.data
 
   return (
@@ -242,7 +242,7 @@ export const DouyinLive: React.FC<Omit<DouyinLiveProps, 'templateType' | 'templa
       <div className="relative z-10">
         <CoverSection imageUrl={d.image_url} />
         <InfoSection data={d} />
-        <BottomSection data={d} qrCodeDataUrl={qrCodeDataUrl} />
+        <BottomSection data={d} />
       </div>
     </DefaultLayout>
   )

--- a/packages/template/src/components/platforms/douyin/MusicInfo.tsx
+++ b/packages/template/src/components/platforms/douyin/MusicInfo.tsx
@@ -8,6 +8,7 @@ import type {
   MusicInfoProps,
   MusicQRCodeProps
 } from '../../../types/platforms/douyin/musicinfo'
+import { generateQRCode } from '../../../utils/QRcode'
 import { DefaultLayout } from '../../layouts/DefaultLayout'
 
 /**
@@ -144,7 +145,7 @@ const MusicAuthorInfoSection: React.FC<MusicAuthorInfoProps> = ({
  * @param props 组件属性
  * @returns JSX元素
  */
-const MusicQRCodeSection: React.FC<MusicQRCodeProps> = ({ qrCodeDataUrl }) => {
+const MusicQRCodeSection: React.FC<MusicQRCodeProps> = ({ share_url, useDarkTheme }) => {
   return (
     <div className='flex flex-col-reverse items-center -mb-12 mr-18'>
       <div className='flex items-center gap-2 text-[45px] text-right mt-5 text-muted select-text'>
@@ -153,7 +154,7 @@ const MusicQRCodeSection: React.FC<MusicQRCodeProps> = ({ qrCodeDataUrl }) => {
       </div>
       <div className='p-2.5 rounded-sm border-[7px] border-dashed border-border'>
         <img
-          src={qrCodeDataUrl}
+          src={generateQRCode(share_url, useDarkTheme)}
           alt='二维码'
           className='w-87.5 h-87.5 select-text'
         />
@@ -168,7 +169,7 @@ const MusicQRCodeSection: React.FC<MusicQRCodeProps> = ({ qrCodeDataUrl }) => {
  * @returns JSX元素
  */
 export const DouyinMusicInfo: React.FC<Omit<DouyinMusicInfoProps, 'templateType' | 'templateName'>> = (props) => {
-  const { data, qrCodeDataUrl } = props
+  const { data } = props
 
   return (
     <DefaultLayout {...props}>
@@ -176,8 +177,8 @@ export const DouyinMusicInfo: React.FC<Omit<DouyinMusicInfoProps, 'templateType'
         <DouyinHeader useDarkTheme={data.useDarkTheme} />
 
         {/* 音乐封面 */}
-        <MusicCoverSection 
-          imageUrl={data.image_url} 
+        <MusicCoverSection
+          imageUrl={data.image_url}
           description={data.desc}
           useDarkTheme={data.useDarkTheme}
         />
@@ -210,7 +211,7 @@ export const DouyinMusicInfo: React.FC<Omit<DouyinMusicInfoProps, 'templateType'
             useDarkTheme={data.useDarkTheme}
           />
           <MusicQRCodeSection
-            qrCodeDataUrl={qrCodeDataUrl}
+            share_url={data.share_url}
             useDarkTheme={data.useDarkTheme}
           />
         </div>

--- a/packages/template/src/components/platforms/douyin/RecommendList.tsx
+++ b/packages/template/src/components/platforms/douyin/RecommendList.tsx
@@ -4,6 +4,7 @@ import React from 'react'
 import { RiHeart3Fill, RiMessage3Fill, RiShareForwardFill, RiStarFill, RiThumbUpFill } from 'react-icons/ri'
 
 import type { DouyinRecommendListProps } from '../../../types/platforms/douyin'
+import { generateQRCode } from '../../../utils/QRcode'
 import { DefaultLayout } from '../../layouts/DefaultLayout'
 
 /**
@@ -125,9 +126,7 @@ export const DouyinRecommendList: React.FC<DouyinRecommendListProps> = (props) =
             
             <div className="h-px w-full bg-linear-to-r from-surface-secondary via-border to-transparent"></div>
             <div className="flex items-end gap-6">
-              {props.qrCodeDataUrl && (
-                <img src={props.qrCodeDataUrl} className="w-65 h-auto rounded-2xl mix-blend-multiply" alt="QR" />
-              )}
+              <img src={generateQRCode(props.data.share_url, props.data.useDarkTheme)} className="w-65 h-auto rounded-2xl mix-blend-multiply" alt="QR" />
               <div className="flex flex-col justify-end h-56 pb-2">
                 <span className="text-muted text-sm font-mono mb-2">SCAN TO VIEW</span>
                 <span className="text-3xl font-bold text-foreground/80 leading-none">

--- a/packages/template/src/components/platforms/douyin/VideoWork.tsx
+++ b/packages/template/src/components/platforms/douyin/VideoWork.tsx
@@ -3,6 +3,7 @@ import { Bookmark, Clock, Eye, Hash, Heart, Maximize, MessageCircle, Share2, Use
 import React from 'react'
 
 import type { DouyinVideoWorkProps } from '../../../types/platforms/douyin'
+import { generateQRCode } from '../../../utils/QRcode'
 import { DefaultLayout } from '../../layouts/DefaultLayout'
 
 /**
@@ -280,19 +281,11 @@ export const DouyinVideoWork: React.FC<Omit<DouyinVideoWorkProps, 'templateType'
 
             {/* 右侧：二维码 */}
             <div className='flex flex-col items-center gap-4'>
-              {props.qrCodeDataUrl
-                ? (
-                  <img
-                    src={props.qrCodeDataUrl}
-                    alt='二维码'
-                    className='h-auto w-75 rounded-xl'
-                  />
-                )
-                : (
-                  <div className='flex justify-center items-center rounded-2xl bg-surface w-100 h-100'>
-                    <span className='text-muted'>二维码</span>
-                  </div>
-                )}
+              <img
+                src={generateQRCode(props.data.share_url, props.data.useDarkTheme)}
+                alt='二维码'
+                className='h-auto w-75 rounded-xl'
+              />
             </div>
           </div>
         </div>

--- a/packages/template/src/components/platforms/douyin/qrcodeImg.tsx
+++ b/packages/template/src/components/platforms/douyin/qrcodeImg.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 import { RiArrowRightFill, RiTiktokFill } from 'react-icons/ri'
 
 import type { DouyinQrcodeImgProps } from '../../../types/platforms/douyin'
+import { generateQRCode } from '../../../utils/QRcode'
 import { DefaultLayout } from '../../layouts/DefaultLayout'
 
 /**
@@ -12,7 +13,7 @@ import { DefaultLayout } from '../../layouts/DefaultLayout'
  */
 export const DouyinQrcodeImg: React.FC<DouyinQrcodeImgProps> = React.memo((props) => {
   const isDark = props.data?.useDarkTheme ?? false
-  const qrCodeImage = props.data.qrCodeDataUrl || (props as any).qrCodeDataUrl
+  const qrCodeImage = generateQRCode(props.data.qr_url || '', isDark)
 
   const theme = {
     bg: isDark ? '#000000' : '#FFFFFF',

--- a/packages/template/src/components/platforms/douyin/videoInfo.tsx
+++ b/packages/template/src/components/platforms/douyin/videoInfo.tsx
@@ -17,7 +17,7 @@ const formatDuration = (ms: number): string => {
   return `${m}:${s.toString().padStart(2, '0')}`
 }
 
-export const DouyinVideoInfo: React.FC<Omit<DouyinVideoInfoProps, 'templateType' | 'templateName'>> = React.memo(
+export const DouyinVideoInfo: React.FC<DouyinVideoInfoProps> = React.memo(
   (props) => {
     const duration = useMemo(
       () => (props.data.video ? formatDuration(props.data.video.duration) : null),

--- a/packages/template/src/components/platforms/kuaishou/Comment.tsx
+++ b/packages/template/src/components/platforms/kuaishou/Comment.tsx
@@ -1,20 +1,18 @@
 import { renderRichTextToReact } from '@kkk/richtext'
 import { differenceInSeconds, format, formatDistanceToNow } from 'date-fns'
 import { zhCN } from 'date-fns/locale'
-import { Heart, MessageCircle, QrCode } from 'lucide-react'
+import { Heart, MessageCircle } from 'lucide-react'
 import React from 'react'
 
 import type {
-  KuaishouCommentItemComponentProps,
-  KuaishouCommentProps,
-  KuaishouQRCodeSectionProps,
-  KuaishouVideoInfoHeaderProps
+  KuaishouCommentProps
 } from '../../../types/platforms/kuaishou'
+import { generateQRCode } from '../../../utils/QRcode'
 import { DefaultLayout } from '../../layouts/DefaultLayout'
 
 const kuaishouMentionClassName = 'text-[#03488d] dark:text-[#c7daef]'
 
-const renderKuaishouCommentRichText = (content: KuaishouCommentItemComponentProps['comment']['text']) => {
+const renderKuaishouCommentRichText = (content: KuaishouCommentProps['data']['CommentsData'][0]['text']) => {
   return renderRichTextToReact(content, {
     mention: { className: kuaishouMentionClassName }
   })
@@ -55,30 +53,17 @@ const formatKuaishouLikeCount = (count: number): string => {
  * @param props 组件属性
  * @returns JSX元素
  */
-const KuaishouQRCodeSection: React.FC<KuaishouQRCodeSectionProps> = ({
-  qrCodeDataUrl,
-  type,
-  imageLength
-}) => {
+const KuaishouQRCodeSection: React.FC<KuaishouCommentProps['data']> = (props) => {
   return (
     <div className='flex flex-col items-center -mr-10'>
       <div className='mt-20 flex items-center justify-center w-150 h-150 bg-surface rounded-lg shadow-medium'>
-        {qrCodeDataUrl
-          ? (
-            <img src={qrCodeDataUrl} alt='二维码' className='object-contain w-full h-full' />
-          )
-          : (
-            <div className='flex flex-col justify-center items-center text-muted'>
-              <QrCode width={80} className='mb-4' />
-              <span className='text-lg'>二维码生成失败</span>
-            </div>
-          )}
+        <img src={generateQRCode(props.share_url, props.useDarkTheme)} alt='二维码' className='object-contain w-full h-full' />
       </div>
       <div className='mt-5 text-[45px] text-center text-foreground'>
-        {type === '视频'
+        {props.Type === '视频'
           ? '视频直链(永久)'
-          : type === '图集'
-            ? `图集分享链接 共${imageLength}张`
+          : props.Type === '图集'
+            ? `图集分享链接 共${props.ImageLength}张`
             : '分享链接'}
       </div>
     </div>
@@ -90,14 +75,7 @@ const KuaishouQRCodeSection: React.FC<KuaishouQRCodeSectionProps> = ({
  * @param props 组件属性
  * @returns JSX元素
  */
-const KuaishouVideoInfoHeader: React.FC<KuaishouVideoInfoHeaderProps> = ({
-  type,
-  commentLength,
-  videoSize,
-  likeCount,
-  viewCount,
-  imageLength
-}) => {
+const KuaishouVideoInfoHeader: React.FC<KuaishouCommentProps['data']> = (props) => {
   return (
     <div className='flex justify-between items-center max-w-300 mx-auto p-5'>
       <div className='mt-2.5 flex flex-col -ml-11'>
@@ -118,24 +96,24 @@ const KuaishouVideoInfoHeader: React.FC<KuaishouVideoInfoHeaderProps> = ({
         </div>
         <div className='space-y-2 text-foreground'>
           <div className='flex items-center p-2.5 tracking-[6px] text-[45px] text-left'>
-            评论数量：{commentLength}条
+            评论数量：{props.CommentLength}条
           </div>
-          {type === '视频' && (
+          {props.Type === '视频' && (
             <>
               <div className='flex items-center p-2.5 tracking-[6px] text-[45px] text-left'>
-                视频大小：{videoSize}MB
+                视频大小：{props.VideoSize}MB
               </div>
               <div className='flex items-center p-2.5 tracking-[6px] text-[45px] text-left'>
-                点赞数量：{likeCount}
+                点赞数量：{props.likeCount}
               </div>
               <div className='flex items-center p-2.5 tracking-[6px] text-[45px] text-left'>
-                观看次数：{viewCount}
+                观看次数：{props.viewCount}
               </div>
             </>
           )}
-          {type === '图集' && (
+          {props.Type === '图集' && (
             <div className='flex items-center p-2.5 tracking-[6px] text-[45px] text-left'>
-              图片数量：{imageLength}张
+              图片数量：{props.ImageLength}张
             </div>
           )}
         </div>
@@ -149,18 +127,18 @@ const KuaishouVideoInfoHeader: React.FC<KuaishouVideoInfoHeaderProps> = ({
  * @param props 组件属性
  * @returns JSX元素
  */
-const KuaishouCommentItemComponent: React.FC<KuaishouCommentItemComponentProps & { isLast?: boolean }> = ({ comment, isLast = false }) => {
+const KuaishouCommentItemComponent: React.FC<KuaishouCommentProps['data']['CommentsData'][0] & { isLast?: boolean }> = ({ ...props }, isLast = false) => {
   return (
     <div className={`flex px-10 pt-10 ${isLast ? 'pb-0' : 'pb-10'}`}>
       <img
-        src={comment.userimageurl}
+        src={props.userimageurl}
         className='mb-12.5 w-[187.5px] h-[187.5px] rounded-full mr-8 object-cover shadow-lg'
         alt='用户头像'
       />
 
       <div className='flex-1'>
         <div className='mb-12.5 text-[50px] text-foreground/70 relative flex items-center'>
-          <span className='font-medium'>{comment.nickname}</span>
+          <span className='font-medium'>{props.nickname}</span>
         </div>
 
         <div
@@ -170,14 +148,14 @@ const KuaishouCommentItemComponent: React.FC<KuaishouCommentItemComponentProps &
             overflowWrap: 'break-word'
           }}
         >
-          {renderKuaishouCommentRichText(comment.text)}
+          {renderKuaishouCommentRichText(props.text)}
         </div>
 
-        {(comment.commentimage || comment.sticker) && (
+        {(props.commentimage || props.sticker) && (
           <div className='flex my-5 overflow-hidden shadow-md rounded-2xl w-[95%] flex-1'>
             <img
               className='object-contain w-full h-full rounded-2xl'
-              src={comment.commentimage || comment.sticker}
+              src={props.commentimage || props.sticker}
               alt='评论图片'
             />
           </div>
@@ -185,14 +163,14 @@ const KuaishouCommentItemComponent: React.FC<KuaishouCommentItemComponentProps &
 
         <div className='flex justify-between items-center mt-6 text-muted'>
           <div className='flex items-center space-x-6'>
-            <span className='text-[45px] select-text'>{formatKuaishouCommentTime(comment.create_time)}</span>
-            {comment.ip_label && (
-              <span className='text-[45px] select-text'>{comment.ip_label}</span>
+            <span className='text-[45px] select-text'>{formatKuaishouCommentTime(props.create_time)}</span>
+            {props.ip_label && (
+              <span className='text-[45px] select-text'>{props.ip_label}</span>
             )}
-            {comment.reply_comment_total && comment.reply_comment_total > 0
+            {props.reply_comment_total && props.reply_comment_total > 0
               ? (
                 <span className='text-[40px] text-foreground/70'>
-                  共{comment.reply_comment_total}条回复
+                  共{props.reply_comment_total}条回复
                 </span>
               )
               : (
@@ -203,7 +181,7 @@ const KuaishouCommentItemComponent: React.FC<KuaishouCommentItemComponentProps &
           <div className='flex items-center space-x-6'>
             <div className='flex items-center space-x-2 transition-colors cursor-pointer hover:text-danger'>
               <Heart size={60} className='stroke-current' />
-              <span className='text-[50px] select-text'>{formatKuaishouLikeCount(comment.digg_count)}</span>
+              <span className='text-[50px] select-text'>{formatKuaishouLikeCount(props.digg_count)}</span>
             </div>
 
             <div className='flex items-center transition-colors cursor-pointer hover:text-accent'>
@@ -229,19 +207,10 @@ export const KuaishouComment: React.FC<Omit<KuaishouCommentProps, 'templateType'
       <div className='p-5'>
         <div className='flex justify-between items-center max-w-300 mx-auto p-5'>
           <KuaishouVideoInfoHeader
-            type={props.data?.Type || '视频'}
-            commentLength={props.data?.CommentLength || 0}
-            videoSize={props.data?.VideoSize}
-            likeCount={props.data?.likeCount}
-            viewCount={props.data?.viewCount}
-            imageLength={props.data?.ImageLength}
-            useDarkTheme={props.data?.useDarkTheme}
+            {...props.data}
           />
           <KuaishouQRCodeSection
-            qrCodeDataUrl={props.qrCodeDataUrl || ''}
-            type={props.data?.Type || '视频'}
-            imageLength={props.data?.ImageLength}
-            useDarkTheme={props.data?.useDarkTheme}
+            {...props.data}
           />
         </div>
 
@@ -251,7 +220,7 @@ export const KuaishouComment: React.FC<Omit<KuaishouCommentProps, 'templateType'
               commentsArray.map((comment, index) => (
                 <KuaishouCommentItemComponent
                   key={comment.cid || index}
-                  comment={comment}
+                  {...comment}
                   isLast={index === commentsArray.length - 1}
                 />
               ))

--- a/packages/template/src/components/platforms/other/changelog.tsx
+++ b/packages/template/src/components/platforms/other/changelog.tsx
@@ -4,6 +4,7 @@ import ReactMarkdown from 'react-markdown'
 import rehypeHighlight from 'rehype-highlight'
 
 import type { ChangelogProps } from '../../../types/platforms/other/changelog'
+import { generateQRCode } from '../../../utils/QRcode'
 import { DefaultLayout } from '../../layouts/DefaultLayout'
 
 const InlineCalloutCode: React.FC<React.PropsWithChildren<{ className?: string }>> = ({ children, className }) => (
@@ -26,7 +27,7 @@ const InlineCalloutCode: React.FC<React.PropsWithChildren<{ className?: string }
  */
 export const Changelog: React.FC<Omit<ChangelogProps & { data: { useDarkTheme: boolean } }, 'templateType' | 'templateName'>> = React.memo((props) => {
   const isDark = props.data.useDarkTheme ?? false
-  const { qrCodeDataUrl } = props as any
+  const share_url = (props as any).data?.share_url || ''
 
   const backgroundColors = isDark
     ? {
@@ -301,10 +302,10 @@ export const Changelog: React.FC<Omit<ChangelogProps & { data: { useDarkTheme: b
           </ReactMarkdown>
         </div>
 
-        {qrCodeDataUrl && (
+        {share_url && (
           <div className='flex flex-col items-center gap-12 py-8'>
             <div className='w-120 h-auto'>
-              <img src={qrCodeDataUrl} alt='二维码' className='w-full h-full object-contain' />
+              <img src={generateQRCode(share_url, isDark)} alt='二维码' className='w-full h-full object-contain' />
             </div>
             <div className='text-4xl text-foreground/60'>
               <span>扫码查看实际运行代码从</span>

--- a/packages/template/src/components/platforms/other/handlerError.tsx
+++ b/packages/template/src/components/platforms/other/handlerError.tsx
@@ -7,6 +7,7 @@ import React from 'react'
 import { MdSchedule } from 'react-icons/md'
 
 import type { ApiErrorProps, BusinessError, LogLevel } from '../../../types/platforms/other/handlerError'
+import { generateQRCode } from '../../../utils/QRcode'
 import { DefaultLayout } from '../../layouts/DefaultLayout'
 import { getRandomErrorTitle } from './errorTitles'
 
@@ -191,7 +192,7 @@ const SectionTitle: React.FC<{ icon: React.ReactNode; en: string; zh: string; co
  * API错误显示组件 - 手机端 Apple 风格
  */
 export const handlerError: React.FC<Omit<ApiErrorProps, 'templateType' | 'templateName'>> = (props) => {
-  const { data, qrCodeDataUrl } = props
+  const { data } = props
   const isDark = data.useDarkTheme === true
   const isBusinessError = data.type === 'business_error'
   const businessError = isBusinessError ? data.error as BusinessError : null
@@ -386,7 +387,7 @@ export const handlerError: React.FC<Omit<ApiErrorProps, 'templateType' | 'templa
         </div>
 
         {/* 验证二维码 */}
-        {data.isVerification && qrCodeDataUrl && (
+        {data.isVerification && data.verificationUrl && (
           <div
             className='mb-16 p-12 rounded-[40px]'
             style={{ backgroundColor: isDark ? 'rgba(0,0,0,0.25)' : 'rgba(255,255,255,0.6)' }}
@@ -396,7 +397,7 @@ export const handlerError: React.FC<Omit<ApiErrorProps, 'templateType' | 'templa
               <span className='text-3xl font-semibold' style={{ color: accentColor }}>人机验证</span>
             </div>
             <div className='flex gap-16 items-center'>
-              <img src={qrCodeDataUrl} alt='验证二维码' className='w-64 h-64 rounded-3xl' />
+              <img src={generateQRCode(data.verificationUrl, isDark)} alt='验证二维码' className='w-64 h-64 rounded-3xl' />
               <div className='space-y-6'>
                 <p className='text-3xl' style={{ color: secondaryColor }}>请在 120 秒内完成验证</p>
                 <ol className='space-y-4 text-2xl' style={{ color: mutedColor }}>

--- a/packages/template/src/components/platforms/other/qrlogin.tsx
+++ b/packages/template/src/components/platforms/other/qrlogin.tsx
@@ -2,6 +2,7 @@ import { AlertTriangle, QrCode, Smartphone } from 'lucide-react'
 import React from 'react'
 
 import type { QrLoginProps } from '../../../types/platforms/other'
+import { generateQRCode } from '../../../utils/QRcode'
 import { GlowImage } from '../../common/GlowImage'
 import { DefaultLayout } from '../../layouts/DefaultLayout'
 
@@ -11,7 +12,7 @@ import { DefaultLayout } from '../../layouts/DefaultLayout'
  * @returns JSX元素
  */
 export const QrLogin: React.FC<Omit<QrLoginProps, 'templateType' | 'templateName'>> = React.memo((props) => {
-  const qrCodeDataUrl = props.qrCodeDataUrl
+  const qrCodeDataUrl = props.data.qr_url ? generateQRCode(props.data.qr_url, props.data.useDarkTheme ?? false) : ''
   const isDark = props.data.useDarkTheme ?? false
 
   // 使用蓝紫色系弥散渐变

--- a/packages/template/src/components/platforms/xiaohongshu/Comment.tsx
+++ b/packages/template/src/components/platforms/xiaohongshu/Comment.tsx
@@ -1,21 +1,19 @@
 import { renderRichTextToReact } from '@kkk/richtext'
 import { differenceInSeconds, format, formatDistanceToNow } from 'date-fns'
 import { zhCN } from 'date-fns/locale'
-import { Heart, MessageCircle, QrCode } from 'lucide-react'
+import { Heart, MessageCircle } from 'lucide-react'
 import React from 'react'
 
 import type {
-  XiaohongshuCommentItemComponentProps,
-  XiaohongshuCommentProps,
-  XiaohongshuNoteInfoHeaderProps,
-  XiaohongshuQRCodeSectionProps
+  XiaohongshuCommentProps
 } from '../../../types/platforms/xiaohongshu'
+import { generateQRCode } from '../../../utils/QRcode'
 import { DefaultLayout } from '../../layouts/DefaultLayout'
 
 const xiaohongshuMentionClassName = 'text-[#13386c] dark:text-[#c7daef]'
 
 const renderXiaohongshuCommentRichText = (
-  content: XiaohongshuCommentItemComponentProps['comment']['content']
+  content: XiaohongshuCommentProps['data']['CommentsData'][0]['content']
 ) => {
   return renderRichTextToReact(content, {
     mention: { className: xiaohongshuMentionClassName }
@@ -54,46 +52,11 @@ const formatXiaohongshuLikeCount = (count: string): string => {
 }
 
 /**
- * 二维码区域组件
- * @param props 组件属性
- * @returns JSX元素
- */
-const QRCodeSection: React.FC<XiaohongshuQRCodeSectionProps> = ({
-  qrCodeDataUrl
-}) => {
-  return (
-    <div className='flex flex-col justify-center items-center p-5'>
-      <div className='flex overflow-hidden justify-center items-center bg-white w-110 h-110'>
-        {qrCodeDataUrl
-          ? (
-            <img
-              src={qrCodeDataUrl}
-              alt='二维码'
-              className='object-contain'
-            />
-          )
-          : (
-            <QrCode width={200} className='text-muted' />
-          )}
-      </div>
-      <p className='mt-5 text-[40px] text-muted text-center'>
-        扫码查看原笔记
-      </p>
-    </div>
-  )
-}
-
-/**
  * 笔记信息头部组件
  * @param props 组件属性
  * @returns JSX元素
  */
-const NoteInfoHeader: React.FC<XiaohongshuNoteInfoHeaderProps> = ({
-  type,
-  commentLength,
-  imageLength,
-  qrCodeDataUrl
-}) => {
+const NoteInfoHeader: React.FC<XiaohongshuCommentProps['data']> = (props) => {
   return (
     <div className='flex justify-between items-center max-w-300 mx-auto p-5'>
       <div className='flex flex-col justify-center items-start'>
@@ -117,21 +80,30 @@ const NoteInfoHeader: React.FC<XiaohongshuNoteInfoHeaderProps> = ({
         {/* 文字信息区域 */}
         <div className='mt-8 space-y-4 text-left text-muted'>
           <div className='tracking-[6px] text-[45px] select-text'>
-            笔记类型：{type}
+            笔记类型：{props.Type}
           </div>
           <div className='tracking-[6px] text-[45px] select-text'>
-            评论数量：{commentLength}条
+            评论数量：{props.CommentLength}条
           </div>
-          {type === '图文' && imageLength && (
+          {props.Type === '图文' && props.ImageLength && (
             <div className='tracking-[6px] text-[45px] select-text'>
-              图片数量：{imageLength}张
+              图片数量：{props.ImageLength}张
             </div>
           )}
         </div>
       </div>
-      <QRCodeSection
-        qrCodeDataUrl={qrCodeDataUrl}
-      />
+      <div className='flex flex-col justify-center items-center p-5'>
+        <div className='flex overflow-hidden justify-center items-center bg-white w-110 h-110'>
+          <img
+            src={generateQRCode(props.share_url, props.useDarkTheme)}
+            alt='二维码'
+            className='object-contain'
+          />
+        </div>
+        <p className='mt-5 text-[40px] text-muted text-center'>
+          扫码查看原笔记
+        </p>
+      </div>
     </div>
   )
 }
@@ -141,12 +113,12 @@ const NoteInfoHeader: React.FC<XiaohongshuNoteInfoHeaderProps> = ({
  * @param props 组件属性
  * @returns JSX元素
  */
-const CommentItemComponent: React.FC<XiaohongshuCommentItemComponentProps & { isLast?: boolean }> = ({ comment, isLast = false }) => {
+const CommentItemComponent: React.FC<XiaohongshuCommentProps['data']['CommentsData'][0] & { isLast?: boolean }> = ({ ...props }, isLast = false) => {
   return (
     <div className={`flex px-10 pt-15 ${isLast ? 'pb-0' : 'pb-15'}`}>
       {/* 用户头像 */}
       <img
-        src={comment.user_info.image}
+        src={props.user_info.image}
         className='mb-12.5 w-[187.5px] h-[187.5px] rounded-full mr-8 object-cover shadow-lg'
         alt='用户头像'
       />
@@ -155,8 +127,8 @@ const CommentItemComponent: React.FC<XiaohongshuCommentItemComponentProps & { is
       <div className='flex-1'>
         {/* 用户信息 */}
         <div className='mb-12.5 text-[50px] text-foreground/70 relative flex items-center select-text'>
-          <span className='text-5xl'>{comment.user_info.nickname}</span>
-          {comment.show_tags && comment.show_tags.length > 0 && comment.show_tags.map((tag, index) => {
+          <span className='text-5xl'>{props.user_info.nickname}</span>
+          {props.show_tags && props.show_tags.length > 0 && props.show_tags.map((tag, index) => {
             if (tag === 'is_author') {
               return (
                 <div key={index} className='inline-block px-6 py-3 ml-3 text-4xl rounded-full bg-surface text-muted'>
@@ -183,15 +155,15 @@ const CommentItemComponent: React.FC<XiaohongshuCommentItemComponentProps & { is
             overflowWrap: 'break-word'
           }}
         >
-          {renderXiaohongshuCommentRichText(comment.content)}
+          {renderXiaohongshuCommentRichText(props.content)}
         </div>
 
         {/* 评论图片 */}
-        {comment.pictures && comment.pictures.length > 0 && (
+        {props.pictures && props.pictures.length > 0 && (
           <div className='flex my-5 overflow-hidden shadow-md rounded-2xl w-[95%] flex-1'>
             <img
               className='object-contain w-full h-full rounded-2xl'
-              src={comment.pictures[0].url_default}
+              src={props.pictures[0].url_default}
               alt='评论图片'
             />
           </div>
@@ -200,12 +172,12 @@ const CommentItemComponent: React.FC<XiaohongshuCommentItemComponentProps & { is
         {/* 底部信息和操作区域 */}
         <div className='flex justify-between items-center mt-6 text-muted'>
           <div className='flex items-center space-x-6 select-text'>
-            <span className='text-[45px]'>{formatXiaohongshuCommentTime(comment.create_time)}</span>
-            <span className='text-[45px]'>{comment.ip_location}</span>
-            {parseInt(comment.sub_comment_count) > 0
+            <span className='text-[45px]'>{formatXiaohongshuCommentTime(props.create_time)}</span>
+            <span className='text-[45px]'>{props.ip_location}</span>
+            {parseInt(props.sub_comment_count) > 0
               ? (
                 <span className='text-[40px] text-foreground/70'>
-                  共{comment.sub_comment_count}条回复
+                  共{props.sub_comment_count}条回复
                 </span>
               )
               : (
@@ -216,8 +188,8 @@ const CommentItemComponent: React.FC<XiaohongshuCommentItemComponentProps & { is
           <div className='flex items-center space-x-6'>
             {/* 点赞按钮 */}
             <div className='flex items-center space-x-2 transition-colors cursor-pointer'>
-              <Heart size={60} className={comment.liked ? 'text-red-500 fill-current' : 'text-muted'} />
-              <span className='text-[50px] select-text'>{formatXiaohongshuLikeCount(comment.like_count)}</span>
+              <Heart size={60} className={props.liked ? 'text-red-500 fill-current' : 'text-muted'} />
+              <span className='text-[50px] select-text'>{formatXiaohongshuLikeCount(props.like_count)}</span>
             </div>
 
             {/* 回复按钮 */}
@@ -228,10 +200,10 @@ const CommentItemComponent: React.FC<XiaohongshuCommentItemComponentProps & { is
         </div>
 
         {/* 子评论 */}
-        {comment.sub_comments && comment.sub_comments.length > 0 && (
+        {props.sub_comments && props.sub_comments.length > 0 && (
           <div className='pl-6 mt-6'>
-            {comment.sub_comments.map((subComment, index) => (
-              <div key={subComment.id} className={`py-4 ${index !== comment.sub_comments.length - 1 ? 'border-b border-divider' : ''}`}>
+            {props.sub_comments.map((subComment, index) => (
+              <div key={subComment.id} className={`py-4 ${index !== props.sub_comments.length - 1 ? 'border-b border-divider' : ''}`}>
                 <div className='flex items-start space-x-4'>
                   <img
                     src={subComment.user_info.image}
@@ -286,17 +258,12 @@ const CommentItemComponent: React.FC<XiaohongshuCommentItemComponentProps & { is
  * @param props 组件属性
  * @returns JSX元素
  */
-export const XiaohongshuComment: React.FC<Omit<XiaohongshuCommentProps, 'templateType' | 'templateName'>> = React.memo((props) => {
+export const XiaohongshuComment: React.FC<XiaohongshuCommentProps> = React.memo(props => {
   return (
     <DefaultLayout {...props}>
       <div className='h-30' />
       {/* 页面头部 */}
-      <NoteInfoHeader
-        type={props.data.Type}
-        commentLength={props.data.CommentLength}
-        imageLength={props.data.ImageLength}
-        qrCodeDataUrl={props.qrCodeDataUrl}
-      />
+      <NoteInfoHeader {...props.data} />
 
       {/* 评论列表 */}
       <div className='overflow-auto mx-20 max-w-full'>
@@ -306,7 +273,7 @@ export const XiaohongshuComment: React.FC<Omit<XiaohongshuCommentProps, 'templat
               {props.data.CommentsData.map((comment, index) => (
                 <CommentItemComponent
                   key={comment.id}
-                  comment={comment}
+                  {...comment}
                   isLast={index === props.data.CommentsData.length - 1}
                 />
               ))}

--- a/packages/template/src/dev/App.tsx
+++ b/packages/template/src/dev/App.tsx
@@ -127,7 +127,6 @@ export const App: React.FC = () => {
   const [selectedTemplate, setSelectedTemplate] = React.useState<string>(initialTemplate)
   const [templateData, setTemplateData] = React.useState<any>(null)
   const [loadError, setLoadError] = React.useState<Error | null>(null)
-  const [qrCodeDataUrl, setQrCodeDataUrl] = React.useState<string>('')
   const [scale, setScale] = React.useState(0.5)
   const [availableDataFiles, setAvailableDataFiles] = React.useState<string[]>([])
   const [selectedDataFile, setSelectedDataFile] = React.useState<string>(urlParams.dataFile || 'default.json')
@@ -271,16 +270,6 @@ export const App: React.FC = () => {
         filename || selectedDataFile
       )
       setTemplateData(data || {})
-
-      // 生成二维码，传递正确的主题参数
-      if (data?.share_url) {
-        try {
-          const qrDataUrl = await dataService.generateQRCode(data.share_url, data.useDarkTheme || false)
-          setQrCodeDataUrl(qrDataUrl)
-        } catch (qrError) {
-          console.warn('生成二维码失败:', qrError)
-        }
-      }
     } catch (error) {
       console.error('加载数据失败:', error)
       setLoadError(error instanceof Error ? error : new Error(String(error)))
@@ -289,14 +278,6 @@ export const App: React.FC = () => {
         const defaultData = await dataService.getTemplateData(selectedPlatform, selectedTemplate)
         setTemplateData(defaultData || {})
         setLoadError(null)
-        if (defaultData?.share_url) {
-          try {
-            const qrDataUrl = await dataService.generateQRCode(defaultData.share_url, defaultData.useDarkTheme || false)
-            setQrCodeDataUrl(qrDataUrl)
-          } catch (qrError) {
-            console.warn('生成二维码失败:', qrError)
-          }
-        }
       } catch (defaultError) {
         console.error('加载默认数据也失败:', defaultError)
         // 设置最终的错误状态
@@ -314,16 +295,6 @@ export const App: React.FC = () => {
     if (templateData) {
       const newData = { ...templateData, useDarkTheme: checked }
       setTemplateData(newData)
-
-      // 如果有分享链接，重新生成二维码
-      if (newData.share_url) {
-        try {
-          const qrDataUrl = await dataService.generateQRCode(newData.share_url, checked)
-          setQrCodeDataUrl(qrDataUrl)
-        } catch (error) {
-          console.error('重新生成二维码失败:', error)
-        }
-      }
     }
   }
 
@@ -712,7 +683,6 @@ export const App: React.FC = () => {
                   dataFile={selectedDataFile}
                   data={templateData}
                   loadError={loadError}
-                  qrCodeDataUrl={qrCodeDataUrl}
                   scale={scale}
                   onScaleChange={setScale}
                   onComponentLoadComplete={handleComponentLoadComplete}

--- a/packages/template/src/dev/components/ComponentRenderer.tsx
+++ b/packages/template/src/dev/components/ComponentRenderer.tsx
@@ -15,8 +15,6 @@ interface ComponentRendererProps {
   dataFile?: string
   /** 当前数据 */
   data: any
-  /** 二维码数据URL */
-  qrCodeDataUrl: string
   /** 加载错误 */
   loadError?: Error | null
   /** 组件加载完成回调 */
@@ -88,7 +86,7 @@ class ComponentErrorBoundary extends React.Component<{ children: React.ReactNode
  * @param props 组件属性
  * @returns JSX元素
  */
-const ComponentRendererInner: React.FC<ComponentRendererProps> = ({ platform, templateId, dataFile, data, qrCodeDataUrl, loadError, onLoadComplete, versionEnabled = true }) => {
+const ComponentRendererInner: React.FC<ComponentRendererProps> = ({ platform, templateId, dataFile, data, loadError, onLoadComplete, versionEnabled = true }) => {
   const { renderData, extraProps } = React.useMemo(() => splitPreviewPayload(data), [data])
   const componentConfig = getComponentConfig(platform, templateId)
 
@@ -286,7 +284,6 @@ const ComponentRendererInner: React.FC<ComponentRendererProps> = ({ platform, te
   const commonProps = {
     ...extraProps,
     data: renderData,
-    qrCodeDataUrl,
     version: versionEnabled ? version : undefined,
     watermarkTextBitSize,
     scale: 1

--- a/packages/template/src/dev/components/PreviewPanel.tsx
+++ b/packages/template/src/dev/components/PreviewPanel.tsx
@@ -22,8 +22,6 @@ interface PreviewPanelProps {
   data: any
   /** 加载错误 */
   loadError: Error | null
-  /** 二维码数据URL */
-  qrCodeDataUrl: string
   /** 缩放比例 */
   scale: number
   /** 缩放变化回调 */
@@ -55,7 +53,6 @@ export const PreviewPanel = forwardRef<PreviewPanelRef, PreviewPanelProps>(({
   dataFile,
   data,
   loadError,
-  qrCodeDataUrl,
   scale,
   onScaleChange,
   onComponentLoadComplete,
@@ -88,11 +85,10 @@ export const PreviewPanel = forwardRef<PreviewPanelRef, PreviewPanelProps>(({
     templateId,
     dataFile,
     data,
-    qrCodeDataUrl,
     loadError,
     onLoadComplete: onComponentLoadComplete,
     versionEnabled
-  }), [platform, templateId, dataFile, data, qrCodeDataUrl, loadError, onComponentLoadComplete, versionEnabled])
+  }), [platform, templateId, dataFile, data, loadError, onComponentLoadComplete, versionEnabled])
 
   /**
    * 截图功能

--- a/packages/template/src/dev/vite-mock-plugin.ts
+++ b/packages/template/src/dev/vite-mock-plugin.ts
@@ -330,63 +330,63 @@ export function mockApiPlugin (): Plugin {
           }
 
           // 二维码生成 API: /api/qrcode
-          if (method === 'GET' && url.startsWith('/qrcode')) {
-            const urlParams = new URLSearchParams(url.split('?')[1] || '')
-            const targetUrl = urlParams.get('url') || 'https://example.com'
-            const useDarkTheme = urlParams.get('useDarkTheme') === 'true'
+          // if (method === 'GET' && url.startsWith('/qrcode')) {
+          //   const urlParams = new URLSearchParams(url.split('?')[1] || '')
+          //   const targetUrl = urlParams.get('url') || 'https://example.com'
+          //   const useDarkTheme = urlParams.get('useDarkTheme') === 'true'
 
-            try {
-              const { JSDOM } = await import('jsdom')
+          //   try {
+          //     const { JSDOM } = await import('jsdom')
 
-              const qrCode = new QRCodeStyling({
-                jsdom: JSDOM,
-                type: 'svg',
-                shape: 'square',
-                width: 2000,
-                height: 2000,
-                data: targetUrl,
-                margin: 0,
-                qrOptions: {
-                  typeNumber: 0,
-                  mode: 'Byte',
-                  errorCorrectionLevel: 'L'
-                },
-                imageOptions: {
-                  hideBackgroundDots: false,
-                  imageSize: 0.4,
-                  margin: 0
-                },
-                dotsOptions: {
-                  type: 'rounded',
-                  color: useDarkTheme ? '#C3C3C3' : '#3A3A3A',  
-                  roundSize: false
-                },
-                backgroundOptions: {
-                  color: 'transparent'
-                },
-                cornersSquareOptions: {
-                  type: 'extra-rounded',
-                  color: useDarkTheme ? '#C3C3C3' : '#3A3A3A'
-                },
-                cornersDotOptions: {
-                  color: useDarkTheme ? '#C3C3C3' : '#3A3A3A'
-                }
-              })
-              const buffer = await qrCode.getRawData('svg')
+          //     const qrCode = new QRCodeStyling({
+          //       jsdom: JSDOM,
+          //       type: 'svg',
+          //       shape: 'square',
+          //       width: 2000,
+          //       height: 2000,
+          //       data: targetUrl,
+          //       margin: 0,
+          //       qrOptions: {
+          //         typeNumber: 0,
+          //         mode: 'Byte',
+          //         errorCorrectionLevel: 'L'
+          //       },
+          //       imageOptions: {
+          //         hideBackgroundDots: false,
+          //         imageSize: 0.4,
+          //         margin: 0
+          //       },
+          //       dotsOptions: {
+          //         type: 'rounded',
+          //         color: useDarkTheme ? '#C3C3C3' : '#3A3A3A',
+          //         roundSize: false
+          //       },
+          //       backgroundOptions: {
+          //         color: 'transparent'
+          //       },
+          //       cornersSquareOptions: {
+          //         type: 'extra-rounded',
+          //         color: useDarkTheme ? '#C3C3C3' : '#3A3A3A'
+          //       },
+          //       cornersDotOptions: {
+          //         color: useDarkTheme ? '#C3C3C3' : '#3A3A3A'
+          //       }
+          //     })
+          //     const buffer = await qrCode.getRawData('svg')
 
-              const dataUrl = buffer && `data:image/svg+xml;base64,${buffer.toString('base64')}`
-              res.setHeader('Content-Type', 'application/json')
-              res.end(JSON.stringify({ dataUrl }))
-            } catch (error) {
-              res.statusCode = 500
-              res.setHeader('Content-Type', 'application/json')
-              res.end(JSON.stringify({
-                error: '生成二维码失败',
-                details: error instanceof Error ? error.message : '未知错误'
-              }))
-            }
-            return
-          }
+          //     const dataUrl = buffer && `data:image/svg+xml;base64,${buffer.toString('base64')}`
+          //     res.setHeader('Content-Type', 'application/json')
+          //     res.end(JSON.stringify({ dataUrl }))
+          //   } catch (error) {
+          //     res.statusCode = 500
+          //     res.setHeader('Content-Type', 'application/json')
+          //     res.end(JSON.stringify({
+          //       error: '生成二维码失败',
+          //       details: error instanceof Error ? error.message : '未知错误'
+          //     }))
+          //   }
+          //   return
+          // }
 
           // 如果没有匹配的路由，继续到下一个中间件
           next()

--- a/packages/template/src/types/index.ts
+++ b/packages/template/src/types/index.ts
@@ -1,14 +1,4 @@
 /**
- * 二维码区域组件属性接口
- */
-export interface QRCodeSectionProps {
-  /** 预生成的二维码数据URL */
-  qrCodeDataUrl: string
-  /** 是否使用深色主题 */
-  useDarkTheme?: boolean
-}
-
-/**
  * 渲染请求参数接口
  */
 export interface RenderRequest<T = Record<string, unknown>> {
@@ -19,7 +9,7 @@ export interface RenderRequest<T = Record<string, unknown>> {
   /** 缩放比例 */
   scale?: number
   /** 是否使用深色主题 */
-  useDarkTheme?: boolean
+  useDarkTheme: boolean
   /** 版本信息 */
   version?: {
     /** 框架插件 */
@@ -70,7 +60,7 @@ export interface BaseComponentProps<T = Record<string, any>> extends Pick<Render
   /** 渲染数据 - 子组件的具体参数 */
   data: T & {
     /** 是否使用深色主题 */
-    useDarkTheme?: boolean
+    useDarkTheme: boolean
   }
 }
 

--- a/packages/template/src/types/platforms/bilibili/bangumi.ts
+++ b/packages/template/src/types/platforms/bilibili/bangumi.ts
@@ -169,11 +169,7 @@ export interface BangumiBilibiliData {
 /**
  * B站番剧组件属性接口
  */
-export interface BilibiliBangumiProps extends BaseComponentProps {
-  /** 番剧数据 */
-  data: BangumiBilibiliData
-  /** 预生成的二维码数据URL */
-  qrCodeDataUrl?: string
+export interface BilibiliBangumiProps extends BaseComponentProps<BangumiBilibiliData> {
 }
 
 /**
@@ -200,6 +196,4 @@ export interface BangumiBilibiliHeaderProps {
   copyright: string
   /** 季度ID */
   seasonID: number
-  /** 是否使用深色主题 */
-  useDarkTheme?: boolean
 }

--- a/packages/template/src/types/platforms/bilibili/comment.ts
+++ b/packages/template/src/types/platforms/bilibili/comment.ts
@@ -5,32 +5,26 @@ import type { BaseComponentProps } from '../../index'
 /**
  * B站评论组件属性接口
  */
-export interface BilibiliCommentProps extends BaseComponentProps {
-  /** 渲染请求数据 */
-  data: {
-    /** 是否使用深色主题 */
-    useDarkTheme?: boolean
-    /** 作品类型：视频/图集/动态 */
-    Type: '视频' | '动态'
-    /** 评论数量 */
-    CommentLength: string
-    /** 视频大小(MB) */
-    VideoSize?: string
-    /** 视频画质 */
-    Clarity?: string
-    /** 图片数量 */
-    ImageLength?: number
-    /** 分享链接 */
-    shareurl: string
-    /** 分享URL */
-    share_url: string
-    /** 视频分辨率 */
-    Resolution: string | null
-    /** 评论数据 */
-    CommentsData: CommentItem[]
-  }
-  /** 预生成的二维码数据URL */
-  qrCodeDataUrl: string
+export interface BilibiliCommentProps extends BaseComponentProps<{
+  /** 作品类型：视频/图集/动态 */
+  Type: '视频' | '动态'
+  /** 评论数量 */
+  CommentLength: string
+  /** 视频大小(MB) */
+  VideoSize?: string
+  /** 视频画质 */
+  Clarity?: string
+  /** 图片数量 */
+  ImageLength?: number
+  /** 分享链接 */
+  shareurl: string
+  /** 分享URL */
+  share_url: string
+  /** 视频分辨率 */
+  Resolution: string | null
+  /** 评论数据 */
+  CommentsData: CommentItem[]
+}> {
 }
 
 /**

--- a/packages/template/src/types/platforms/bilibili/dynamic/article.ts
+++ b/packages/template/src/types/platforms/bilibili/dynamic/article.ts
@@ -6,69 +6,63 @@ import type { DecorationCardData, UsernameMetadata } from './normal'
 /**
  * B站专栏动态组件属性接口
  */
-export interface BilibiliArticleDynamicProps extends BaseComponentProps {
-  /** 渲染请求数据 */
-  data: {
-    /** 是否使用深色主题 */
-    useDarkTheme?: boolean
-    /** 用户头像URL */
-    avatar_url: string
-    /** 头像框 */
-    frame?: string
-    /** 用户名元数据 */
-    usernameMeta: UsernameMetadata
-    /** 动态创建时间 */
-    create_time: string
-    /** 装饰卡片 */
-    decoration_card?: DecorationCardData
-    /** 专栏标题 */
-    title: string
-    /** 专栏摘要 */
-    summary: string
-    /** 专栏封面图片URL */
-    banner_url?: string
-    /** 专栏分类 */
-    categories: Array<{
-      id: number
-      name: string
-      parent_id: number
-    }>
-    /** 专栏字数 */
-    words: number
-    /** 专栏统计数据 */
-    stats: {
-      /** 阅读数 */
-      view: number
-      /** 点赞数 */
-      like: number
-      /** 收藏数 */
-      favorite: number
-      /** 评论数 */
-      reply: number
-      /** 分享数 */
-      share: number
-      /** 投币数 */
-      coin: number
-      /** 转发动态 */
-      dynamic: number
-    }
-    /** 专栏正文（richtext 格式） */
-    body: RichTextDocument
-    /** 渲染时间 */
-    render_time: string
-    /** 动态类型 */
-    dynamicTYPE: string
-    /** 分享链接 */
-    share_url: string
-    /** 用户短ID */
-    user_shortid: string | number
-    /** 获赞总数 */
-    total_favorited: string | number
-    /** 关注数 */
-    following_count: string | number
-    /** 粉丝数 */
-    fans: string | number
+export interface BilibiliArticleDynamicProps extends BaseComponentProps<{
+  /** 用户头像URL */
+  avatar_url: string
+  /** 头像框 */
+  frame?: string
+  /** 用户名元数据 */
+  usernameMeta: UsernameMetadata
+  /** 动态创建时间 */
+  create_time: string
+  /** 装饰卡片 */
+  decoration_card?: DecorationCardData
+  /** 专栏标题 */
+  title: string
+  /** 专栏摘要 */
+  summary: string
+  /** 专栏封面图片URL */
+  banner_url?: string
+  /** 专栏分类 */
+  categories: Array<{
+    id: number
+    name: string
+    parent_id: number
+  }>
+  /** 专栏字数 */
+  words: number
+  /** 专栏统计数据 */
+  stats: {
+    /** 阅读数 */
+    view: number
+    /** 点赞数 */
+    like: number
+    /** 收藏数 */
+    favorite: number
+    /** 评论数 */
+    reply: number
+    /** 分享数 */
+    share: number
+    /** 投币数 */
+    coin: number
+    /** 转发动态 */
+    dynamic: number
   }
-  /** 预生成的二维码数据URL */
-  qrCodeDataUrl?: string
+  /** 专栏正文（richtext 格式） */
+  body: RichTextDocument
+  /** 渲染时间 */
+  render_time: string
+  /** 动态类型 */
+  dynamicTYPE: string
+  /** 分享链接 */
+  share_url: string
+  /** 用户短ID */
+  user_shortid: string | number
+  /** 获赞总数 */
+  total_favorited: string | number
+  /** 关注数 */
+  following_count: string | number
+  /** 粉丝数 */
+  fans: string | number
+}> {
 }

--- a/packages/template/src/types/platforms/bilibili/dynamic/forward.ts
+++ b/packages/template/src/types/platforms/bilibili/dynamic/forward.ts
@@ -122,23 +122,17 @@ export interface BilibiliForwardContentProps {
   text: RichTextDocument
   /** 原始内容 */
   original_content: BilibiliForwardOriginalContentProps['original_content']
-  /** 是否使用深色主题 */
-  useDarkTheme?: boolean
 }
 
 /**
  * B站转发动态组件属性接口
  */
-export interface BilibiliForwardDynamicProps extends BaseComponentProps {
-  /** 渲染请求数据 */
-  data: BilibiliDynamicBaseData & {
-    /** 动态文本内容（富文本文档） */
-    text: RichTextDocument
-    /** 原始内容 */
-    original_content: BilibiliForwardOriginalContentProps['original_content']
-    /** 图片URL */
-    imgList: string[] | null
-  }
-  /** 预生成的二维码数据URL */
-  qrCodeDataUrl?: string
+export interface BilibiliForwardDynamicProps extends BaseComponentProps<BilibiliDynamicBaseData & {
+  /** 动态文本内容（富文本文档） */
+  text: RichTextDocument
+  /** 原始内容 */
+  original_content: BilibiliForwardOriginalContentProps['original_content']
+  /** 图片URL */
+  imgList: string[] | null
+}> {
 }

--- a/packages/template/src/types/platforms/bilibili/dynamic/live.ts
+++ b/packages/template/src/types/platforms/bilibili/dynamic/live.ts
@@ -21,36 +21,30 @@ export interface BilibiliPosterPalettes {
 /**
  * B站直播动态组件属性接口
  */
-export interface BilibiliLiveDynamicProps extends BaseComponentProps {
-  /** 渲染请求数据 */
-  data: {
-    /** 是否使用深色主题 */
-    useDarkTheme?: boolean
-    /** 直播封面 */
-    image_url: string
-    /** 直播标题 */
-    text: RichTextDocument
-    /** 直播房间信息（分区 | 房间号） */
-    liveinf: string
-    /** 用户名元数据 */
-    usernameMeta: UsernameMetadata
-    /** 用户头像URL */
-    avatar_url: string
-    /** 头像框 */
-    frame?: string
-    /** 粉丝数 */
-    fans: string
-    /** 时间信息 */
-    create_time: string
-    /** 直播开始时间 */
-    now_time: string
-    /** 分享和配置 */
-    share_url: string
-    /** 动态类型 */
-    dynamicTYPE: string
-  }
-  /** 预生成的二维码数据URL */
-  qrCodeDataUrl?: string
+export interface BilibiliLiveDynamicProps extends BaseComponentProps<{
+  /** 直播封面 */
+  image_url: string
+  /** 直播标题 */
+  text: RichTextDocument
+  /** 直播房间信息（分区 | 房间号） */
+  liveinf: string
+  /** 用户名元数据 */
+  usernameMeta: UsernameMetadata
+  /** 用户头像URL */
+  avatar_url: string
+  /** 头像框 */
+  frame?: string
+  /** 粉丝数 */
+  fans: string
+  /** 时间信息 */
+  create_time: string
+  /** 直播开始时间 */
+  now_time: string
+  /** 分享和配置 */
+  share_url: string
+  /** 动态类型 */
+  dynamicTYPE: string
+}> {
   /** 服务端预计算的海报色板（亮色/深色） */
   posterPalettes?: BilibiliPosterPalettes
   /** 服务端预计算的海报色板 */
@@ -92,6 +86,4 @@ export interface BilibiliLiveDynamicFooterProps {
   dynamicTYPE: string
   /** 分享链接 */
   share_url: string
-  /** 二维码数据URL */
-  qrCodeDataUrl?: string
 }

--- a/packages/template/src/types/platforms/bilibili/dynamic/normal.ts
+++ b/packages/template/src/types/platforms/bilibili/dynamic/normal.ts
@@ -30,8 +30,6 @@ export interface UsernameMetadata {
  * B站动态基础数据接口（所有动态类型共有的字段）
  */
 export interface BilibiliDynamicBaseData {
-  /** 是否使用深色主题 */
-  useDarkTheme?: boolean
   /** 用户头像URL */
   avatar_url: string
   /** 头像框 */
@@ -69,22 +67,18 @@ export interface BilibiliDynamicBaseData {
 /**
  * B站普通动态组件属性接口
  */
-export interface BilibiliDynamicProps extends BaseComponentProps {
-  /** 渲染请求数据 */
-  data: BilibiliDynamicBaseData & {
-    /** 图文动态标题 */
-    title?: string
-    /** 动态文本内容（富文本文档） */
-    text: RichTextDocument | null
-    /** 图片URL数组 */
-    image_url: Array<{ image_src: string }>
-    /** 图片布局方式 */
-    imageLayout: string
-    /** 相关内容卡片 */
-    additional?: BilibiliAdditionalData
-  }
-  /** 预生成的二维码数据URL */
-  qrCodeDataUrl?: string
+export interface BilibiliDynamicProps extends BaseComponentProps<BilibiliDynamicBaseData & {
+  /** 图文动态标题 */
+  title?: string
+  /** 动态文本内容（富文本文档） */
+  text: RichTextDocument | null
+  /** 图片URL数组 */
+  image_url: Array<{ image_src: string }>
+  /** 图片布局方式 */
+  imageLayout: string
+  /** 相关内容卡片 */
+  additional?: BilibiliAdditionalData
+}> {
 }
 
 /**
@@ -217,26 +211,33 @@ export interface BilibiliDynamicFooterProps {
   dynamicTYPE: string
   /** 分享链接 */
   share_url: string
-  /** 二维码数据URL */
-  qrCodeDataUrl?: string
+  /** 头像URL */
+  avatar_url: string
+  /** 头像框URL */
+  frame?: string
+  /** 用户名元数据 */
+  usernameMeta: {
+    /** 用户名 */
+    name: string
+    /** VIP状态，1为年度大会员 */
+    vipStatus: number
+    /** 昵称颜色 */
+    nicknameColor: string | null
+  }
   /** 是否使用深色主题 */
-  useDarkTheme?: boolean
+  useDarkTheme: boolean
 }
 
 
 /**
  * B站纯文动态组件属性接口
  */
-export interface BilibiliWordDynamicProps extends BaseComponentProps {
-  /** 渲染请求数据 */
-  data: BilibiliDynamicBaseData & {
-    /** 动态文本内容（富文本文档） */
-    text: RichTextDocument | null
-    /** 相关内容卡片 */
-    additional?: BilibiliAdditionalData
-  }
-  /** 预生成的二维码数据URL */
-  qrCodeDataUrl?: string
+export interface BilibiliWordDynamicProps extends BaseComponentProps<BilibiliDynamicBaseData & {
+  /** 动态文本内容（富文本文档） */
+  text: RichTextDocument | null
+  /** 相关内容卡片 */
+  additional?: BilibiliAdditionalData
+}> {
 }
 
 /**
@@ -245,8 +246,6 @@ export interface BilibiliWordDynamicProps extends BaseComponentProps {
 export interface BilibiliWordContentProps {
   /** 动态文本内容（富文本文档） */
   text: RichTextDocument | null
-  /** 是否使用深色主题 */
-  useDarkTheme?: boolean
   /** 相关内容卡片 */
   additional?: BilibiliAdditionalData
 }

--- a/packages/template/src/types/platforms/bilibili/dynamic/video.ts
+++ b/packages/template/src/types/platforms/bilibili/dynamic/video.ts
@@ -6,39 +6,35 @@ import type { BilibiliDynamicBaseData } from './normal'
 /**
  * B站视频动态组件属性接口
  */
-export interface BilibiliVideoDynamicProps extends BaseComponentProps {
-  /** 渲染请求数据 */
-  data: BilibiliDynamicBaseData & {
-    /** 视频标题 */
-    text: RichTextDocument
-    /** 视频描述 */
-    desc: RichTextDocument
-    /** 动态正文（富文本文档） */
-    dynamic_text: RichTextDocument | null
-    /** 视频封面图片URL */
-    image_url: string
-    /** 硬币数 */
-    coin: string | number
-    /** 浏览量 */
-    view: string | number
-    /** 视频时长 */
-    duration_text: string
-    /** 视频分P数量 */
-    page_length: number
-    /** 共创者列表 (可选) */
-    staff?: Array<{
-      /** 用户ID */
-      mid: number
-      /** 职位标题 (UP主/参演) */
-      title: string
-      /** 用户名 */
-      name: string
-      /** 头像URL */
-      face: string
-      /** 粉丝数 */
-      follower: number
-    }>
-  }
-  /** 预生成的二维码数据URL */
-  qrCodeDataUrl?: string
+export interface BilibiliVideoDynamicProps extends BaseComponentProps<BilibiliDynamicBaseData & {
+  /** 视频标题 */
+  text: RichTextDocument
+  /** 视频描述 */
+  desc: RichTextDocument
+  /** 动态正文（富文本文档） */
+  dynamic_text: RichTextDocument | null
+  /** 视频封面图片URL */
+  image_url: string
+  /** 硬币数 */
+  coin: string | number
+  /** 浏览量 */
+  view: string | number
+  /** 视频时长 */
+  duration_text: string
+  /** 视频分P数量 */
+  page_length: number
+  /** 共创者列表 (可选) */
+  staff?: Array<{
+    /** 用户ID */
+    mid: number
+    /** 职位标题 (UP主/参演) */
+    title: string
+    /** 用户名 */
+    name: string
+    /** 头像URL */
+    face: string
+    /** 粉丝数 */
+    follower: number
+  }>
+}> {
 }

--- a/packages/template/src/types/platforms/bilibili/index.ts
+++ b/packages/template/src/types/platforms/bilibili/index.ts
@@ -1,22 +1,10 @@
-/**
- * 二维码组件属性接口
- */
-export interface QRCodeSectionProps {
-  /** 二维码数据URL */
-  qrCodeDataUrl?: string
-}
-
+import type { BaseComponentProps } from '../../index'
 
 /** B站二维码登录组件属性 */
-export interface BilibiliQrcodeImgProps {
-  data: {
-    /** 分享链接 */
-    share_url: string
-    /** 是否使用深色主题 */
-    useDarkTheme?: boolean
-  }
-  /** 二维码数据URL */
-  qrCodeDataUrl?: string
+export interface BilibiliQrcodeImgProps extends BaseComponentProps<{
+  /** 分享链接 */
+  share_url: string
+}> {
 }
 
 export * from './bangumi'

--- a/packages/template/src/types/platforms/bilibili/userlist.ts
+++ b/packages/template/src/types/platforms/bilibili/userlist.ts
@@ -3,38 +3,33 @@ import type { BaseComponentProps } from '../../index'
 /**
  * B站用户列表组件属性接口
  */
-export interface BilibiliUserListProps extends BaseComponentProps {
-  /** 渲染请求数据 */
-  data: {
-    /** 是否使用深色主题 */
-    useDarkTheme?: boolean
-    /** 群组信息 */
-    groupInfo: {
-      /** 群号 */
-      groupId: string
-      /** 群名称 */
-      groupName: string
-      /** 群头像 */
-      groupAvatar: string
-    }
-    /** 用户列表数据 */
-    renderOpt: {
-      /** 用户头像图片URL */
-      avatar_img: string
-      /** 用户名 */
-      username: string
-      /** 用户UID */
-      host_mid: string
-      /** 粉丝数 */
-      fans: string
-      /** 获赞总数 */
-      total_favorited: string
-      /** 关注数 */
-      following_count: string
-      /** 全局推送开关状态 */
-      switch: boolean
-      /** 推送类型列表 */
-      pushTypes?: ('video' | 'draw' | 'word' | 'live' | 'forward' | 'article')[]
-    }[]
+export interface BilibiliUserListProps extends BaseComponentProps<{
+  /** 群组信息 */
+  groupInfo: {
+    /** 群号 */
+    groupId: string
+    /** 群名称 */
+    groupName: string
+    /** 群头像 */
+    groupAvatar: string
   }
-}
+  /** 用户列表数据 */
+  renderOpt: {
+    /** 用户头像图片URL */
+    avatar_img: string
+    /** 用户名 */
+    username: string
+    /** 用户UID */
+    host_mid: string
+    /** 粉丝数 */
+    fans: string
+    /** 获赞总数 */
+    total_favorited: string
+    /** 关注数 */
+    following_count: string
+    /** 全局推送开关状态 */
+    switch: boolean
+    /** 推送类型列表 */
+    pushTypes?: ('video' | 'draw' | 'word' | 'live' | 'forward' | 'article')[]
+  }[]
+}> {}

--- a/packages/template/src/types/platforms/bilibili/videoInfo.ts
+++ b/packages/template/src/types/platforms/bilibili/videoInfo.ts
@@ -71,18 +71,12 @@ export interface BilibiliVideoInfoData {
   pic: string
   /** UP主信息 */
   owner: BilibiliVideoOwner
-  /** 是否使用深色主题 */
-  useDarkTheme?: boolean
 }
 
 /**
  * B站视频信息组件属性接口
  */
-export interface BilibiliVideoInfoProps extends BaseComponentProps {
-  /** 渲染请求数据 */
-  data: BilibiliVideoInfoData
-  /** 预生成的二维码数据URL */
-  qrCodeDataUrl?: string
+export interface BilibiliVideoInfoProps extends BaseComponentProps<BilibiliVideoInfoData> {
 }
 
 /**
@@ -95,8 +89,6 @@ export interface VideoStatItemProps {
   label: string
   /** 数值 */
   value: number | string
-  /** 是否使用深色主题 */
-  useDarkTheme?: boolean
 }
 
 /**
@@ -109,8 +101,6 @@ export interface VideoHeaderProps {
   owner: BilibiliVideoOwner
   /** 创建时间戳 */
   ctime: number
-  /** 是否使用深色主题 */
-  useDarkTheme?: boolean
 }
 
 /**
@@ -119,8 +109,4 @@ export interface VideoHeaderProps {
 export interface QRCodeSectionProps {
   /** 分享链接 */
   share_url: string
-  /** 预生成的二维码数据URL */
-  qrCodeDataUrl?: string
-  /** 是否使用深色主题 */
-  useDarkTheme?: boolean
 }

--- a/packages/template/src/types/platforms/douyin/UserVideoList.ts
+++ b/packages/template/src/types/platforms/douyin/UserVideoList.ts
@@ -1,8 +1,7 @@
 /**
  * 用户视频列表页面的数据类型定义
  */
-
-export type VideoListItem = {
+type VideoListItem = {
   /** 视频ID */
   aweme_id: string
   /** 视频索引 */
@@ -64,13 +63,11 @@ export type UserVideoListData = {
     ip_location: string
   }
   /** 视频列表 */
-  videos: VideoListItem[]
+  videos: Array<VideoListItem>
   /** 超时秒数 */
   timeoutSeconds?: number
 }
 
 export interface DouyinUserVideoListProps {
-  data: UserVideoListData & {
-    useDarkTheme?: boolean
-  }
+  data: UserVideoListData
 }

--- a/packages/template/src/types/platforms/douyin/articleWork.ts
+++ b/packages/template/src/types/platforms/douyin/articleWork.ts
@@ -17,44 +17,38 @@ export interface ArticleImage {
 /**
  * 抖音文章作品组件属性接口
  */
-export interface DouyinArticleWorkProps extends BaseComponentProps {
-  /** 渲染请求数据 */
-  data: {
-    /** 是否使用深色主题 */
-    useDarkTheme?: boolean
-    /** 文章标题 */
-    title: string
-    /** 文章Markdown内容 */
-    markdown: string
-    /** 文章图片列表 */
-    images: ArticleImage[]
-    /** 阅读时间(分钟) */
-    read_time: number
-    /** 点赞数 */
-    dianzan: string
-    /** 评论数 */
-    pinglun: string
-    /** 收藏数 */
-    shouchang: string
-    /** 分享数 */
-    share: string
-    /** 创建时间 */
-    create_time: string
-    /** 用户头像URL */
-    avater_url: string
-    /** 用户名 */
-    username: string
-    /** 抖音号 */
-    抖音号: string
-    /** 获赞数 */
-    获赞: string
-    /** 关注数 */
-    关注: string
-    /** 粉丝数 */
-    粉丝: string
-    /** 分享链接 */
-    share_url: string
-  }
-  /** 预生成的二维码数据URL */
-  qrCodeDataUrl: string
+export interface DouyinArticleWorkProps extends BaseComponentProps<{
+  /** 文章标题 */
+  title: string
+  /** 文章Markdown内容 */
+  markdown: string
+  /** 文章图片列表 */
+  images: ArticleImage[]
+  /** 阅读时间(分钟) */
+  read_time: number
+  /** 点赞数 */
+  dianzan: string
+  /** 评论数 */
+  pinglun: string
+  /** 收藏数 */
+  shouchang: string
+  /** 分享数 */
+  share: string
+  /** 创建时间 */
+  create_time: string
+  /** 用户头像URL */
+  avater_url: string
+  /** 用户名 */
+  username: string
+  /** 抖音号 */
+  抖音号: string
+  /** 获赞数 */
+  获赞: string
+  /** 关注数 */
+  关注: string
+  /** 粉丝数 */
+  粉丝: string
+  /** 分享链接 */
+  share_url: string
+}> {
 }

--- a/packages/template/src/types/platforms/douyin/comment.ts
+++ b/packages/template/src/types/platforms/douyin/comment.ts
@@ -5,89 +5,83 @@ import type { BaseComponentProps } from '../../index'
 /**
  * 抖音评论组件属性接口
  */
-export interface DouyinCommentProps extends BaseComponentProps {
-  /** 渲染请求数据 */
-  data: {
-    /** 是否使用深色主题 */
-    useDarkTheme?: boolean
-    /** 作品类型：视频/图集/合辑/文章 */
-    Type: '视频' | '图集' | '合辑' | '文章'
-    /** 评论数量 */
-    CommentLength: number
-    /** 视频大小(MB) */
-    VideoSize?: string
-    /** 视频帧率(Hz) */
-    VideoFPS?: number
-    /** 图片数量 */
-    ImageLength?: number
-    /** 区域 */
-    Region: string
-    /** 相关搜索（大家都在搜） */
-    suggestWrod: string[]
-    /** 视频分辨率 */
-    Resolution: string | null
-    /** 分享链接 */
-    share_url: string
-    /** 作者昵称 */
-    Author: string
-    /** 作者头像 */
-    AuthorAvatar: string
-    /** 作品统计 */
-    Statistics: {
-      digg_count: number
-      comment_count: number
-      share_count: number
-      collect_count: number
-    }
-    /** 发布时间戳（秒） */
-    CreateTime: number
-    /** 评论数据列表 */
-    CommentsData: Array<{
-      /** 评论ID */
-      id?: number
-      /** 评论CID */
-      cid?: string
-      /** 作品ID */
-      aweme_id?: string
-      /** 用户头像URL */
-      userimageurl: string
-      /** 用户昵称 */
-      nickname: string
-      /** 标签类型 (1=作者) */
-      label_type?: number
-      /** 状态标签 */
-      status_label?: string
-      /** 评论内容 */
-      text: RichTextDocument
-      /** 评论图片 */
-      commentimage?: string
-      /** 贴纸 */
-      sticker?: string
-      /** 创建时间戳（秒） */
-      create_time: number
-      /** IP标签 */
-      ip_label: string
-      /** 点赞数 */
-      digg_count: number
-      /** 搜索文本 */
-      search_text?: Array<{
-        /** 搜索文本内容 */
-        search_text: string
-        /** 搜索查询ID */
-        search_query_id: string
-      }> | null
-      /** 是否@用户ID */
-      is_At_user_id?: any
-      /** 回复评论数据 */
-      replyComment?: DouyinSubComment[]
-      /** 作者是否点赞 */
-      is_author_digged?: boolean
-    }>
-    /** 最大嵌套层级 */
-    maxDepth?: number
+export interface DouyinCommentProps extends BaseComponentProps<{
+  /** 作品类型：视频/图集/合辑/文章 */
+  Type: '视频' | '图集' | '合辑' | '文章'
+  /** 评论数量 */
+  CommentLength: number
+  /** 视频大小(MB) */
+  VideoSize?: string
+  /** 视频帧率(Hz) */
+  VideoFPS?: number
+  /** 图片数量 */
+  ImageLength?: number
+  /** 区域 */
+  Region: string
+  /** 相关搜索（大家都在搜） */
+  suggestWrod: string[]
+  /** 视频分辨率 */
+  Resolution: string | null
+  /** 分享链接 */
+  share_url: string
+  /** 作者昵称 */
+  Author: string
+  /** 作者头像 */
+  AuthorAvatar: string
+  /** 作品统计 */
+  Statistics: {
+    digg_count: number
+    comment_count: number
+    share_count: number
+    collect_count: number
   }
-  /** 预生成的二维码数据URL */
-  qrCodeDataUrl: string
+  /** 发布时间戳（秒） */
+  CreateTime: number
+  /** 评论数据列表 */
+  CommentsData: Array<{
+    /** 评论ID */
+    id?: number
+    /** 评论CID */
+    cid?: string
+    /** 作品ID */
+    aweme_id?: string
+    /** 用户头像URL */
+    userimageurl: string
+    /** 用户昵称 */
+    nickname: string
+    /** 标签类型 (1=作者) */
+    label_type?: number
+    /** 状态标签 */
+    status_label?: string
+    /** 评论内容 */
+    text: RichTextDocument
+    /** 评论图片 */
+    commentimage?: string
+    /** 贴纸 */
+    sticker?: string
+    /** 创建时间戳（秒） */
+    create_time: number
+    /** IP标签 */
+    ip_label: string
+    /** 点赞数 */
+    digg_count: number
+    /** 搜索文本 */
+    search_text?: Array<{
+      /** 搜索文本内容 */
+      search_text: string
+      /** 搜索查询ID */
+      search_query_id: string
+    }> | null
+    /** 是否@用户ID */
+    is_At_user_id?: any
+    /** 回复评论数据 */
+    replyComment?: DouyinSubComment[]
+    /** 作者是否点赞 */
+    is_author_digged?: boolean
+  }>
+  /** 最大嵌套层级 */
+  maxDepth?: number
+}> {
 }
 
 /**

--- a/packages/template/src/types/platforms/douyin/dynamic.ts
+++ b/packages/template/src/types/platforms/douyin/dynamic.ts
@@ -3,51 +3,45 @@ import type { BaseComponentProps } from '../../index'
 /**
  * 抖音动态组件属性接口
  */
-export interface DouyinDynamicProps extends BaseComponentProps {
-  /** 渲染请求数据 */
-  data: {
-    /** 是否使用深色主题 */
-    useDarkTheme?: boolean
-    /** 图片URL */
-    image_url: string
-    /** 描述内容 */
-    desc: string
-    /** 点赞数 */
-    dianzan: string
-    /** 评论数 */
-    pinglun: string
-    /** 收藏数 */
-    shouchang: string
-    /** 分享数 */
-    share: string
-    /** 创建时间 */
-    create_time: string
-    /** 用户头像URL */
-    avater_url: string
-    /** 用户名 */
-    username: string
-    /** 抖音号 */
-    抖音号: string
-    /** 获赞数 */
-    获赞: string
-    /** 关注数 */
-    关注: string
-    /** 粉丝数 */
-    粉丝: string
-    /** 分享链接 */
-    share_url: string
-    /** 动态类型 */
-    dynamicTYPE?: string
-    /** 合作信息 */
-    cooperation_info?: {
-      co_creator_nums: number
-      co_creators: Array<{
-        avatar_url?: string
-        nickname: string
-        role_title: string
-      }>
-    }
+export interface DouyinDynamicProps extends BaseComponentProps<{
+  /** 图片URL */
+  image_url: string
+  /** 描述内容 */
+  desc: string
+  /** 点赞数 */
+  dianzan: string
+  /** 评论数 */
+  pinglun: string
+  /** 收藏数 */
+  shouchang: string
+  /** 分享数 */
+  share: string
+  /** 创建时间 */
+  create_time: string
+  /** 用户头像URL */
+  avater_url: string
+  /** 用户名 */
+  username: string
+  /** 抖音号 */
+  抖音号: string
+  /** 获赞数 */
+  获赞: string
+  /** 关注数 */
+  关注: string
+  /** 粉丝数 */
+  粉丝: string
+  /** 分享链接 */
+  share_url: string
+  /** 动态类型 */
+  dynamicTYPE?: string
+  /** 合作信息 */
+  cooperation_info?: {
+    co_creator_nums: number
+    co_creators: Array<{
+      avatar_url?: string
+      nickname: string
+      role_title: string
+    }>
   }
-  /** 预生成的二维码数据URL */
-  qrCodeDataUrl: string
+}> {
 }

--- a/packages/template/src/types/platforms/douyin/favorite-list.ts
+++ b/packages/template/src/types/platforms/douyin/favorite-list.ts
@@ -4,43 +4,37 @@ import type { BaseComponentProps } from '../../index'
  * 抖音喜欢列表组件属性接口
  * 用于展示"谁喜欢了谁的作品"
  */
-export interface DouyinFavoriteListProps extends BaseComponentProps {
-  /** 渲染请求数据 */
-  data: {
-    /** 是否使用深色主题 */
-    useDarkTheme?: boolean
-    /** 作品封面图片URL */
-    image_url: string
-    /** 作品描述内容 */
-    desc: string
-    /** 点赞数 */
-    dianzan: string
-    /** 评论数 */
-    pinglun: string
-    /** 收藏数 */
-    shouchang: string
-    /** 分享数 */
-    share: string
-    /** 推荐数 */
-    tuijian: string
-    /** 作品创建时间 */
-    create_time: string
-    /** 点赞者（订阅者）用户名 */
-    liker_username: string
-    /** 点赞者头像URL */
-    liker_avatar: string
-    /** 点赞者抖音号 */
-    liker_douyin_id: string
-    /** 作品作者用户名 */
-    author_username: string
-    /** 作品作者头像URL */
-    author_avatar: string
-    /** 作品作者抖音号 */
-    author_douyin_id: string
-    /** 分享链接 */
-    share_url: string
-  }
-  /** 预生成的二维码数据URL */
-  qrCodeDataUrl: string
+export interface DouyinFavoriteListProps extends BaseComponentProps<{
+  /** 作品封面图片URL */
+  image_url: string
+  /** 作品描述内容 */
+  desc: string
+  /** 点赞数 */
+  dianzan: string
+  /** 评论数 */
+  pinglun: string
+  /** 收藏数 */
+  shouchang: string
+  /** 分享数 */
+  share: string
+  /** 推荐数 */
+  tuijian: string
+  /** 作品创建时间 */
+  create_time: string
+  /** 点赞者（订阅者）用户名 */
+  liker_username: string
+  /** 点赞者头像URL */
+  liker_avatar: string
+  /** 点赞者抖音号 */
+  liker_douyin_id: string
+  /** 作品作者用户名 */
+  author_username: string
+  /** 作品作者头像URL */
+  author_avatar: string
+  /** 作品作者抖音号 */
+  author_douyin_id: string
+  /** 分享链接 */
+  share_url: string
+}> {
 }
 

--- a/packages/template/src/types/platforms/douyin/imageWork.ts
+++ b/packages/template/src/types/platforms/douyin/imageWork.ts
@@ -3,51 +3,45 @@ import type { BaseComponentProps } from '../../index'
 /**
  * 抖音图文作品组件属性接口
  */
-export interface DouyinImageWorkProps extends BaseComponentProps {
-  /** 渲染请求数据 */
-  data: {
-    /** 是否使用深色主题 */
-    useDarkTheme?: boolean
-    /** 图文封面URL */
-    image_url: string
-    /** 描述内容 */
-    desc: string
-    /** 点赞数 */
-    dianzan: string
-    /** 评论数 */
-    pinglun: string
-    /** 收藏数 */
-    shouchang: string
-    /** 分享数 */
-    share: string
-    /** 创建时间 */
-    create_time: string
-    /** 用户头像URL */
-    avater_url: string
-    /** 用户名 */
-    username: string
-    /** 抖音号 */
-    抖音号: string
-    /** 获赞数 */
-    获赞: string
-    /** 关注数 */
-    关注: string
-    /** 粉丝数 */
-    粉丝: string
-    /** 分享链接 */
-    share_url: string
-    /** 动态类型 */
-    dynamicTYPE?: string
-    /** 合作信息 */
-    cooperation_info?: {
-      co_creator_nums: number
-      co_creators: Array<{
-        avatar_url?: string
-        nickname: string
-        role_title: string
-      }>
-    }
+export interface DouyinImageWorkProps extends BaseComponentProps<{
+  /** 图文封面URL */
+  image_url: string
+  /** 描述内容 */
+  desc: string
+  /** 点赞数 */
+  dianzan: string
+  /** 评论数 */
+  pinglun: string
+  /** 收藏数 */
+  shouchang: string
+  /** 分享数 */
+  share: string
+  /** 创建时间 */
+  create_time: string
+  /** 用户头像URL */
+  avater_url: string
+  /** 用户名 */
+  username: string
+  /** 抖音号 */
+  抖音号: string
+  /** 获赞数 */
+  获赞: string
+  /** 关注数 */
+  关注: string
+  /** 粉丝数 */
+  粉丝: string
+  /** 分享链接 */
+  share_url: string
+  /** 动态类型 */
+  dynamicTYPE?: string
+  /** 合作信息 */
+  cooperation_info?: {
+    co_creator_nums: number
+    co_creators: Array<{
+      avatar_url?: string
+      nickname: string
+      role_title: string
+    }>
   }
-  /** 预生成的二维码数据URL */
-  qrCodeDataUrl: string
+}> {
 }

--- a/packages/template/src/types/platforms/douyin/index.ts
+++ b/packages/template/src/types/platforms/douyin/index.ts
@@ -2,8 +2,6 @@ import type { BaseComponentProps } from '../../index'
 
 /** 抖音二维码登录组件属性 */
 export interface DouyinQrcodeImgProps extends BaseComponentProps<{
-  /** 二维码数据URL（插件生成的自定义二维码，或原始二维码图片） */
-  qrCodeDataUrl?: string
   /** 分享链接（用于生成自定义二维码） */
   share_url?: string
 }> {

--- a/packages/template/src/types/platforms/douyin/live.ts
+++ b/packages/template/src/types/platforms/douyin/live.ts
@@ -3,54 +3,48 @@ import type { BaseComponentProps } from '../../index'
 /**
  * 抖音直播组件属性接口
  */
-export interface DouyinLiveProps extends BaseComponentProps {
-  /** 渲染请求数据 */
-  data: {
-    /** 是否使用深色主题 */
-    useDarkTheme?: boolean
-    /** 直播封面图片URL */
-    image_url: string
-    /** 直播标题/描述 */
-    text: string
-    /** 直播分区标题 */
-    partition_title: string
-    /** 房间号 */
-    room_id: string
-    /** 总观看次数 */
-    total_viewers: string
-    /** 在线观众数 */
-    online_viewers: string
-    /** 用户头像URL */
-    avater_url: string
-    /** 用户名 */
-    username: string
-    /** 粉丝数 */
-    fans: string
-    /** 动态类型 */
-    dynamicTYPE: string
-    /** 分享链接 */
-    share_url: string
-    /** 点赞数 */
-    like_count: string
-    /** 在线人数文本 */
-    user_count_str: string
-    /** 直播分辨率 */
-    resolution: string
-    /** 主播签名 */
-    signature: string
-    /** 城市 */
-    city: string
-    /** 作品数 */
-    aweme_count: string
-    /** 关注数 */
-    following_count: string
-    /** 获赞数 */
-    total_favorited: string
-    /** 是否有商品 */
-    has_commerce_goods: boolean
-  }
-  /** 预生成的二维码数据URL */
-  qrCodeDataUrl: string
+export interface DouyinLiveProps extends BaseComponentProps<{
+  /** 直播封面图片URL */
+  image_url: string
+  /** 直播标题/描述 */
+  text: string
+  /** 直播分区标题 */
+  partition_title: string
+  /** 房间号 */
+  room_id: string
+  /** 总观看次数 */
+  total_viewers: string
+  /** 在线观众数 */
+  online_viewers: string
+  /** 用户头像URL */
+  avater_url: string
+  /** 用户名 */
+  username: string
+  /** 粉丝数 */
+  fans: string
+  /** 动态类型 */
+  dynamicTYPE: string
+  /** 分享链接 */
+  share_url: string
+  /** 点赞数 */
+  like_count: string
+  /** 在线人数文本 */
+  user_count_str: string
+  /** 直播分辨率 */
+  resolution: string
+  /** 主播签名 */
+  signature: string
+  /** 城市 */
+  city: string
+  /** 作品数 */
+  aweme_count: string
+  /** 关注数 */
+  following_count: string
+  /** 获赞数 */
+  total_favorited: string
+  /** 是否有商品 */
+  has_commerce_goods: boolean
+}> {
 }
 
 /**
@@ -71,8 +65,6 @@ export interface DouyinLiveUserInfoProps {
  * 抖音直播二维码组件属性接口
  */
 export interface DouyinLiveQRCodeProps {
-  /** 预生成的二维码数据URL */
-  qrCodeDataUrl: string
   /** 是否使用深色主题 */
   useDarkTheme?: boolean
 }

--- a/packages/template/src/types/platforms/douyin/musicinfo.ts
+++ b/packages/template/src/types/platforms/douyin/musicinfo.ts
@@ -3,38 +3,32 @@ import type { BaseComponentProps } from '../../index'
 /**
  * 抖音音乐信息组件属性接口
  */
-export interface DouyinMusicInfoProps extends BaseComponentProps {
-  /** 渲染请求数据 */
-  data: {
-    /** 是否使用深色主题 */
-    useDarkTheme?: boolean
-    /** 音乐封面图片URL */
-    image_url: string
-    /** 音乐描述/标题 */
-    desc: string
-    /** 音乐ID */
-    music_id: string
-    /** 创建时间 */
-    create_time: string
-    /** 使用该音乐的用户数量 */
-    user_count: string
-    /** 用户头像URL */
-    avater_url: string
-    /** 用户名 */
-    username: string
-    /** 用户短ID */
-    user_shortid: string
-    /** 获赞数 */
-    total_favorited: number
-    /** 关注数 */
-    following_count: number
-    /** 粉丝数 */
-    fans: number
-    /** 分享链接 */
-    share_url: string
-  }
-  /** 预生成的二维码数据URL */
-  qrCodeDataUrl: string
+export interface DouyinMusicInfoProps extends BaseComponentProps<{
+  /** 音乐封面图片URL */
+  image_url: string
+  /** 音乐描述/标题 */
+  desc: string
+  /** 音乐ID */
+  music_id: string
+  /** 创建时间 */
+  create_time: string
+  /** 使用该音乐的用户数量 */
+  user_count: string
+  /** 用户头像URL */
+  avater_url: string
+  /** 用户名 */
+  username: string
+  /** 用户短ID */
+  user_shortid: string
+  /** 获赞数 */
+  total_favorited: number
+  /** 关注数 */
+  following_count: number
+  /** 粉丝数 */
+  fans: number
+  /** 分享链接 */
+  share_url: string
+}> {
 }
 
 /**
@@ -87,8 +81,6 @@ export interface MusicAuthorInfoProps {
  * 音乐二维码组件属性接口
  */
 export interface MusicQRCodeProps {
-  /** 分享链接 */
-  qrCodeDataUrl: string
   /** 是否使用深色主题 */
   useDarkTheme?: boolean
 }

--- a/packages/template/src/types/platforms/douyin/recommend-list.ts
+++ b/packages/template/src/types/platforms/douyin/recommend-list.ts
@@ -3,44 +3,36 @@ import type { BaseComponentProps } from '../../index'
 /**
  * 抖音推荐列表组件属性接口
  */
-export interface DouyinRecommendListProps extends BaseComponentProps {
-  /** 渲染请求数据 */
-  data: {
-    /** 是否使用深色主题 */
-    useDarkTheme?: boolean
-    /** 图片URL */
-    image_url: string
-    /** 描述内容 */
-    desc: string
-    /** 点赞数 */
-    dianzan: string
-    /** 评论数 */
-    pinglun: string
-    /** 收藏数 */
-    shouchang: string
-    /** 推荐数 */
-    tuijian: string
-    /** 分享数 */
-    share: string
-    /** 创建时间 */
-    create_time: string
-    
-    /** 推荐者（订阅者）用户名 */
-    recommender_username: string
-    /** 推荐者头像URL */
-    recommender_avatar: string
-    /** 推荐者抖音号 */
-    recommender_douyin_id: string
-
-    /** 作品作者用户名 */
-    author_username: string
-    /** 作品作者头像URL */
-    author_avatar: string
-    /** 作品作者抖音号 */
-    author_douyin_id: string
-    /** 分享链接 */
-    share_url: string
-  }
-  /** 预生成的二维码数据URL */
-  qrCodeDataUrl: string
+export interface DouyinRecommendListProps extends BaseComponentProps<{
+  /** 图片URL */
+  image_url: string
+  /** 描述内容 */
+  desc: string
+  /** 点赞数 */
+  dianzan: string
+  /** 评论数 */
+  pinglun: string
+  /** 收藏数 */
+  shouchang: string
+  /** 推荐数 */
+  tuijian: string
+  /** 分享数 */
+  share: string
+  /** 创建时间 */
+  create_time: string
+  /** 推荐者（订阅者）用户名 */
+  recommender_username: string
+  /** 推荐者头像URL */
+  recommender_avatar: string
+  /** 推荐者抖音号 */
+  recommender_douyin_id: string
+  /** 作品作者用户名 */
+  author_username: string
+  /** 作品作者头像URL */
+  author_avatar: string
+  /** 作品作者抖音号 */
+  author_douyin_id: string
+  /** 分享链接 */
+  share_url: string
+}> {
 }

--- a/packages/template/src/types/platforms/douyin/userlist.ts
+++ b/packages/template/src/types/platforms/douyin/userlist.ts
@@ -3,38 +3,33 @@ import type { BaseComponentProps } from '../../index'
 /**
  * 抖音用户列表组件属性接口
  */
-export interface DouyinUserListProps extends BaseComponentProps {
-  /** 渲染请求数据 */
-  data: {
-    /** 是否使用深色主题 */
-    useDarkTheme?: boolean
-    /** 群组信息 */
-    groupInfo: {
-      /** 群号 */
-      groupId: string
-      /** 群名称 */
-      groupName: string
-      /** 群头像 */
-      groupAvatar: string
-    }
-    /** 用户列表数据 */
-    renderOpt: {
-      /** 用户头像图片URL */
-      avatar_img: string
-      /** 用户名 */
-      username: string
-      /** 抖音短ID */
-      short_id: string
-      /** 粉丝数 */
-      fans: string
-      /** 获赞总数 */
-      total_favorited: string
-      /** 关注数 */
-      following_count: string
-      /** 全局推送开关状态 */
-      switch: boolean
-      /** 推送类型列表 */
-      pushTypes: string[]
-    }[]
+export interface DouyinUserListProps extends BaseComponentProps<{
+  /** 群组信息 */
+  groupInfo: {
+    /** 群号 */
+    groupId: string
+    /** 群名称 */
+    groupName: string
+    /** 群头像 */
+    groupAvatar: string
   }
-}
+  /** 用户列表数据 */
+  renderOpt: {
+    /** 用户头像图片URL */
+    avatar_img: string
+    /** 用户名 */
+    username: string
+    /** 抖音短ID */
+    short_id: string
+    /** 粉丝数 */
+    fans: string
+    /** 获赞总数 */
+    total_favorited: string
+    /** 关注数 */
+    following_count: string
+    /** 全局推送开关状态 */
+    switch: boolean
+    /** 推送类型列表 */
+    pushTypes: string[]
+  }[]
+}> {}

--- a/packages/template/src/types/platforms/douyin/videoInfo.ts
+++ b/packages/template/src/types/platforms/douyin/videoInfo.ts
@@ -1,7 +1,7 @@
 /**
  * 抖音视频统计信息接口
  */
-export interface DouyinVideoStatistics {
+interface DouyinVideoStatistics {
   /** 点赞数 */
   admire_count: number
   /** 视频ID */
@@ -23,7 +23,7 @@ export interface DouyinVideoStatistics {
 /**
  * 抖音作者信息接口
  */
-export interface DouyinAuthor {
+interface DouyinAuthor {
   /** 作者名称 */
   name: string
   /** 作者头像URL */
@@ -35,7 +35,7 @@ export interface DouyinAuthor {
 /**
  * 抖音用户主页扩展信息接口
  */
-export interface DouyinUserProfile {
+interface DouyinUserProfile {
   /** IP属地 */
   ip_location: string
   /** 粉丝数 */
@@ -53,7 +53,7 @@ export interface DouyinUserProfile {
 /**
  * 抖音视频信息数据接口
  */
-export interface DouyinVideoInfoData {
+interface DouyinVideoInfoData {
   /** 视频描述 */
   desc: string
   /** 统计信息 */
@@ -94,12 +94,6 @@ export interface DouyinVideoInfoData {
  * 抖音视频信息组件属性接口
  */
 export interface DouyinVideoInfoProps {
-  /** 模板类型 */
-  templateType: string
-  /** 模板名称 */
-  templateName: string
   /** 视频数据 */
   data: DouyinVideoInfoData
-  /** 是否使用深色主题 */
-  useDarkTheme?: boolean
 }

--- a/packages/template/src/types/platforms/douyin/videoWork.ts
+++ b/packages/template/src/types/platforms/douyin/videoWork.ts
@@ -3,52 +3,46 @@ import type { BaseComponentProps } from '../../index'
 /**
  * 抖音视频作品组件属性接口
  */
-export interface DouyinVideoWorkProps extends BaseComponentProps {
-  /** 渲染请求数据 */
-  data: {
-    /** 是否使用深色主题 */
-    useDarkTheme?: boolean
-    /** 视频封面URL */
-    image_url: string
-    /** 描述内容 */
-    desc: string
-    /** 点赞数 */
-    dianzan: string
-    /** 评论数 */
-    pinglun: string
-    /** 收藏数 */
-    shouchang: string
-    /** 分享数 */
-    share: string
-    /** 创建时间 */
-    create_time: string
-    /** 用户头像URL */
-    avater_url: string
-    /** 用户名 */
-    username: string
-    /** 抖音号 */
-    抖音号: string
-    /** 获赞数 */
-    获赞: string
-    /** 关注数 */
-    关注: string
-    /** 粉丝数 */
-    粉丝: string
-    /** 分享链接 */
-    share_url: string
-    /** 动态类型 */
-    dynamicTYPE?: string
-    /** 合作信息 */
-    cooperation_info?: {
-      co_creator_nums: number
-      co_creators: Array<{
-        avatar_url?: string
-        nickname: string
-        role_title: string
-      }>
-      subscriber_role?: string
-    }
+export interface DouyinVideoWorkProps extends BaseComponentProps<{
+  /** 视频封面URL */
+  image_url: string
+  /** 描述内容 */
+  desc: string
+  /** 点赞数 */
+  dianzan: string
+  /** 评论数 */
+  pinglun: string
+  /** 收藏数 */
+  shouchang: string
+  /** 分享数 */
+  share: string
+  /** 创建时间 */
+  create_time: string
+  /** 用户头像URL */
+  avater_url: string
+  /** 用户名 */
+  username: string
+  /** 抖音号 */
+  抖音号: string
+  /** 获赞数 */
+  获赞: string
+  /** 关注数 */
+  关注: string
+  /** 粉丝数 */
+  粉丝: string
+  /** 分享链接 */
+  share_url: string
+  /** 动态类型 */
+  dynamicTYPE?: string
+  /** 合作信息 */
+  cooperation_info?: {
+    co_creator_nums: number
+    co_creators: Array<{
+      avatar_url?: string
+      nickname: string
+      role_title: string
+    }>
+    subscriber_role?: string
   }
-  /** 预生成的二维码数据URL */
-  qrCodeDataUrl: string
+}> {
 }

--- a/packages/template/src/types/platforms/kuaishou/comment.ts
+++ b/packages/template/src/types/platforms/kuaishou/comment.ts
@@ -5,30 +5,24 @@ import type { BaseComponentProps } from '../../index'
 /**
  * 快手评论组件属性接口
  */
-export interface KuaishouCommentProps extends BaseComponentProps {
-  /** 渲染请求数据 */
-  data: {
-    /** 是否使用深色主题 */
-    useDarkTheme?: boolean
-    /** 作品类型：视频/图集 */
-    Type: '视频' | '图集'
-    /** 评论数量 */
-    CommentLength: number
-    /** 视频大小(MB) */
-    VideoSize?: string
-    /** 点赞数量 */
-    likeCount?: number
-    /** 观看次数 */
-    viewCount?: number
-    /** 图片数量 */
-    ImageLength?: number
-    /** 分享链接 */
-    share_url: string
-    /** 评论数据 */
-    CommentsData: KuaishouCommentItem[]
-  }
-  /** 预生成的二维码数据URL */
-  qrCodeDataUrl: string
+export interface KuaishouCommentProps extends BaseComponentProps<{
+  /** 作品类型：视频/图集 */
+  Type: '视频' | '图集'
+  /** 评论数量 */
+  CommentLength: number
+  /** 视频大小(MB) */
+  VideoSize?: string
+  /** 点赞数量 */
+  likeCount?: number
+  /** 观看次数 */
+  viewCount?: number
+  /** 图片数量 */
+  ImageLength?: number
+  /** 分享链接 */
+  share_url: string
+  /** 评论数据 */
+  CommentsData: KuaishouCommentItem[]
+}> {
 }
 
 /**
@@ -57,46 +51,4 @@ export interface KuaishouCommentItem {
   reply_comment_total?: number
   /** IP标签 */
   ip_label?: string
-}
-
-/**
- * 快手二维码组件属性接口
- */
-export interface KuaishouQRCodeSectionProps {
-  /** 二维码数据URL */
-  qrCodeDataUrl: string
-  /** 作品类型 */
-  type: string
-  /** 图片数量 */
-  imageLength?: number
-  /** 是否使用深色主题 */
-  useDarkTheme?: boolean
-}
-
-/**
- * 快手视频信息头部组件属性接口
- */
-export interface KuaishouVideoInfoHeaderProps {
-  /** 作品类型 */
-  type: string
-  /** 评论数量 */
-  commentLength: number
-  /** 视频大小 */
-  videoSize?: string
-  /** 点赞数量 */
-  likeCount?: number
-  /** 观看次数 */
-  viewCount?: number
-  /** 图片数量 */
-  imageLength?: number
-  /** 是否使用深色主题 */
-  useDarkTheme?: boolean
-}
-
-/**
- * 快手评论项组件属性接口
- */
-export interface KuaishouCommentItemComponentProps {
-  /** 评论数据 */
-  comment: KuaishouCommentItem
 }

--- a/packages/template/src/types/platforms/other/VersionWarningProps.ts
+++ b/packages/template/src/types/platforms/other/VersionWarningProps.ts
@@ -1,8 +1,8 @@
 import type { BaseComponentProps } from '../../index'
 
-export interface VersionWarningProps extends BaseComponentProps {
+export interface VersionWarningProps extends BaseComponentProps<{
   /** 插件构建时的 karin 版本 */
   requireVersion: string
   /** 当前运行的 karin 版本 */
   currentVersion: string
-}
+}> {}

--- a/packages/template/src/types/platforms/other/changelog.ts
+++ b/packages/template/src/types/platforms/other/changelog.ts
@@ -3,22 +3,19 @@ import type { BaseComponentProps } from '../../index'
 /**
  * 更新日志组件属性接口
  */
-export interface ChangelogProps extends BaseComponentProps {
-  /** 渲染请求数据 */
-  data: {
-    /** 是否包含更新提示 */
-    Tip?: boolean
-    /** 后端传入的 Markdown 源码 */
-    markdown: string,
-    /** 本地版本号 */
-    localVersion: string,
-    /** 远程版本号 */
-    remoteVersion: string,
-    /** 落后的版本数量 */
-    lagVersionCount?: number,
-    /** 构建时间 */
-    buildTime?: string,
-    /** 版本差异对比页面分享链接 */
-    share_url?: string,
-  }
-}
+export interface ChangelogProps extends BaseComponentProps<{
+  /** 是否包含更新提示 */
+  Tip?: boolean
+  /** 后端传入的 Markdown 源码 */
+  markdown: string
+  /** 本地版本号 */
+  localVersion: string
+  /** 远程版本号 */
+  remoteVersion: string
+  /** 落后的版本数量 */
+  lagVersionCount?: number
+  /** 构建时间 */
+  buildTime?: string
+  /** 版本差异对比页面分享链接 */
+  share_url?: string
+}> {}

--- a/packages/template/src/types/platforms/other/handlerError.ts
+++ b/packages/template/src/types/platforms/other/handlerError.ts
@@ -67,44 +67,38 @@ export type AdapterInfo = Omit<KarinAdapterInfo, 'index' | 'secret' | 'connectTi
 /**
  * API错误组件属性接口
  */
-export interface ApiErrorProps extends BaseComponentProps {
-  /** 渲染请求数据 */
-  data: {
-    /** 是否使用深色主题 */
-    useDarkTheme?: boolean
-    /** 错误类型 */
-    type: 'business_error'
-    /** 平台名称 */
-    platform: 'douyin' | 'bilibili' | 'kuaishou' | 'system' | 'unknown'
-    /** 错误信息 */
-    error: BusinessError
-    /** 调用的方法名 */
-    method: string
-    /** 错误发生时间 */
-    timestamp: string
-    /** 收集到的日志信息 */
-    logs?: LogEntry[]
-    /** 触发命令 */
-    triggerCommand?: string
-    /** 框架版本 */
-    frameworkVersion: string
-    /** 插件版本 */
-    pluginVersion: string
-    /** 构建时间 */
-    buildTime?: string
-    /** Commit ID */
-    commitHash?: string
-    /** 适配器信息 */
-    adapterInfo?: AdapterInfo
-    /** 是否为验证流程 */
-    isVerification?: boolean
-    /** 验证链接 */
-    verificationUrl?: string
-    /** 分享链接（用于生成二维码） */
-    share_url?: string
-  }
-  /** 分享链接二维码 */
-  qrCodeDataUrl?: string
+export interface ApiErrorProps extends BaseComponentProps<{
+  /** 错误类型 */
+  type: 'business_error'
+  /** 平台名称 */
+  platform: 'douyin' | 'bilibili' | 'kuaishou' | 'system' | 'unknown'
+  /** 错误信息 */
+  error: BusinessError
+  /** 调用的方法名 */
+  method: string
+  /** 错误发生时间 */
+  timestamp: string
+  /** 收集到的日志信息 */
+  logs?: LogEntry[]
+  /** 触发命令 */
+  triggerCommand?: string
+  /** 框架版本 */
+  frameworkVersion: string
+  /** 插件版本 */
+  pluginVersion: string
+  /** 构建时间 */
+  buildTime?: string
+  /** Commit ID */
+  commitHash?: string
+  /** 适配器信息 */
+  adapterInfo?: AdapterInfo
+  /** 是否为验证流程 */
+  isVerification?: boolean
+  /** 验证链接 */
+  verificationUrl?: string
+  /** 分享链接（用于生成二维码） */
+  share_url?: string
+}> {
 }
 
 /**

--- a/packages/template/src/types/platforms/other/help.ts
+++ b/packages/template/src/types/platforms/other/help.ts
@@ -3,24 +3,19 @@ import type { BaseComponentProps } from '../../index'
 /**
  * 帮助页面组件属性接口
  */
-export interface HelpProps extends BaseComponentProps {
-  /** 渲染请求数据 */
-  data: {
-    /** 是否使用深色主题 */
-    useDarkTheme?: boolean
-    /** 页面标题 */
-    title?: string
-    /** 角色：主人/普通 */
-    role?: 'master' | 'member'
-    /** 菜单数据：按角色筛选后的分组 */
-    menu?: MenuGroup[]
-    /** 简单的列表数据 (用于 Help.tsx 渲染) */
-    list: {
-      title: string
-      description: string
-    }[]
-  }
-}
+export interface HelpProps extends BaseComponentProps<{
+  /** 页面标题 */
+  title?: string
+  /** 角色：主人/普通 */
+  role?: 'master' | 'member'
+  /** 菜单数据：按角色筛选后的分组 */
+  menu?: MenuGroup[]
+  /** 简单的列表数据 (用于 Help.tsx 渲染) */
+  list: {
+    title: string
+    description: string
+  }[]
+}> {}
 
 /**
  * 菜单项接口

--- a/packages/template/src/types/platforms/other/livePhotoTip.ts
+++ b/packages/template/src/types/platforms/other/livePhotoTip.ts
@@ -1,13 +1,8 @@
 import type { BaseComponentProps } from '../../index'
 
-export interface LivePhotoTipProps extends BaseComponentProps {
-  data: {
-    /** 提示标题 */
-    title?: string
-    /** 附加说明 */
-    description?: string
-  } & {
-    /** 是否使用深色主题 */
-    useDarkTheme?: boolean
-  }
-}
+export interface LivePhotoTipProps extends BaseComponentProps<{
+  /** 提示标题 */
+  title?: string
+  /** 附加说明 */
+  description?: string
+}> {}

--- a/packages/template/src/types/platforms/other/qrlogin.ts
+++ b/packages/template/src/types/platforms/other/qrlogin.ts
@@ -1,15 +1,10 @@
+import type { BaseComponentProps } from '../../index'
+
 /** APP 扫码登录组件属性 */
-export interface QrLoginProps {
-  data: {
-    /** 服务器地址 */
-    serverUrl: string
-    /** 分享链接（用于生成二维码） */
-    share_url: string
-    /** 是否使用深色主题 */
-    useDarkTheme?: boolean
-  }
-  /** 二维码数据URL（由 createQrCodePlugin 自动生成，作为顶级 prop） */
-  qrCodeDataUrl?: string
-  /** 是否使用深色主题 */
-  useDarkTheme?: boolean
+export interface QrLoginProps extends BaseComponentProps<{
+  /** 服务器地址 */
+  serverUrl: string
+  /** 分享链接（用于生成二维码） */
+  share_url: string
+}> {
 }

--- a/packages/template/src/types/platforms/other/statistics.ts
+++ b/packages/template/src/types/platforms/other/statistics.ts
@@ -3,66 +3,58 @@ import type { BaseComponentProps } from '../../index'
 /**
  * 群组解析统计数据接口
  */
-export interface GroupStatisticsProps extends BaseComponentProps {
-  data: {
-    /** 是否使用深色主题 */
-    useDarkTheme?: boolean
-    /** 群组ID */
-    groupId: string
-    /** 群组名称 */
-    groupName?: string
-    /** 群组人数 */
-    groupMemberCount?: number
-    /** 群组头像 */
-    groupAvatar?: string
-    /** 群组总解析次数 */
-    groupTotalParses: number
-    /** 群组唯一用户数 */
-    groupUniqueUsers: number
-    /** 各平台解析数据 */
-    platformData: {
-      douyin: number
-      bilibili: number
-      kuaishou: number
-      xiaohongshu: number
-    }
-    /** 全局总群组数 */
-    globalTotalGroups: number
-    /** 全局总解析次数 */
-    globalTotalParses: number
+export interface GroupStatisticsProps extends BaseComponentProps<{
+  /** 群组ID */
+  groupId: string
+  /** 群组名称 */
+  groupName?: string
+  /** 群组人数 */
+  groupMemberCount?: number
+  /** 群组头像 */
+  groupAvatar?: string
+  /** 群组总解析次数 */
+  groupTotalParses: number
+  /** 群组唯一用户数 */
+  groupUniqueUsers: number
+  /** 各平台解析数据 */
+  platformData: {
+    douyin: number
+    bilibili: number
+    kuaishou: number
+    xiaohongshu: number
   }
-}
+  /** 全局总群组数 */
+  globalTotalGroups: number
+  /** 全局总解析次数 */
+  globalTotalParses: number
+}> {}
 
 /**
  * 全局解析统计数据接口
  */
-export interface GlobalStatisticsProps extends BaseComponentProps {
-  data: {
-    /** 是否使用深色主题 */
-    useDarkTheme?: boolean
-    /** 所有统计数据 */
-    allStats: Array<{
-      id: number
-      groupId: string
-      userId: string
-      platform: 'douyin' | 'bilibili' | 'kuaishou' | 'xiaohongshu'
-      parseCount: number
-      createdAt: string
-      updatedAt: string
-    }>
-    /** 历史数据（最近30天） */
-    historyData: Array<{
-      date: string
-      totalParses: number
-      douyin: number
-      bilibili: number
-      kuaishou: number
-      xiaohongshu: number
-    }>
-    /** 群组信息映射 */
-    groupInfoMap: Record<string, {
-      groupName?: string
-      groupAvatar?: string
-    }>
-  }
-}
+export interface GlobalStatisticsProps extends BaseComponentProps<{
+  /** 所有统计数据 */
+  allStats: Array<{
+    id: number
+    groupId: string
+    userId: string
+    platform: 'douyin' | 'bilibili' | 'kuaishou' | 'xiaohongshu'
+    parseCount: number
+    createdAt: string
+    updatedAt: string
+  }>
+  /** 历史数据（最近30天） */
+  historyData: Array<{
+    date: string
+    totalParses: number
+    douyin: number
+    bilibili: number
+    kuaishou: number
+    xiaohongshu: number
+  }>
+  /** 群组信息映射 */
+  groupInfoMap: Record<string, {
+    groupName?: string
+    groupAvatar?: string
+  }>
+}> {}

--- a/packages/template/src/types/platforms/xiaohongshu/comment.ts
+++ b/packages/template/src/types/platforms/xiaohongshu/comment.ts
@@ -5,30 +5,24 @@ import type { BaseComponentProps } from '../../index'
 /**
  * 小红书评论组件属性接口
  */
-export interface XiaohongshuCommentProps extends BaseComponentProps {
-  /** 渲染请求数据 */
-  data: {
-    /** 是否使用深色主题 */
-    useDarkTheme?: boolean
-    /** 笔记类型：图文/视频 */
-    Type: '图文' | '视频'
-    /** 评论数量 */
-    CommentLength: number
-    /** 图片数量 */
-    ImageLength?: number
-    /** 分享链接 */
-    share_url: string
-    /** 评论数据 - 简化为直接的评论数组 */
-    CommentsData: XiaohongshuCommentItem[]
-  }
-  /** 预生成的二维码数据URL */
-  qrCodeDataUrl: string
+export interface XiaohongshuCommentProps extends BaseComponentProps<{
+  /** 笔记类型：图文/视频 */
+  Type: '图文' | '视频'
+  /** 评论数量 */
+  CommentLength: number
+  /** 图片数量 */
+  ImageLength?: number
+  /** 分享链接 */
+  share_url: string
+  /** 评论数据 - 简化为直接的评论数组 */
+  CommentsData: XiaohongshuCommentItem[]
+}> {
 }
 
 /**
  * 小红书评论项数据接口
  */
-export interface XiaohongshuCommentItem {
+interface XiaohongshuCommentItem {
   /** 评论ID */
   id: string
   /** 笔记ID */
@@ -76,7 +70,7 @@ export interface XiaohongshuCommentItem {
 /**
  * 小红书子评论数据接口
  */
-export interface XiaohongshuSubComment {
+interface XiaohongshuSubComment {
   /** 子评论ID */
   id: string
   /** 笔记ID */
@@ -116,33 +110,4 @@ export interface XiaohongshuSubComment {
       xsec_token: string
     }
   }
-}
-
-/**
- * 小红书二维码区域组件属性接口
- */
-export interface XiaohongshuQRCodeSectionProps {
-  /** 预生成的二维码数据URL */
-  qrCodeDataUrl: string
-}
-
-/**
- * 小红书笔记信息头部组件属性接口
- */
-export interface XiaohongshuNoteInfoHeaderProps {
-  /** 笔记类型：图文/视频 */
-  type: '图文' | '视频'
-  /** 评论数量 */
-  commentLength: number
-  /** 图片数量 */
-  imageLength?: number
-  /** 预生成的二维码数据URL */
-  qrCodeDataUrl: string
-  /** 是否使用深色主题 */
-  useDarkTheme?: boolean
-}
-
-export interface XiaohongshuCommentItemComponentProps {
-  /** 评论数据 */
-  comment: XiaohongshuCommentItem
 }

--- a/packages/template/src/types/platforms/xiaohongshu/noteInfo.ts
+++ b/packages/template/src/types/platforms/xiaohongshu/noteInfo.ts
@@ -5,7 +5,7 @@ import type { BaseComponentProps } from '../../index'
 /**
  * 小红书笔记统计信息接口
  */
-export interface XiaohongshuNoteStatistics {
+interface XiaohongshuNoteStatistics {
   /** 分享数 */
   share_count: string | number
   /** 是否已关注 */
@@ -27,7 +27,7 @@ export interface XiaohongshuNoteStatistics {
 /**
  * 小红书作者信息接口
  */
-export interface XiaohongshuAuthor {
+interface XiaohongshuAuthor {
   /** xsec_token */
   xsec_token?: string
   /** 用户ID */
@@ -41,7 +41,7 @@ export interface XiaohongshuAuthor {
 /**
  * 小红书笔记信息数据接口
  */
-export interface XiaohongshuNoteInfoData {
+interface XiaohongshuNoteInfoData {
   /** 笔记标题 */
   title: string
   /** 笔记描述 */
@@ -58,14 +58,9 @@ export interface XiaohongshuNoteInfoData {
   time: number
   /** IP位置 */
   ip_location: string
-  /** 是否使用深色主题 */
-  useDarkTheme?: boolean
 }
 
 /**
  * 小红书笔记信息组件属性接口
  */
-export interface XiaohongshuNoteInfoProps extends BaseComponentProps {
-  /** 渲染请求数据 */
-  data: XiaohongshuNoteInfoData
-}
+export interface XiaohongshuNoteInfoProps extends BaseComponentProps<XiaohongshuNoteInfoData> { }

--- a/packages/template/src/utils/QRcode.ts
+++ b/packages/template/src/utils/QRcode.ts
@@ -1,0 +1,36 @@
+import { generate } from '@ikenxuan/qrcode'
+
+/**
+ * Generates a QR code image in base64 format for the given text.
+ *
+ * @param {string} text - The text to encode in the QR code.
+ * @param {boolean} [useDarkTheme=false] - Whether to use a dark theme for the QR code.
+ * @return {string} The base64-encoded QR code image.
+ */
+export const generateQRCode = (text: string, useDarkTheme: boolean = false) => {
+  const base64 = generate(
+    {
+      data: text,
+      size: 1000,
+      dotsOptions: {
+        dotType: 'rounded',
+        color: useDarkTheme ? 'rgba(255, 255, 255, 0.9)' : 'rgba(0, 0, 0, 0.8)'
+      },
+      cornersSquareOptions: {
+        cornerType: 'extra-rounded',
+        color: useDarkTheme ? 'rgba(255, 255, 255, 0.9)' : 'rgba(0, 0, 0, 0.8)'
+      },
+      cornersDotOptions: {
+        cornerType: 'dot',
+        color: useDarkTheme ? 'rgba(255, 255, 255, 0.9)' : 'rgba(0, 0, 0, 0.8)'
+      },
+      backgroundOptions: {
+        transparent: true
+      }
+    },
+    'webp',
+    'base64'
+  )
+
+  return `data:image/webp;base64,${base64}`
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -128,7 +128,7 @@ importers:
         version: 18.19.130
       '@vitest/coverage-v8':
         specifier: ^3.1.3
-        version: 3.2.4(vitest@3.2.4(@types/debug@4.1.13)(@types/node@18.19.130)(@vitejs/devtools@0.1.24)(esbuild@0.28.0)(happy-dom@20.9.0)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.13.6(@types/node@18.19.130)(typescript@6.0.3))(sass@1.100.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.8.3))
+        version: 3.2.4(vitest@3.2.4(@types/debug@4.1.13)(@types/node@18.19.130)(@vitejs/devtools@0.1.24)(esbuild@0.27.7)(happy-dom@20.9.0)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.13.6(@types/node@18.19.130)(typescript@6.0.3))(sass@1.100.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.8.3))
       eslint:
         specifier: '9'
         version: 9.39.4(jiti@2.6.1)
@@ -170,13 +170,13 @@ importers:
         version: 6.0.3
       vite:
         specifier: 8.0.14
-        version: 8.0.14(@types/node@18.19.130)(@vitejs/devtools@0.1.24)(esbuild@0.28.0)(jiti@2.6.1)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.8.3)
+        version: 8.0.14(@types/node@18.19.130)(@vitejs/devtools@0.1.24)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.8.3)
       vite-plugin-dts:
         specifier: ^4.5.4
         version: 4.5.4(@types/node@18.19.130)(rollup@4.60.4)(typescript@6.0.3)(vite@8.0.14)
       vitest:
         specifier: ^3.1.3
-        version: 3.2.4(@types/debug@4.1.13)(@types/node@18.19.130)(@vitejs/devtools@0.1.24)(esbuild@0.28.0)(happy-dom@20.9.0)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.13.6(@types/node@18.19.130)(typescript@6.0.3))(sass@1.100.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.8.3)
+        version: 3.2.4(@types/debug@4.1.13)(@types/node@18.19.130)(@vitejs/devtools@0.1.24)(esbuild@0.27.7)(happy-dom@20.9.0)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.13.6(@types/node@18.19.130)(typescript@6.0.3))(sass@1.100.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.8.3)
 
   Karin/packages/cli: {}
 
@@ -872,9 +872,6 @@ importers:
       date-fns:
         specifier: ^4.3.0
         version: 4.3.0
-      happy-dom:
-        specifier: ^20.9.0
-        version: 20.9.0
       heic-decode:
         specifier: ^2.1.0
         version: 2.1.0
@@ -890,9 +887,6 @@ importers:
       pngjs:
         specifier: ^7.0.0
         version: 7.0.0
-      qr-code-styling:
-        specifier: ^1.9.2
-        version: 1.9.2
       template:
         specifier: workspace:*
         version: link:../template
@@ -1080,6 +1074,9 @@ importers:
       '@icons-pack/react-simple-icons':
         specifier: ^13.13.0
         version: 13.13.0(react@19.2.6)
+      '@ikenxuan/qrcode':
+        specifier: ^1.1.0
+        version: 1.1.0
       '@kkk/richtext':
         specifier: workspace:*
         version: link:../richtext
@@ -1135,7 +1132,7 @@ importers:
         specifier: ^7.0.2
         version: 7.0.2
       tailwind-merge:
-        specifier: ^3.6.0
+        specifier: 3.6.0
         version: 3.6.0
       victory:
         specifier: ^37.3.6
@@ -2975,6 +2972,9 @@ packages:
     resolution: {integrity: sha512-QPcGmICAPbGLGb6F/yNf/KzKqvFx8z5qx3D1yFqVAjoFmXK35EgyW+cJ57Te3CNsmzblwtzakLGFqHPqrfb4Tw==}
     peerDependencies:
       react: 19.2.6
+
+  '@ikenxuan/qrcode@1.1.0':
+    resolution: {integrity: sha512-EVvyJoZOdrkQtzVE2erxiqHnDAnR5fFimyvWnEYnb6wnOUZMwnSmGJ52zosiJlzGZirGPxogak6bkqLsU/3Cog==}
 
   '@ikenxuan/watermark-darwin-arm64@1.1.5':
     resolution: {integrity: sha512-Qz1nZRKBuRR6IA2bC+0HWirlO+syfKDpQrHLuXDKU8hJFlEt31VODc2Tr5Vigaw/2cHdgY7++Q2jJtvjwDqK9g==}
@@ -16570,6 +16570,8 @@ snapshots:
     dependencies:
       react: 19.2.6
 
+  '@ikenxuan/qrcode@1.1.0': {}
+
   '@ikenxuan/watermark-darwin-arm64@1.1.5':
     optional: true
 
@@ -21353,7 +21355,8 @@ snapshots:
 
   '@types/webxr@0.5.24': {}
 
-  '@types/whatwg-mimetype@3.0.2': {}
+  '@types/whatwg-mimetype@3.0.2':
+    optional: true
 
   '@types/ws@8.18.1':
     dependencies:
@@ -21839,7 +21842,7 @@ snapshots:
       pathe: 2.0.3
       perfect-debounce: 2.1.0
       tinyexec: 1.1.2
-      vite: 8.0.14(@types/node@25.6.0)(@vitejs/devtools@0.1.24)(esbuild@0.28.0)(jiti@2.6.1)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.8.3)
+      vite: 8.0.14(@types/node@18.19.130)(@vitejs/devtools@0.1.24)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.8.3)
     transitivePeerDependencies:
       - '@modelcontextprotocol/sdk'
       - bufferutil
@@ -21857,7 +21860,7 @@ snapshots:
       pathe: 2.0.3
       perfect-debounce: 2.1.0
       tinyexec: 1.1.2
-      vite: 8.0.14(@types/node@24.12.4)(@vitejs/devtools@0.2.0)(esbuild@0.28.0)(jiti@2.6.1)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.8.3)
+      vite: 8.0.14(@types/node@25.6.0)(@vitejs/devtools@0.2.0)(esbuild@0.28.0)(jiti@2.6.1)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.8.3)
     transitivePeerDependencies:
       - '@modelcontextprotocol/sdk'
       - bufferutil
@@ -22159,7 +22162,7 @@ snapshots:
       pathe: 2.0.3
       perfect-debounce: 2.1.0
       tinyexec: 1.1.2
-      vite: 8.0.14(@types/node@25.6.0)(@vitejs/devtools@0.1.24)(esbuild@0.28.0)(jiti@2.6.1)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.8.3)
+      vite: 8.0.14(@types/node@18.19.130)(@vitejs/devtools@0.1.24)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.8.3)
       vue: 3.5.34(typescript@6.0.3)
       ws: 8.20.1
     transitivePeerDependencies:
@@ -22204,7 +22207,7 @@ snapshots:
       pathe: 2.0.3
       perfect-debounce: 2.1.0
       tinyexec: 1.1.2
-      vite: 8.0.14(@types/node@24.12.4)(@vitejs/devtools@0.2.0)(esbuild@0.28.0)(jiti@2.6.1)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.8.3)
+      vite: 8.0.14(@types/node@25.6.0)(@vitejs/devtools@0.2.0)(esbuild@0.28.0)(jiti@2.6.1)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.8.3)
       vue: 3.5.34(typescript@6.0.3)
       ws: 8.20.1
     transitivePeerDependencies:
@@ -22292,7 +22295,7 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0
       vite: 8.0.14(@types/node@24.12.4)(@vitejs/devtools@0.2.0)(esbuild@0.28.0)(jiti@2.6.1)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.8.3)
 
-  '@vitest/coverage-v8@3.2.4(vitest@3.2.4(@types/debug@4.1.13)(@types/node@18.19.130)(@vitejs/devtools@0.1.24)(esbuild@0.28.0)(happy-dom@20.9.0)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.13.6(@types/node@18.19.130)(typescript@6.0.3))(sass@1.100.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.8.3))':
+  '@vitest/coverage-v8@3.2.4(vitest@3.2.4(@types/debug@4.1.13)(@types/node@18.19.130)(@vitejs/devtools@0.1.24)(esbuild@0.27.7)(happy-dom@20.9.0)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.13.6(@types/node@18.19.130)(typescript@6.0.3))(sass@1.100.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.8.3))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 1.0.2
@@ -22307,7 +22310,7 @@ snapshots:
       std-env: 3.10.0
       test-exclude: 7.0.2
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/debug@4.1.13)(@types/node@18.19.130)(@vitejs/devtools@0.1.24)(esbuild@0.28.0)(happy-dom@20.9.0)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.13.6(@types/node@18.19.130)(typescript@6.0.3))(sass@1.100.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.8.3)
+      vitest: 3.2.4(@types/debug@4.1.13)(@types/node@18.19.130)(@vitejs/devtools@0.1.24)(esbuild@0.27.7)(happy-dom@20.9.0)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.13.6(@types/node@18.19.130)(typescript@6.0.3))(sass@1.100.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.8.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -22335,7 +22338,7 @@ snapshots:
       magic-string: 0.30.21
     optionalDependencies:
       msw: 2.13.6(@types/node@18.19.130)(typescript@6.0.3)
-      vite: 8.0.14(@types/node@18.19.130)(@vitejs/devtools@0.1.24)(esbuild@0.28.0)(jiti@2.6.1)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.8.3)
+      vite: 8.0.14(@types/node@18.19.130)(@vitejs/devtools@0.1.24)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.8.3)
 
   '@vitest/mocker@4.1.7(msw@2.13.6(@types/node@25.6.0)(typescript@6.0.3))(vite@8.0.14)':
     dependencies:
@@ -25131,6 +25134,7 @@ snapshots:
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
+    optional: true
 
   has-bigints@1.1.0: {}
 
@@ -29397,7 +29401,7 @@ snapshots:
       unconfig-core: 7.5.0
       unrun: 0.2.37(synckit@0.11.12)
     optionalDependencies:
-      '@vitejs/devtools': 0.2.0(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(@pnpm/logger@1001.0.1)(typescript@6.0.3)(vite@8.0.14)
+      '@vitejs/devtools': 0.2.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(@pnpm/logger@1001.0.1)(typescript@6.0.3)(vite@8.0.14)
       publint: 0.3.21
       typescript: 6.0.3
     transitivePeerDependencies:
@@ -30206,13 +30210,13 @@ snapshots:
       react-dom: 19.2.6(react@19.2.6)
       vue: 3.5.34(typescript@6.0.3)
 
-  vite-node@3.2.4(@types/node@18.19.130)(@vitejs/devtools@0.1.24)(esbuild@0.28.0)(jiti@2.6.1)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.8.3):
+  vite-node@3.2.4(@types/node@18.19.130)(@vitejs/devtools@0.1.24)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.8.3):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 8.0.14(@types/node@18.19.130)(@vitejs/devtools@0.1.24)(esbuild@0.28.0)(jiti@2.6.1)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.8.3)
+      vite: 8.0.14(@types/node@18.19.130)(@vitejs/devtools@0.1.24)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.8.3)
     transitivePeerDependencies:
       - '@types/node'
       - '@vitejs/devtools'
@@ -30268,7 +30272,7 @@ snapshots:
       magic-string: 0.30.21
       typescript: 6.0.3
     optionalDependencies:
-      vite: 8.0.14(@types/node@18.19.130)(@vitejs/devtools@0.1.24)(esbuild@0.28.0)(jiti@2.6.1)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.8.3)
+      vite: 8.0.14(@types/node@18.19.130)(@vitejs/devtools@0.1.24)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.8.3)
     transitivePeerDependencies:
       - '@types/node'
       - rollup
@@ -30314,7 +30318,7 @@ snapshots:
       - supports-color
       - typescript
 
-  vite@8.0.14(@types/node@18.19.130)(@vitejs/devtools@0.1.24)(esbuild@0.28.0)(jiti@2.6.1)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.8.3):
+  vite@8.0.14(@types/node@18.19.130)(@vitejs/devtools@0.1.24)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.8.3):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
@@ -30324,7 +30328,7 @@ snapshots:
     optionalDependencies:
       '@types/node': 18.19.130
       '@vitejs/devtools': 0.1.24(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(@pnpm/logger@1001.0.1)(typescript@6.0.3)(vite@8.0.14)
-      esbuild: 0.28.0
+      esbuild: 0.27.7
       fsevents: 2.3.3
       jiti: 2.6.1
       sass: 1.100.0
@@ -30424,7 +30428,25 @@ snapshots:
       tsx: 4.22.3
       yaml: 2.8.3
 
-  vitest@3.2.4(@types/debug@4.1.13)(@types/node@18.19.130)(@vitejs/devtools@0.1.24)(esbuild@0.28.0)(happy-dom@20.9.0)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.13.6(@types/node@18.19.130)(typescript@6.0.3))(sass@1.100.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.8.3):
+  vite@8.0.14(@types/node@25.6.0)(@vitejs/devtools@0.2.0)(esbuild@0.28.0)(jiti@2.6.1)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.8.3):
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.4
+      postcss: 8.5.15
+      rolldown: 1.0.2
+      tinyglobby: 0.2.16
+    optionalDependencies:
+      '@types/node': 25.6.0
+      '@vitejs/devtools': 0.2.0(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(@pnpm/logger@1001.0.1)(typescript@6.0.3)(vite@8.0.14)
+      esbuild: 0.28.0
+      fsevents: 2.3.3
+      jiti: 2.6.1
+      sass: 1.100.0
+      terser: 5.48.0
+      tsx: 4.22.3
+      yaml: 2.8.3
+
+  vitest@3.2.4(@types/debug@4.1.13)(@types/node@18.19.130)(@vitejs/devtools@0.1.24)(esbuild@0.27.7)(happy-dom@20.9.0)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.13.6(@types/node@18.19.130)(typescript@6.0.3))(sass@1.100.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.8.3):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
@@ -30446,8 +30468,8 @@ snapshots:
       tinyglobby: 0.2.16
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 8.0.14(@types/node@18.19.130)(@vitejs/devtools@0.1.24)(esbuild@0.28.0)(jiti@2.6.1)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.8.3)
-      vite-node: 3.2.4(@types/node@18.19.130)(@vitejs/devtools@0.1.24)(esbuild@0.28.0)(jiti@2.6.1)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.8.3)
+      vite: 8.0.14(@types/node@18.19.130)(@vitejs/devtools@0.1.24)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.8.3)
+      vite-node: 3.2.4(@types/node@18.19.130)(@vitejs/devtools@0.1.24)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.8.3)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/debug': 4.1.13
@@ -30528,7 +30550,8 @@ snapshots:
 
   webpack-virtual-modules@0.6.2: {}
 
-  whatwg-mimetype@3.0.0: {}
+  whatwg-mimetype@3.0.0:
+    optional: true
 
   whatwg-mimetype@5.0.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -829,6 +829,9 @@ importers:
 
   packages/core:
     dependencies:
+      '@ikenxuan/qrcode':
+        specifier: ^1.1.0
+        version: 1.1.0
       '@ikenxuan/watermark':
         specifier: 1.1.5
         version: 1.1.5(@react-spectrum/provider@3.11.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(tailwind-merge@3.4.0)(tailwindcss@4.3.0)
@@ -21877,7 +21880,7 @@ snapshots:
       pathe: 2.0.3
       perfect-debounce: 2.1.0
       tinyexec: 1.1.2
-      vite: 8.0.14(@types/node@24.12.2)(@vitejs/devtools@0.2.0)(esbuild@0.28.0)(jiti@2.6.1)(sass@1.100.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 8.0.14(@types/node@24.12.2)(@vitejs/devtools@0.2.0)(esbuild@0.28.0)(jiti@2.6.1)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.8.3)
     transitivePeerDependencies:
       - '@modelcontextprotocol/sdk'
       - bufferutil
@@ -22251,7 +22254,7 @@ snapshots:
       pathe: 2.0.3
       perfect-debounce: 2.1.0
       tinyexec: 1.1.2
-      vite: 8.0.14(@types/node@24.12.2)(@vitejs/devtools@0.2.0)(esbuild@0.28.0)(jiti@2.6.1)(sass@1.100.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 8.0.14(@types/node@24.12.2)(@vitejs/devtools@0.2.0)(esbuild@0.28.0)(jiti@2.6.1)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.8.3)
       vue: 3.5.34(typescript@6.0.3)
       ws: 8.20.1
     transitivePeerDependencies:
@@ -29401,7 +29404,7 @@ snapshots:
       unconfig-core: 7.5.0
       unrun: 0.2.37(synckit@0.11.12)
     optionalDependencies:
-      '@vitejs/devtools': 0.2.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(@pnpm/logger@1001.0.1)(typescript@6.0.3)(vite@8.0.14)
+      '@vitejs/devtools': 0.2.0(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(@pnpm/logger@1001.0.1)(typescript@6.0.3)(vite@8.0.14)
       publint: 0.3.21
       typescript: 6.0.3
     transitivePeerDependencies:
@@ -30373,7 +30376,7 @@ snapshots:
       yaml: 2.8.3
     optional: true
 
-  vite@8.0.14(@types/node@24.12.2)(@vitejs/devtools@0.2.0)(esbuild@0.28.0)(jiti@2.6.1)(sass@1.100.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3):
+  vite@8.0.14(@types/node@24.12.2)(@vitejs/devtools@0.2.0)(esbuild@0.28.0)(jiti@2.6.1)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.8.3):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
@@ -30388,7 +30391,7 @@ snapshots:
       jiti: 2.6.1
       sass: 1.100.0
       terser: 5.48.0
-      tsx: 4.21.0
+      tsx: 4.22.3
       yaml: 2.8.3
     optional: true
 


### PR DESCRIPTION
改用基于 Rust + WASM 封装的 @ikenxuan/qrcode，移除原 qr-code-styling + happy-dom 方案，不再依赖 DOM 环境生成二维码。

## Summary by Sourcery

Replace the QR code generation pipeline with a shared Rust+WASM-based utility and simplify template props to carry only business data and theme information.

Enhancements:
- Refactor template component props to use a generic BaseComponentProps<T> shape, making dark theme flags explicit and centralizing business data structures.
- Remove the QR-code pre-generation plugin and related qrCodeDataUrl plumbing in favor of on-demand QR generation within React components via a shared generateQRCode helper.
- Update multiple platform-specific templates (Douyin, Bilibili, Kuaishou, Xiaohongshu, and generic/other views) to render QR codes directly from share URLs and theme state instead of relying on server-side or dev-tool generated images.
- Simplify dev preview and mock infrastructure by dropping the QR-code mock API and no longer managing QR-code state in the playground.
- Adjust various type definitions (statistics, user lists, help, changelog, error handling, etc.) to align with the new props model and remove redundant dark-theme flags.

Build:
- Swap the previous qr-code-styling + happy-dom-based QR implementation for the @ikenxuan/qrcode package in both core and template packages, removing now-unused dependencies and increasing the Vite assets inline limit while marking the new library as external for Node builds.