### PR TITLE
ui(dy): 重写部分组件样式

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -120,5 +120,5 @@
     "web": "./lib/web.config.js",
     "ts-web": "./src/web.config.ts"
   },
-  "timestamp": "2026-05-29T21:31:10.669Z"
+  "timestamp": "2026-05-30T12:33:55.890Z"
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -66,7 +66,7 @@
   },
   "dependencies": {
     "@ikenxuan/qrcode": "1.2.0",
-    "@ikenxuan/watermark": "1.1.5",
+    "@ikenxuan/watermark": "1.1.6",
     "fingerprint-injector": "^2.1.82"
   },
   "devDependencies": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -120,5 +120,5 @@
     "web": "./lib/web.config.js",
     "ts-web": "./src/web.config.ts"
   },
-  "timestamp": "2026-05-27T21:29:01.580Z"
+  "timestamp": "2026-05-29T21:31:10.669Z"
 }

--- a/packages/core/src/apps/testPush.ts
+++ b/packages/core/src/apps/testPush.ts
@@ -1,0 +1,173 @@
+import karin, { logger } from 'node-karin'
+
+import { douyinFetcher } from '@/module/utils/amagiClient'
+import { Config } from '@/module/utils/Config'
+import { wrapWithErrorHandler } from '@/module/utils/ErrorHandler'
+import { getDouyinID } from '@/platform/douyin/getID'
+import { renderFavoriteImage, renderLiveImage, renderRecommendImage, renderWorkImage } from '@/platform/douyin/push/render'
+
+/**
+ * 测试抖音推送命令处理器
+ * 支持四种推送类型的预览渲染，无数据库交互，仅用于调试和验证推送卡片效果
+ *
+ * 命令格式：
+ * - #测试抖音作品推送 <作品链接>
+ * - #测试抖音喜欢列表推送 <用户主页链接>
+ * - #测试抖音推荐列表推送 <用户主页链接>
+ * - #测试抖音直播状态推送 <用户主页链接>
+ */
+const handleTestPush = wrapWithErrorHandler(async (e) => {
+  const match = e.msg.match(/^#测试抖音(作品|喜欢列表|推荐列表|直播状态)推送/)
+  if (!match) {
+    await e.reply('支持的命令：\n#测试抖音作品推送 <作品链接>\n#测试抖音喜欢列表推送 <用户主页链接>\n#测试抖音推荐列表推送 <用户主页链接>\n#测试抖音直播状态推送 <用户主页链接>')
+    return true
+  }
+
+  /** 提取推送类型和链接 */
+  const pushType = match[1] as '作品' | '喜欢列表' | '推荐列表' | '直播状态'
+  const restMsg = e.msg.replace(match[0], '').trim()
+
+  const urlMatch = restMsg.match(/(https?:\/\/[^\s]+)/i)
+  if (!urlMatch) {
+    await e.reply(`请在命令后提供对应的${pushType === '作品' ? '作品' : '用户主页'}链接`)
+    return true
+  }
+  const url = urlMatch[1]
+  const iddata = await getDouyinID(e, url, false)
+
+  switch (pushType) {
+    /** 作品推送：作品链接 → parseWork → 渲染 */
+    case '作品': {
+      if (iddata.type !== 'one_work' || !iddata.aweme_id) {
+        await e.reply('该链接不是作品链接，请提供视频/图集/文章链接')
+        return true
+      }
+      logger.mark(`[测试抖音推送] 开始解析作品: ${iddata.aweme_id}`)
+      const workData = await douyinFetcher.parseWork({ aweme_id: iddata.aweme_id, typeMode: 'strict' })
+      if (!workData.data.aweme_detail) {
+        await e.reply('获取作品详情失败，作品可能已被删除或设为私密')
+        return true
+      }
+      const aweme = workData.data.aweme_detail
+      const userinfo = await douyinFetcher.fetchUserProfile({ sec_uid: aweme.author.sec_uid, typeMode: 'strict' })
+      const Detail_Data = { ...aweme, user_info: userinfo }
+      const shareLink = Detail_Data.video?.play_addr?.uri
+        ? `https://aweme.snssdk.com/aweme/v1/play/?video_id=${Detail_Data.video.play_addr.uri}&ratio=1080p&line=0`
+        : Detail_Data.share_url || url
+      const img = await renderWorkImage({ e, Detail_Data, create_time: aweme.create_time, shareLink, dynamicTypeLabel: '测试推送' })
+      if (img.length === 0) {
+        await e.reply('未能识别该作品类型，无法渲染推送图片')
+        return true
+      }
+      await e.reply(img)
+      break
+    }
+
+    /** 喜欢列表：用户主页 → fetchUserFavoriteList[0] → 渲染 */
+    case '喜欢列表': {
+      if (iddata.type !== 'user_dynamic' || !iddata.sec_uid) {
+        await e.reply('需要用户主页链接以获取喜欢列表')
+        return true
+      }
+      logger.mark(`[测试抖音推送] 开始获取喜欢列表: sec_uid=${iddata.sec_uid}`)
+      const userinfo = await douyinFetcher.fetchUserProfile({ sec_uid: iddata.sec_uid, typeMode: 'strict' })
+      const favoriteData = await douyinFetcher.fetchUserFavoriteList({ sec_uid: iddata.sec_uid, number: 1, typeMode: 'strict' })
+      if (!favoriteData.data.aweme_list?.length) {
+        await e.reply('该用户的喜欢列表为空或未公开')
+        return true
+      }
+      const aweme = favoriteData.data.aweme_list[0]
+      let authorUserInfo: any
+      try {
+        authorUserInfo = await douyinFetcher.fetchUserProfile({ sec_uid: aweme.author.sec_uid, typeMode: 'strict' })
+      } catch { /* ignore */ }
+      const Detail_Data = { ...aweme, user_info: userinfo, author_user_info: authorUserInfo }
+      const shareLink = Detail_Data.video?.play_addr?.uri
+        ? `https://aweme.snssdk.com/aweme/v1/play/?video_id=${Detail_Data.video.play_addr.uri}&ratio=1080p&line=0`
+        : aweme.share_url
+      const img = await renderFavoriteImage({ e, Detail_Data, create_time: aweme.create_time, shareLink, remark: userinfo.data.user.nickname })
+      if (!img.length) {
+        await e.reply('渲染喜欢列表推送图片失败')
+        return true
+      }
+      await e.reply(img)
+      break
+    }
+
+    /** 推荐列表：用户主页 → fetchUserRecommendList[0] → 渲染 */
+    case '推荐列表': {
+      if (iddata.type !== 'user_dynamic' || !iddata.sec_uid) {
+        await e.reply('需要用户主页链接以获取推荐列表')
+        return true
+      }
+      logger.mark(`[测试抖音推送] 开始获取推荐列表: sec_uid=${iddata.sec_uid}`)
+      const userinfo = await douyinFetcher.fetchUserProfile({ sec_uid: iddata.sec_uid, typeMode: 'strict' })
+      const recommendData = await douyinFetcher.fetchUserRecommendList({ sec_uid: iddata.sec_uid, number: 1, typeMode: 'strict' })
+      if (!recommendData.data.aweme_list?.length) {
+        await e.reply('该用户的推荐列表为空或未公开')
+        return true
+      }
+      const aweme = recommendData.data.aweme_list[0]
+      let authorUserInfo: any
+      try {
+        authorUserInfo = await douyinFetcher.fetchUserProfile({ sec_uid: aweme.author.sec_uid, typeMode: 'strict' })
+      } catch { /* ignore */ }
+      const Detail_Data = { ...aweme, user_info: userinfo, author_user_info: authorUserInfo }
+      const shareLink = Detail_Data.video?.play_addr?.uri
+        ? `https://aweme.snssdk.com/aweme/v1/play/?video_id=${Detail_Data.video.play_addr.uri}&ratio=1080p&line=0`
+        : aweme.share_url
+      const img = await renderRecommendImage({ e, Detail_Data, create_time: aweme.create_time, shareLink, remark: userinfo.data.user.nickname })
+      if (!img.length) {
+        await e.reply('渲染推荐列表推送图片失败')
+        return true
+      }
+      await e.reply(img)
+      break
+    }
+
+    /** 直播状态：用户主页 → 检查 live_status → fetchLiveRoomInfo → 渲染 */
+    case '直播状态': {
+      if (iddata.type !== 'user_dynamic' || !iddata.sec_uid) {
+        await e.reply('需要用户主页链接以检查直播状态')
+        return true
+      }
+      const sec_uid = iddata.sec_uid
+      logger.mark(`[测试抖音推送] 开始检查直播状态: sec_uid=${sec_uid}`)
+      const userinfo = await douyinFetcher.fetchUserProfile({ sec_uid, typeMode: 'strict' })
+      const user = userinfo.data.user
+      if (user.live_status !== 1) {
+        await e.reply(`${user.nickname} 当前未在直播`)
+        return true
+      }
+      if (!user.room_data) {
+        await e.reply('未获取到直播间信息')
+        return true
+      }
+      const room_data = JSON.parse(user.room_data)
+      const liveInfo = await douyinFetcher.fetchLiveRoomInfo({
+        room_id: user.room_id_str,
+        web_rid: room_data.owner.web_rid,
+        typeMode: 'strict'
+      })
+      const Detail_Data = { user_info: userinfo, room_data, live_data: liveInfo }
+      const img = await renderLiveImage({ e, Detail_Data, dynamicTypeLabel: '测试推送' })
+      if (!img.length) {
+        await e.reply('渲染直播状态推送图片失败')
+        return true
+      }
+      await e.reply(img)
+      break
+    }
+  }
+
+  logger.mark(`[测试抖音推送] ${pushType}推送渲染完成`)
+  return true
+}, {
+  businessName: '测试抖音推送'
+})
+
+/** 注册测试推送命令，仅在开发环境下生效 */
+export const testPush = process.env.NODE_ENV === 'development' && Config.douyin.switch && karin.command(/^#测试抖音(作品|喜欢列表|推荐列表|直播状态)推送/, handleTestPush, {
+  name: 'kkk-测试抖音推送',
+  perm: 'master'
+})

--- a/packages/core/src/apps/testPush.ts
+++ b/packages/core/src/apps/testPush.ts
@@ -166,8 +166,8 @@ const handleTestPush = wrapWithErrorHandler(async (e) => {
   businessName: '测试抖音推送'
 })
 
-/** 注册测试推送命令，仅在开发环境下生效 */
-export const testPush = process.env.NODE_ENV === 'development' && Config.douyin.switch && karin.command(/^#测试抖音(作品|喜欢列表|推荐列表|直播状态)推送/, handleTestPush, {
+/** 注册测试推送命令 */
+export const testPush = Config.douyin.switch && karin.command(/^#测试抖音(作品|喜欢列表|推荐列表|直播状态)推送/, handleTestPush, {
   name: 'kkk-测试抖音推送',
   perm: 'master'
 })

--- a/packages/core/src/apps/testPush.ts
+++ b/packages/core/src/apps/testPush.ts
@@ -54,7 +54,7 @@ const handleTestPush = wrapWithErrorHandler(async (e) => {
       const shareLink = Detail_Data.video?.play_addr?.uri
         ? `https://aweme.snssdk.com/aweme/v1/play/?video_id=${Detail_Data.video.play_addr.uri}&ratio=1080p&line=0`
         : Detail_Data.share_url || url
-      const img = await renderWorkImage({ e, Detail_Data, create_time: aweme.create_time, shareLink, dynamicTypeLabel: '测试推送' })
+      const img = await renderWorkImage({ e, Detail_Data, create_time: aweme.create_time, shareLink })
       if (img.length === 0) {
         await e.reply('未能识别该作品类型，无法渲染推送图片')
         return true
@@ -150,7 +150,7 @@ const handleTestPush = wrapWithErrorHandler(async (e) => {
         typeMode: 'strict'
       })
       const Detail_Data = { user_info: userinfo, room_data, live_data: liveInfo }
-      const img = await renderLiveImage({ e, Detail_Data, dynamicTypeLabel: '测试推送' })
+      const img = await renderLiveImage({ e, Detail_Data })
       if (!img.length) {
         await e.reply('渲染直播状态推送图片失败')
         return true

--- a/packages/core/src/apps/tools.ts
+++ b/packages/core/src/apps/tools.ts
@@ -18,9 +18,9 @@ const reg = {
 }
 
 // 包装抖音处理函数
-const handleDouyin = wrapWithErrorHandler(async (e) => {
+const handleDouyin = wrapWithErrorHandler(async (e, next) => {
   if (e.msg.startsWith('#测试')) {
-    return false
+    return next()
   }
 
   // 判断是否为弹幕解析（通过 #弹幕解析 命令触发）
@@ -29,7 +29,7 @@ const handleDouyin = wrapWithErrorHandler(async (e) => {
   const urlMatch = e.msg.match(/(https?:\/\/[^\s]*\.(douyin|iesdouyin)\.com[^\s]*)/gi)
   if (!urlMatch) {
     logger.warn(`未能在消息中找到有效的抖音链接: ${e.msg}`)
-    return true
+    return next()
   }
   const url = String(urlMatch[0])
   const iddata = await getDouyinID(e, url)
@@ -47,13 +47,13 @@ const handleDouyin = wrapWithErrorHandler(async (e) => {
     }
   }
   
-  return true
+  return
 }, {
   businessName: '抖音视频解析'
 })
 
 // 包装B站处理函数
-const handleBilibili = wrapWithErrorHandler(async (e) => {
+const handleBilibili = wrapWithErrorHandler(async (e, next) => {
   e.msg = e.msg.replace(/\\/g, '') // 移除消息中的反斜杠
 
   // 判断是否为弹幕解析（通过 #弹幕解析 命令触发）
@@ -74,7 +74,7 @@ const handleBilibili = wrapWithErrorHandler(async (e) => {
   }
   if (!url) {
     logger.warn(`未能在消息中找到有效的B站分享链接、BV号或AV号: ${e.msg}`)
-    return true
+    return next()
   }
   const iddata = await getBilibiliID(url)
   await new Bilibili(e, iddata, { forceBurnDanmaku }).BilibiliHandler(iddata)
@@ -91,7 +91,7 @@ const handleBilibili = wrapWithErrorHandler(async (e) => {
     }
   }
   
-  return true
+  return
 }, {
   businessName: 'B站视频解析'
 })
@@ -119,13 +119,13 @@ const handleKuaishou = wrapWithErrorHandler(async (e) => {
 })
 
 // 包装小红书处理函数
-const handleXiaohongshu = wrapWithErrorHandler(async (e) => {
+const handleXiaohongshu = wrapWithErrorHandler(async (e, next) => {
   const cleaned = e.msg.replaceAll('\\', '')
   const m = cleaned.match(/https?:\/\/[^\s"'<>]+/)
   const url = m?.[0]
   if (!url) {
     logger.warn(`未能在消息中找到有效链接: ${e.msg}`)
-    return true
+    return next()
   }
   const iddata = await getXiaohongshuID(url)
   await new Xiaohongshu(e, iddata).XiaohongshuHandler(iddata)
@@ -142,7 +142,7 @@ const handleXiaohongshu = wrapWithErrorHandler(async (e) => {
     }
   }
   
-  return true
+  return
 }, {
   businessName: '小红书视频解析'
 })

--- a/packages/core/src/module/utils/ErrorHandler/handler.ts
+++ b/packages/core/src/module/utils/ErrorHandler/handler.ts
@@ -59,12 +59,13 @@ export const handleBusinessError = async (
 }
 
 export const wrapWithErrorHandler = <R> (
-  fn: (e: Message, next?: () => unknown) => R | Promise<R>,
+  fn: (e: Message, next: () => unknown) => R | Promise<R>,
   options: ErrorHandlerOptions
 ) => {
   return async (e?: Message, next?: () => unknown): Promise<R> => {
     const rawEvent = e
     const normalizedEvent = await injectBotToEventForPushTask(rawEvent, options.businessName)
+    const normalizedNext = next ?? (() => undefined)
     const shouldHandleEmoji = Boolean(rawEvent) && !isPushTask(rawEvent, options.businessName)
     const emojiManager = shouldHandleEmoji ? new EmojiReactionManager(rawEvent as Message) : undefined
     let processingTimer: NodeJS.Timeout | null = null
@@ -77,7 +78,7 @@ export const wrapWithErrorHandler = <R> (
       }, 1500)
     }
 
-    const ctx = logger.runContext(async () => fn(normalizedEvent, next))
+    const ctx = logger.runContext(async () => fn(normalizedEvent, normalizedNext))
 
     try {
       const result = await ctx.run()

--- a/packages/core/src/platform/douyin/push.ts
+++ b/packages/core/src/platform/douyin/push.ts
@@ -276,8 +276,7 @@ export class DouYinpush extends Base {
               Detail_Data,
               create_time: pushItem.create_time,
               shareLink,
-              skipWatermark: true,
-              dynamicTypeLabel: '作品动态推送'
+              skipWatermark: true
             })
             break
           }

--- a/packages/core/src/platform/douyin/push.ts
+++ b/packages/core/src/platform/douyin/push.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs'
 
 import type { DySearchInfo } from '@ikenxuan/amagi'
-import { format, fromUnixTime } from 'date-fns'
+import { format } from 'date-fns'
 import type { AdapterType, ImageElement, Message } from 'node-karin'
 import karin, { common, logger, segment } from 'node-karin'
 import { DouyinUserListProps } from 'template/types/platforms/douyin'
@@ -24,13 +24,14 @@ import {
   Render } from '@/module'
 import { Config } from '@/module/utils/Config'
 import { DouyinIdData, douyinProcessVideos, getDouyinID } from '@/platform/douyin'
-import { getWorkCoverUrl, getWorkTypeDisplayName, getWorkTypeInfo } from '@/platform/douyin/workType'
+import { getWorkTypeDisplayName, getWorkTypeInfo } from '@/platform/douyin/workType'
 import type { douyinPushItem } from '@/types/config/pushlist'
 
 import { processFavoriteList } from './push/favorite'
 import { processLiveStream } from './push/live'
 import { processPostList } from './push/post'
 import { processRecommendList } from './push/recommend'
+import { renderFavoriteImage, renderLiveImage, renderRecommendImage, renderWorkImage } from './push/render'
 import { type DouyinPushItem, type WillBePushList } from './push/types'
 
 // Re-export types for backward compatibility
@@ -191,9 +192,13 @@ export class DouYinpush extends Base {
     for (const awemeId in data) {
       const pushItem = data[awemeId]
       const actualAwemeId = awemeId.replace(/^(post|favorite|recommend|live)_/, '') // 移除推送类型前缀
-      const pushTypeLabel = pushItem.pushType === 'post' ? '作品列表' :
-        pushItem.pushType === 'favorite' ? '喜欢列表' :
-          pushItem.pushType === 'recommend' ? '推荐列表' : '直播'
+      let pushTypeLabel: string
+      switch (pushItem.pushType) {
+        case 'post': pushTypeLabel = '作品列表'; break
+        case 'favorite': pushTypeLabel = '喜欢列表'; break
+        case 'recommend': pushTypeLabel = '推荐列表'; break
+        default: pushTypeLabel = '直播'; break
+      }
 
       logger.mark(`
         ${logger.blue('开始处理并渲染抖音动态图片')}
@@ -214,243 +219,67 @@ export class DouYinpush extends Base {
       }
 
       if (!skip) {
-        if (pushItem.pushType === 'live' && 'room_data' in pushItem.Detail_Data && Detail_Data.live_data) {
-          // 处理直播推送
-          const liveItem = Detail_Data.live_data.data.data.data[0]
-          //@ts-ignore
-          const streamExtra = liveItem.stream_url.extra
-          const resolution = streamExtra
-            ? `${streamExtra.width}x${streamExtra.height}`
-            //@ts-ignore
-            : liveItem.stream_url.default_resolution
+        const realUrl = pushItem.pushType !== 'live' && Config.douyin.push.shareType === 'web' && await new Networks({
+          url: Detail_Data.share_url,
+          headers: {
+            'User-Agent': 'Apifox/1.0.0 (https://apifox.com)',
+            Accept: '*/*',
+            'Accept-Encoding': 'gzip, deflate, br',
+            Connection: 'keep-alive'
+          }
+        }).getLocation()
 
-          img = await Render(this.e, 'douyin/live', {
-            //@ts-ignore
-            image_url: liveItem.cover.url_list[0],
-            //@ts-ignore
-            text: liveItem.title,
-            partition_title: Detail_Data.live_data.data.data.partition_road_map?.partition?.title || '未知分区',
-            room_id: Detail_Data.room_data.owner.web_rid,
-            //@ts-ignore
-            online_viewers: this.count(liveItem.room_view_stats.display_value),
-            //@ts-ignore
-            total_viewers: liveItem.stats.total_user_str,
-            username: Detail_Data.user_info.data.user.nickname,
-            avater_url: 'https://p3-pc.douyinpic.com/aweme/1080x1080/' + Detail_Data.user_info.data.user.avatar_larger.uri,
-            fans: this.count(Detail_Data.user_info.data.user.follower_count),
-            share_url: 'https://live.douyin.com/' + Detail_Data.room_data.owner.web_rid,
-            dynamicTYPE: '直播动态推送',
-            //@ts-ignore
-            like_count: this.count(liveItem.like_count),
-            //@ts-ignore
-            user_count_str: liveItem.user_count_str,
-            resolution,
-            signature: Detail_Data.user_info.data.user.signature,
-            //@ts-ignore
-            city: Detail_Data.user_info.data.user.city,
-            aweme_count: this.count(Detail_Data.user_info.data.user.aweme_count),
-            following_count: this.count(Detail_Data.user_info.data.user.following_count),
-            total_favorited: this.count(Detail_Data.user_info.data.user.total_favorited),
-            //@ts-ignore
-            has_commerce_goods: liveItem.has_commerce_goods
-          }, { skipWatermark: true })
-        } else {
-          // 处理普通作品推送
-          const realUrl = Config.douyin.push.shareType === 'web' && await new Networks({
-            url: Detail_Data.share_url,
-            headers: {
-              'User-Agent': 'Apifox/1.0.0 (https://apifox.com)',
-              Accept: '*/*',
-              'Accept-Encoding': 'gzip, deflate, br',
-              Connection: 'keep-alive'
-            }
-          }).getLocation()
+        switch (pushItem.pushType) {
+          case 'live': {
+            if (!('room_data' in pushItem.Detail_Data && Detail_Data.live_data)) break
+            img = await renderLiveImage({
+              e: this.e,
+              Detail_Data,
+              skipWatermark: true,
+              dynamicTypeLabel: '直播动态推送'
+            })
+            break
+          }
 
-          // 根据推送类型选择不同的渲染模板和数据
-          if (pushItem.pushType === 'favorite') {
-            // 喜欢列表模板：需要显示"谁喜欢了谁的作品"
-            // 获取作者用户信息（如果有的话）
-            const authorUserInfo = 'author_user_info' in Detail_Data ? Detail_Data.author_user_info : undefined
+          case 'favorite': {
+            const shareLink = Config.douyin.push.shareType === 'web' ? realUrl! : `https://aweme.snssdk.com/aweme/v1/play/?video_id=${Detail_Data.video.play_addr.uri}&ratio=1080p&line=0`
+            img = await renderFavoriteImage({
+              e: this.e,
+              Detail_Data,
+              create_time: pushItem.create_time,
+              shareLink,
+              remark: pushItem.remark,
+              skipWatermark: true
+            })
+            break
+          }
 
-            // 获取作品类型信息和封面
-            const workTypeInfo = getWorkTypeInfo(Detail_Data as any)
-            const coverUrl = getWorkCoverUrl(workTypeInfo, Detail_Data as any)
+          case 'recommend': {
+            const shareLink = Config.douyin.push.shareType === 'web' ? realUrl! : `https://aweme.snssdk.com/aweme/v1/play/?video_id=${Detail_Data.video.play_addr.uri}&ratio=1080p&line=0`
+            img = await renderRecommendImage({
+              e: this.e,
+              Detail_Data,
+              create_time: pushItem.create_time,
+              shareLink,
+              remark: pushItem.remark,
+              skipWatermark: true
+            })
+            break
+          }
 
-            img = await Render(this.e, 'douyin/favorite-list', {
-              image_url: coverUrl,
-              desc: this.desc(Detail_Data, Detail_Data.desc),
-              dianzan: this.count(Detail_Data.statistics.digg_count),
-              pinglun: this.count(Detail_Data.statistics.comment_count),
-              share: this.count(Detail_Data.statistics.share_count),
-              shouchang: this.count(Detail_Data.statistics.collect_count),
-              tuijian: this.count(Detail_Data.statistics.recommend_count),
-              create_time: format(fromUnixTime(pushItem.create_time), 'yyyy-MM-dd HH:mm'),
-              // 点赞者信息（订阅者）
-              liker_username: pushItem.remark,
-              liker_avatar: 'https://p3-pc.douyinpic.com/aweme/1080x1080/' + Detail_Data.user_info.data.user.avatar_larger.uri,
-              liker_douyin_id: Detail_Data.user_info.data.user.unique_id === '' ? Detail_Data.user_info.data.user.short_id : Detail_Data.user_info.data.user.unique_id,
-              // 作品作者信息
-              author_username: Detail_Data.author.nickname,
-              author_avatar: 'https://p3-pc.douyinpic.com/aweme/1080x1080/' + authorUserInfo.data.user.avatar_larger.uri,
-              author_douyin_id: (authorUserInfo.data.user.unique_id === '' ? authorUserInfo.data.user.short_id : authorUserInfo.data.user.unique_id),
-              share_url: Config.douyin.push.shareType === 'web' ? realUrl : `https://aweme.snssdk.com/aweme/v1/play/?video_id=${Detail_Data.video.play_addr.uri}&ratio=1080p&line=0`
-            }, { skipWatermark: true })
-          } else if (pushItem.pushType === 'recommend') {
-            // 推荐列表模板
-            // 获取作者用户信息（如果有的话）
-            const authorUserInfo = 'author_user_info' in Detail_Data ? Detail_Data.author_user_info : undefined
+          case 'post':
+          default: {
+            const shareLink = Config.douyin.push.shareType === 'web' ? realUrl! : `https://aweme.snssdk.com/aweme/v1/play/?video_id=${Detail_Data.video.play_addr.uri}&ratio=1080p&line=0`
 
-            // 获取作品类型信息和封面
-            const workTypeInfo = getWorkTypeInfo(Detail_Data as any)
-            const coverUrl = getWorkCoverUrl(workTypeInfo, Detail_Data as any)
-
-            img = await Render(this.e, 'douyin/recommend-list', {
-              image_url: coverUrl,
-              desc: this.desc(Detail_Data, Detail_Data.desc),
-              dianzan: this.count(Detail_Data.statistics.digg_count),
-              pinglun: this.count(Detail_Data.statistics.comment_count),
-              share: this.count(Detail_Data.statistics.share_count),
-              shouchang: this.count(Detail_Data.statistics.collect_count),
-              tuijian: this.count(Detail_Data.statistics.recommend_count),
-              create_time: format(fromUnixTime(pushItem.create_time), 'yyyy-MM-dd HH:mm'),
-
-              // 推荐者信息（订阅者）
-              recommender_username: pushItem.remark,
-              recommender_avatar: 'https://p3-pc.douyinpic.com/aweme/1080x1080/' + Detail_Data.user_info.data.user.avatar_larger.uri,
-              recommender_douyin_id: Detail_Data.user_info.data.user.unique_id === '' ? Detail_Data.user_info.data.user.short_id : Detail_Data.user_info.data.user.unique_id,
-
-              // 作品作者信息
-              author_username: Detail_Data.author.nickname,
-              author_avatar: 'https://p3-pc.douyinpic.com/aweme/1080x1080/' + authorUserInfo.data.user.avatar_larger.uri,
-              author_douyin_id: (authorUserInfo.data.user.unique_id === '' ? authorUserInfo.data.user.short_id : authorUserInfo.data.user.unique_id),
-              share_url: Config.douyin.push.shareType === 'web' ? realUrl : `https://aweme.snssdk.com/aweme/v1/play/?video_id=${Detail_Data.video.play_addr.uri}&ratio=1080p&line=0`
-            }, { skipWatermark: true })
-          } else {
-            // 作品列表模板（post）
-            const dynamicTypeLabel = '作品动态推送'
-
-            // 获取作品类型信息
-            const workTypeInfo = getWorkTypeInfo(Detail_Data as any)
-
-            // 获取封面 URL
-            const coverUrl = getWorkCoverUrl(workTypeInfo, Detail_Data as any)
-
-            // 如果是文章类型，使用文章模板
-            if (workTypeInfo.isArticle) {
-              // 解析文章内容
-              const content = JSON.parse(Detail_Data.article_info.article_content)
-              const fe_data = JSON.parse(Detail_Data.article_info.fe_data)
-
-              // 渲染文章模板
-              img = await Render(this.e, 'douyin/article-work', {
-                title: Detail_Data.article_info.article_title,
-                markdown: content.markdown,
-                images: fe_data.image_list || [],
-                read_time: fe_data.read_time || 0,
-
-                // 互动数据
-                dianzan: this.count(Detail_Data.statistics.digg_count),
-                pinglun: this.count(Detail_Data.statistics.comment_count),
-                shouchang: this.count(Detail_Data.statistics.collect_count),
-                share: this.count(Detail_Data.statistics.share_count),
-
-                // 时间信息
-                create_time: format(fromUnixTime(pushItem.create_time), 'yyyy-MM-dd HH:mm'),
-
-                // 用户信息
-                avater_url: 'https://p3-pc.douyinpic.com/aweme/1080x1080/' + Detail_Data.user_info.data.user.avatar_larger.uri,
-                username: Detail_Data.author.nickname,
-                抖音号: Detail_Data.user_info.data.user.unique_id === '' ? Detail_Data.user_info.data.user.short_id : Detail_Data.user_info.data.user.unique_id,
-                获赞: this.count(Detail_Data.user_info.data.user.total_favorited),
-                关注: this.count(Detail_Data.user_info.data.user.following_count),
-                粉丝: this.count(Detail_Data.user_info.data.user.follower_count),
-
-                // 分享链接
-                share_url: Detail_Data.share_url,
-
-                // 主题
-                useDarkTheme: false
-              }, { skipWatermark: true })
-            } else {
-              // 视频或图文作品
-              img = await Render(this.e, workTypeInfo.templatePath, {
-                image_url: coverUrl,
-                desc: this.desc(Detail_Data, Detail_Data.desc),
-                dianzan: this.count(Detail_Data.statistics.digg_count),
-                pinglun: this.count(Detail_Data.statistics.comment_count),
-                share: this.count(Detail_Data.statistics.share_count),
-                shouchang: this.count(Detail_Data.statistics.collect_count),
-                create_time: format(fromUnixTime(pushItem.create_time), 'yyyy-MM-dd HH:mm'),
-                avater_url: 'https://p3-pc.douyinpic.com/aweme/1080x1080/' + Detail_Data.user_info.data.user.avatar_larger.uri,
-                share_url: Config.douyin.push.shareType === 'web' ? realUrl : `https://aweme.snssdk.com/aweme/v1/play/?video_id=${Detail_Data.video.play_addr.uri}&ratio=1080p&line=0`,
-                username: Detail_Data.user_info.data.user.nickname,
-                抖音号: Detail_Data.user_info.data.user.unique_id === '' ? Detail_Data.user_info.data.user.short_id : Detail_Data.user_info.data.user.unique_id,
-                粉丝: this.count(Detail_Data.user_info.data.user.follower_count),
-                获赞: this.count(Detail_Data.user_info.data.user.total_favorited),
-                关注: this.count(Detail_Data.user_info.data.user.following_count),
-                dynamicTYPE: dynamicTypeLabel,
-                cooperation_info: (() => {
-                  const raw = Detail_Data.cooperation_info
-                  if (!raw) return undefined
-
-                  const rawCreators = Array.isArray(raw.co_creators) ? raw.co_creators : []
-
-                  // 订阅者信息（user_info）
-                  const subscriberUid = Detail_Data.user_info.data.user.uid
-                  const subscriberSecUid = Detail_Data.user_info.data.user.sec_uid
-
-                  // 查找订阅者在共创列表中的职位
-                  const subscriberInCreators = rawCreators.find((c: { uid: string; sec_uid: string }) =>
-                    (subscriberUid && c.uid && c.uid === subscriberUid) ||
-                    (subscriberSecUid && c.sec_uid && c.sec_uid === subscriberSecUid)
-                  )
-
-                  // 简化共创者信息：只保留头像链接、名字、职位（使用 avatar_url）
-                  const co_creators = rawCreators.map((c: {
-                    avatar_thumb: { url_list: (string | undefined)[]; uri: any }
-                    nickname: any
-                    role_title: any
-                  }) => {
-                    const avatarUrl = c.avatar_thumb?.url_list?.[0] ??
-                      (c.avatar_thumb?.uri ? `https://p3.douyinpic.com/${c.avatar_thumb.uri}` : undefined)
-
-                    return {
-                      avatar_url: avatarUrl,
-                      nickname: c.nickname,
-                      role_title: c.role_title
-                    }
-                  })
-
-                  if (
-                    Detail_Data.author &&
-                    !rawCreators.some((c: { uid: string; sec_uid: string; nickname: string }) =>
-                      (Detail_Data.author?.uid && c.uid && c.uid === Detail_Data.author.uid) ||
-                      (Detail_Data.author?.sec_uid && c.sec_uid && c.sec_uid === Detail_Data.author.sec_uid) ||
-                      (Detail_Data.author?.nickname && c.nickname && c.nickname === Detail_Data.author.nickname)
-                    )
-                  ) {
-                    co_creators.unshift({
-                      avatar_url: Detail_Data.author.avatar_thumb?.url_list?.[0] ??
-                        (Detail_Data.author.avatar_thumb?.uri ? `https://p3.douyinpic.com/${Detail_Data.author.avatar_thumb.uri}` : undefined),
-                      nickname: Detail_Data.author.nickname,
-                      role_title: '作者'
-                    })
-                  }
-
-                  return {
-                    co_creator_nums: Math.max(Number(raw.co_creator_nums || 0), co_creators.length),
-                    co_creators,
-                    subscriber_role: subscriberInCreators?.role_title ?? (
-                      (subscriberUid && Detail_Data.author?.uid && subscriberUid === Detail_Data.author.uid) ||
-                        (subscriberSecUid && Detail_Data.author?.sec_uid && subscriberSecUid === Detail_Data.author.sec_uid) ||
-                        (Detail_Data.user_info.data.user.nickname && Detail_Data.author?.nickname && Detail_Data.user_info.data.user.nickname === Detail_Data.author.nickname)
-                        ? '作者'
-                        : undefined
-                    )
-                  }
-                })()
-              }, { skipWatermark: true })
-            }
+            img = await renderWorkImage({
+              e: this.e,
+              Detail_Data,
+              create_time: pushItem.create_time,
+              shareLink,
+              skipWatermark: true,
+              dynamicTypeLabel: '作品动态推送'
+            })
+            break
           }
         }
       }
@@ -1255,18 +1084,8 @@ export class DouYinpush extends Base {
   }
 
   /**
-   * 处理作品描述
-   */
-  desc (Detail_Data: any, desc: string) {
-    if (desc === '') {
-      return '该作品没有描述'
-    }
-    return desc
-  }
-
-  /**
-   * 格式化数字
-   */
+    * 格式化数字
+    */
   count (num: number) {
     if (num > 10000) {
       return (num / 10000).toFixed(1) + '万'

--- a/packages/core/src/platform/douyin/push/render.ts
+++ b/packages/core/src/platform/douyin/push/render.ts
@@ -1,0 +1,360 @@
+import { format, fromUnixTime } from 'date-fns'
+import type { ImageElement, Message } from 'node-karin'
+
+import { Count, Render } from '@/module/utils'
+
+import { DouyinWorkMainType, getWorkCoverUrl, getWorkTypeInfo } from '../workType'
+
+/**
+ * 处理作品描述
+ * @param Desc - 作品原始描述文本
+ * @returns 如果描述为空则返回默认提示，否则返回原文
+ */
+function desc (Desc: string) {
+  return Desc === '' ? '该作品没有描述' : Desc
+}
+
+/**
+ * 构建合作信息数据
+ * 从作品详情中提取创作者合作信息，包括合作者列表和订阅者角色
+ * @param Detail_Data - 作品详情数据，包含 cooperation_info、user_info、author 等字段
+ * @returns 合作信息对象，如果不存在则返回 undefined
+ */
+function buildCooperationInfo (Detail_Data: any): {
+  co_creator_nums: number
+  co_creators: Array<{
+    avatar_url?: string
+    nickname: string
+    role_title: string
+  }>
+  subscriber_role?: string
+} | undefined {
+  const raw = Detail_Data.cooperation_info
+  if (!raw) return undefined
+
+  const rawCreators = Array.isArray(raw.co_creators) ? raw.co_creators : []
+
+  const subscriberUid = Detail_Data.user_info.data.user.uid
+  const subscriberSecUid = Detail_Data.user_info.data.user.sec_uid
+
+  const subscriberInCreators = rawCreators.find((c: { uid: string; sec_uid: string }) =>
+    (subscriberUid && c.uid && c.uid === subscriberUid) ||
+    (subscriberSecUid && c.sec_uid && c.sec_uid === subscriberSecUid)
+  )
+
+  const co_creators = rawCreators.map((c: {
+    avatar_thumb: { url_list: (string | undefined)[]; uri: any }
+    nickname: any
+    role_title: any
+  }) => {
+    const avatarUrl = c.avatar_thumb?.url_list?.[0] ??
+      (c.avatar_thumb?.uri ? `https://p3.douyinpic.com/${c.avatar_thumb.uri}` : undefined)
+
+    return {
+      avatar_url: avatarUrl,
+      nickname: c.nickname,
+      role_title: c.role_title
+    }
+  })
+
+  if (
+    Detail_Data.author &&
+    !rawCreators.some((c: { uid: string; sec_uid: string; nickname: string }) =>
+      (Detail_Data.author?.uid && c.uid && c.uid === Detail_Data.author.uid) ||
+      (Detail_Data.author?.sec_uid && c.sec_uid && c.sec_uid === Detail_Data.author.sec_uid) ||
+      (Detail_Data.author?.nickname && c.nickname && c.nickname === Detail_Data.author.nickname)
+    )
+  ) {
+    co_creators.unshift({
+      avatar_url: Detail_Data.author.avatar_thumb?.url_list?.[0] ??
+        (Detail_Data.author.avatar_thumb?.uri ? `https://p3.douyinpic.com/${Detail_Data.author.avatar_thumb.uri}` : undefined),
+      nickname: Detail_Data.author.nickname,
+      role_title: '作者'
+    })
+  }
+
+  return {
+    co_creator_nums: Math.max(Number(raw.co_creator_nums || 0), co_creators.length),
+    co_creators,
+    subscriber_role: subscriberInCreators?.role_title ?? (
+      (subscriberUid && Detail_Data.author?.uid && subscriberUid === Detail_Data.author.uid) ||
+        (subscriberSecUid && Detail_Data.author?.sec_uid && subscriberSecUid === Detail_Data.author.sec_uid) ||
+        (Detail_Data.user_info.data.user.nickname && Detail_Data.author?.nickname && Detail_Data.user_info.data.user.nickname === Detail_Data.author.nickname)
+        ? '作者'
+        : undefined
+    )
+  }
+}
+
+/**
+ * 构建 Douyin CDN 头像 URL
+ * @param uri - 头像资源的 URI 标识
+ * @returns 完整的 1080x1080 分辨率头像 CDN 地址
+ */
+function cdnAvatar (uri: string): string {
+  return 'https://p3-pc.douyinpic.com/aweme/1080x1080/' + uri
+}
+
+/**
+ * 获取用户抖音号
+ * @param user - 用户对象，包含 unique_id 和 short_id
+ * @returns 优先返回抖音号（unique_id），为空则返回短 ID
+ */
+function douyinId (user: { unique_id: string; short_id: string }): string {
+  return user.unique_id === '' ? user.short_id : user.unique_id
+}
+
+/** 作品推送图片渲染参数 */
+export interface RenderWorkImageOptions {
+  /** Karin 消息事件，传递给 Render 用于获取 bot 信息 */
+  e: Message
+  /** 作品详情数据，包含 user_info、statistics、author 等字段 */
+  Detail_Data: any
+  /** 作品创建时间（Unix 时间戳，秒） */
+  create_time: number
+  /** 分享链接地址 */
+  shareLink: string
+  /** 是否跳过水印嵌入（推送场景为 true，避免重复水印） */
+  skipWatermark?: boolean
+  /** 推送类型标签，显示在图片头部 */
+  dynamicTypeLabel?: string
+}
+
+/**
+ * 渲染作品推送图片
+ * 根据作品类型（文章/视频/图文）自动选择对应模板进行渲染
+ * 支持视频、图集、文章三种作品类型，未知类型返回空数组
+ * @param options - 渲染参数
+ * @returns 渲染后的图片元素数组
+ */
+export async function renderWorkImage (options: RenderWorkImageOptions): Promise<ImageElement[]> {
+  const { e, Detail_Data, create_time, shareLink, skipWatermark = false } = options
+  const dynamicTypeLabel = options.dynamicTypeLabel ?? '作品动态推送'
+  const workTypeInfo = getWorkTypeInfo(Detail_Data)
+  const coverUrl = getWorkCoverUrl(workTypeInfo, Detail_Data)
+  const formatTime = format(fromUnixTime(create_time), 'yyyy-MM-dd HH:mm')
+  const user = Detail_Data.user_info.data.user
+  const userDouyinId = douyinId(user)
+  const avatarUrl = cdnAvatar(user.avatar_larger.uri)
+  const authorNickname = Detail_Data.author?.nickname ?? user.nickname
+  const cooperationInfo = buildCooperationInfo(Detail_Data)
+
+  const renderOpts = skipWatermark ? { skipWatermark: true } : undefined
+
+  switch (workTypeInfo.mainType) {
+    case DouyinWorkMainType.ARTICLE: {
+      const content = JSON.parse(Detail_Data.article_info.article_content)
+      const fe_data = JSON.parse(Detail_Data.article_info.fe_data)
+      return await Render(e, 'douyin/article-work', {
+        title: Detail_Data.article_info.article_title,
+        markdown: content.markdown,
+        images: fe_data.image_list || [],
+        read_time: fe_data.read_time || 0,
+        dianzan: Count(Detail_Data.statistics.digg_count),
+        pinglun: Count(Detail_Data.statistics.comment_count),
+        shouchang: Count(Detail_Data.statistics.collect_count),
+        share: Count(Detail_Data.statistics.share_count),
+        create_time: formatTime,
+        avater_url: avatarUrl,
+        username: authorNickname,
+        抖音号: userDouyinId,
+        获赞: Count(user.total_favorited),
+        关注: Count(user.following_count),
+        粉丝: Count(user.follower_count),
+        share_url: Detail_Data.share_url
+      }, renderOpts)
+    }
+
+    case DouyinWorkMainType.VIDEO: {
+      return await Render(e, 'douyin/video-work', {
+        image_url: coverUrl,
+        desc: desc(Detail_Data.desc),
+        dianzan: Count(Detail_Data.statistics.digg_count),
+        pinglun: Count(Detail_Data.statistics.comment_count),
+        share: Count(Detail_Data.statistics.share_count),
+        shouchang: Count(Detail_Data.statistics.collect_count),
+        create_time: formatTime,
+        avater_url: avatarUrl,
+        share_url: shareLink,
+        username: user.nickname,
+        抖音号: userDouyinId,
+        粉丝: Count(user.follower_count),
+        获赞: Count(user.total_favorited),
+        关注: Count(user.following_count),
+        dynamicTYPE: dynamicTypeLabel,
+        cooperation_info: cooperationInfo
+      }, renderOpts)
+    }
+
+    case DouyinWorkMainType.IMAGE: {
+      return await Render(e, 'douyin/image-work', {
+        image_url: coverUrl,
+        desc: desc(Detail_Data.desc),
+        dianzan: Count(Detail_Data.statistics.digg_count),
+        pinglun: Count(Detail_Data.statistics.comment_count),
+        share: Count(Detail_Data.statistics.share_count),
+        shouchang: Count(Detail_Data.statistics.collect_count),
+        create_time: formatTime,
+        avater_url: avatarUrl,
+        share_url: shareLink,
+        username: user.nickname,
+        抖音号: userDouyinId,
+        粉丝: Count(user.follower_count),
+        获赞: Count(user.total_favorited),
+        关注: Count(user.following_count),
+        dynamicTYPE: dynamicTypeLabel,
+        cooperation_info: cooperationInfo
+      }, renderOpts)
+    }
+
+    default:
+      return []
+  }
+}
+
+/** 喜欢列表/推荐列表推送图片渲染参数 */
+export interface RenderFavoriteRecommendOptions {
+  /** Karin 消息事件 */
+  e: Message
+  /** 作品详情数据，包含 user_info（订阅者/推荐者）、author（作品作者）、author_user_info（作者用户信息）、statistics */
+  Detail_Data: any
+  /** 作品创建时间（Unix 时间戳，秒） */
+  create_time: number
+  /** 分享链接地址 */
+  shareLink: string
+  /** 订阅者/推荐者昵称（remark） */
+  remark: string
+  /** 是否跳过水印 */
+  skipWatermark?: boolean
+}
+
+/**
+ * 渲染喜欢列表推送图片
+ * 展示用户喜欢的作品，同时显示点赞者和作品原作者的信息
+ * @param options - 渲染参数
+ * @returns 渲染后的图片元素数组
+ */
+export async function renderFavoriteImage (options: RenderFavoriteRecommendOptions): Promise<ImageElement[]> {
+  const { e, Detail_Data, create_time, shareLink, remark, skipWatermark = false } = options
+  const workTypeInfo = getWorkTypeInfo(Detail_Data)
+  const coverUrl = getWorkCoverUrl(workTypeInfo, Detail_Data)
+  const authorUserInfo = Detail_Data.author_user_info
+  const subscriberUser = Detail_Data.user_info.data.user
+
+  return await Render(e, 'douyin/favorite-list', {
+    image_url: coverUrl,
+    desc: desc(Detail_Data.desc),
+    dianzan: Count(Detail_Data.statistics.digg_count),
+    pinglun: Count(Detail_Data.statistics.comment_count),
+    share: Count(Detail_Data.statistics.share_count),
+    shouchang: Count(Detail_Data.statistics.collect_count),
+    tuijian: Count(Detail_Data.statistics.recommend_count),
+    create_time: format(fromUnixTime(create_time), 'yyyy-MM-dd HH:mm'),
+    liker_username: remark,
+    liker_avatar: cdnAvatar(subscriberUser.avatar_larger.uri),
+    liker_douyin_id: douyinId(subscriberUser),
+    author_username: Detail_Data.author.nickname,
+    author_avatar: authorUserInfo ? cdnAvatar(authorUserInfo.data.user.avatar_larger.uri) : Detail_Data.author.avatar_thumb.url_list[0],
+    author_douyin_id: authorUserInfo ? douyinId(authorUserInfo.data.user) : douyinId(Detail_Data.author),
+    share_url: shareLink
+  }, skipWatermark ? { skipWatermark: true } : undefined)
+}
+
+/**
+ * 渲染推荐列表推送图片
+ * 展示用户推荐的作品，同时显示推荐者和作品原作者的信息
+ * @param options - 渲染参数
+ * @returns 渲染后的图片元素数组
+ */
+export async function renderRecommendImage (options: RenderFavoriteRecommendOptions): Promise<ImageElement[]> {
+  const { e, Detail_Data, create_time, shareLink, remark, skipWatermark = false } = options
+  const workTypeInfo = getWorkTypeInfo(Detail_Data)
+  const coverUrl = getWorkCoverUrl(workTypeInfo, Detail_Data)
+  const authorUserInfo = Detail_Data.author_user_info
+  const recommenderUser = Detail_Data.user_info.data.user
+
+  return await Render(e, 'douyin/recommend-list', {
+    image_url: coverUrl,
+    desc: desc(Detail_Data.desc),
+    dianzan: Count(Detail_Data.statistics.digg_count),
+    pinglun: Count(Detail_Data.statistics.comment_count),
+    share: Count(Detail_Data.statistics.share_count),
+    shouchang: Count(Detail_Data.statistics.collect_count),
+    tuijian: Count(Detail_Data.statistics.recommend_count),
+    create_time: format(fromUnixTime(create_time), 'yyyy-MM-dd HH:mm'),
+    recommender_username: remark,
+    recommender_avatar: cdnAvatar(recommenderUser.avatar_larger.uri),
+    recommender_douyin_id: douyinId(recommenderUser),
+    author_username: Detail_Data.author.nickname,
+    author_avatar: authorUserInfo ? cdnAvatar(authorUserInfo.data.user.avatar_larger.uri) : Detail_Data.author.avatar_thumb.url_list[0],
+    author_douyin_id: authorUserInfo ? douyinId(authorUserInfo.data.user) : douyinId(Detail_Data.author),
+    share_url: shareLink
+  }, skipWatermark ? { skipWatermark: true } : undefined)
+}
+
+/** 直播状态推送图片渲染参数 */
+export interface RenderLiveImageOptions {
+  /** Karin 消息事件 */
+  e: Message
+  /** 直播详情数据，包含 user_info、room_data、live_data 等字段 */
+  Detail_Data: any
+  /** 是否跳过水印 */
+  skipWatermark?: boolean
+  /** 推送类型标签，显示在图片头部 */
+  dynamicTypeLabel?: string
+}
+
+/**
+ * 渲染直播状态推送图片
+ * 展示直播间封面、主播信息、在线人数、分区等数据
+ * 如果 room_data 或 live_data 缺失则返回空数组
+ * @param options - 渲染参数
+ * @returns 渲染后的图片元素数组
+ */
+export async function renderLiveImage (options: RenderLiveImageOptions): Promise<ImageElement[]> {
+  const { e, Detail_Data, skipWatermark = false } = options
+  const dynamicTypeLabel = options.dynamicTypeLabel ?? '直播动态推送'
+  const user = Detail_Data.user_info.data.user
+
+  if (!Detail_Data.room_data || !Detail_Data.live_data) return []
+
+  const liveItem = Detail_Data.live_data.data.data.data[0]
+  const room_data = Detail_Data.room_data
+  //@ts-ignore
+  const streamExtra = liveItem.stream_url?.extra
+  const resolution = streamExtra
+    ? `${streamExtra.width}x${streamExtra.height}`
+    //@ts-ignore
+    : liveItem.stream_url?.default_resolution
+
+  return await Render(e, 'douyin/live', {
+    //@ts-ignore
+    image_url: liveItem.cover?.url_list[0],
+    //@ts-ignore
+    text: liveItem.title,
+    partition_title: Detail_Data.live_data.data.data.partition_road_map?.partition?.title || '未知分区',
+    room_id: room_data.owner.web_rid,
+    //@ts-ignore
+    online_viewers: Count(Number(liveItem.room_view_stats?.display_value)),
+    //@ts-ignore
+    total_viewers: liveItem.stats?.total_user_str || '',
+    username: user.nickname,
+    avater_url: cdnAvatar(user.avatar_larger.uri),
+    fans: Count(user.follower_count),
+    share_url: 'https://live.douyin.com/' + room_data.owner.web_rid,
+    dynamicTYPE: dynamicTypeLabel,
+    //@ts-ignore
+    like_count: Count(Number(liveItem.like_count || 0)),
+    //@ts-ignore
+    user_count_str: liveItem.user_count_str || '',
+    resolution,
+    signature: user.signature || '',
+    //@ts-ignore
+    city: user.city || '',
+    aweme_count: Count(user.aweme_count || 0),
+    following_count: Count(user.following_count || 0),
+    total_favorited: Count(user.total_favorited || 0),
+    //@ts-ignore
+    has_commerce_goods: liveItem.has_commerce_goods || false
+  }, skipWatermark ? { skipWatermark: true } : undefined)
+}

--- a/packages/core/src/platform/douyin/push/render.ts
+++ b/packages/core/src/platform/douyin/push/render.ts
@@ -1,9 +1,17 @@
+import {
+  createHashtagNode,
+  createLineBreakNode,
+  createRichTextDocument,
+  createTextNode,
+  type RichTextDocument,
+  type RichTextNode
+} from '@kkk/richtext'
 import { format, fromUnixTime } from 'date-fns'
 import type { ImageElement, Message } from 'node-karin'
 
 import { Count, Render } from '@/module/utils'
 
-import { DouyinWorkMainType, getWorkCoverUrl, getWorkTypeInfo } from '../workType'
+import { DouyinWorkMainType, type DouyinWorkTypeInfo, getWorkCoverUrl, getWorkTypeInfo } from '../workType'
 
 /**
  * 处理作品描述
@@ -95,25 +103,250 @@ function cdnAvatar (uri: string): string {
   return 'https://p3-pc.douyinpic.com/aweme/1080x1080/' + uri
 }
 
+/** 图文内单张媒体的模板类型。 */
+type ImageMediaType = 'static' | 'live' | 'clip'
+
 /**
- * 构建图文作品图片列表
- * 从作品详情中提取全部图片 URL（排除封面首图），优先取中分辨率 url_list[1]
- * 限制最多返回 3 张预览图，并提供作品总图数供前端视觉锚点使用
- * @param images - 作品原始图片数组，每项包含 url_list（多分辨率 URL）
- * @returns 图片列表数据，若作品无多图则返回 undefined
+ * 解析图文/合辑中单张图片的媒体类型。
+ * clip_type 规则参考普通解析逻辑：2/空为静态图，5 为实况动图，4 为短片。
+ * @param image - 抖音 images 数组中的单项
+ * @returns 模板可识别的媒体类型
  */
-function buildImageList (images: Array<{ url_list: string[] }> | null | undefined): {
-  images: string[]
+function getImageMediaType (image: { clip_type?: number } | null | undefined): ImageMediaType {
+  switch (image?.clip_type) {
+    case 4:
+      return 'clip'
+    case 5:
+      return 'live'
+    case 2:
+    case undefined:
+    default:
+      return 'static'
+  }
+}
+
+/**
+ * 构建图文作品图片列表。
+ * 第一项为封面，后续最多保留 2 张预览图，并在每项上携带媒体类型。
+ * @param images - 作品原始图片数组，每项包含 url_list（多分辨率 URL）
+ * @param fallbackCover - images 缺失时使用的兜底封面
+ * @returns 图片列表数据
+ */
+function buildImageList (
+  images: Array<{ url_list: string[]; clip_type?: number }> | null | undefined,
+  fallbackCover: string
+): {
+  images: Array<{
+    url: string
+    media_type: ImageMediaType
+  }>
   total_count: number
-} | undefined {
-  if (!images || images.length <= 1) return undefined
+} {
+  if (!images || images.length === 0) {
+    return {
+      images: fallbackCover
+        ? [{ url: fallbackCover, media_type: 'static' }]
+        : [],
+      total_count: fallbackCover ? 1 : 0
+    }
+  }
 
-  const total_count = images.length
-  const previews = images.slice(1, 4).map(
-    (img) => img.url_list[1] ?? img.url_list[0] ?? img.url_list[2] ?? ''
-  ).filter(Boolean)
+  const usedUrls = new Set<string>()
+  const imageItems = images.map((img, index) => ({
+    url: index === 0
+      ? (img.url_list[2] ?? img.url_list[1] ?? img.url_list[0] ?? fallbackCover)
+      : (img.url_list[1] ?? img.url_list[0] ?? img.url_list[2] ?? ''),
+    media_type: getImageMediaType(img)
+  })).filter((item) => {
+    if (!item.url) return false
+    const key = normalizeImageUrl(item.url)
+    if (usedUrls.has(key)) return false
+    usedUrls.add(key)
+    return true
+  }).slice(0, 3)
 
-  return { images: previews, total_count }
+  return {
+    images: imageItems,
+    total_count: images.length
+  }
+}
+
+/**
+ * 去掉签名参数，避免同一张图因 CDN 查询参数不同被重复放入预览列表。
+ * @param url - 原始图片 URL
+ * @returns 用于去重的稳定 URL key
+ */
+function normalizeImageUrl (url: string): string {
+  try {
+    const parsed = new URL(url)
+    return `${parsed.host}${parsed.pathname}`
+  } catch {
+    return url.split('?')[0]
+  }
+}
+
+/**
+ * 将作品描述按首句句号/感叹号/问号拆分为标题和正文
+ * @param desc - 原始描述文本
+ * @returns `{ title, body }`，若无句点分隔符则 title 为空字符串
+ */
+function splitTitleAndBody (desc: string): { title: string; body: string } {
+  const match = desc.match(/^[^。！？!?\n]*[。！？!?]/)
+  if (!match) return { title: '', body: desc }
+  const title = match[0].replace(/[。！？!?]$/, '')
+  const body = desc.slice(match[0].length)
+  return { title, body }
+}
+
+/**
+ * 根据抖音作品描述和 text_extra 构建富文本文档
+ * 普通正文走 text 节点，换行走 lineBreak 节点，hashtag 走纯文字高亮节点。
+ * @param body - 去除标题后的正文部分
+ * @param textExtra - 抖音作品 text_extra 数组（含 hashtag 起止位置与 hashtag_name）
+ * @param titleOffset - 正文在原始 desc 中的起始偏移字符数
+ * @returns 构建好的 RichTextDocument
+ */
+function buildDescRichText (
+  body: string,
+  textExtra?: Array<{ start: number; end: number; hashtag_name?: string; hashtag_id?: string; type?: number }>,
+  titleOffset = 0
+): RichTextDocument {
+  if (!body) return createRichTextDocument([], { platform: 'douyin' })
+
+  const hashtags = (textExtra ?? [])
+    .filter((item): item is { start: number; end: number; hashtag_name: string; hashtag_id?: string; type: number } =>
+      item.type === 1 && !!item.hashtag_name && typeof item.start === 'number' && typeof item.end === 'number')
+    .map((item) => ({
+      start: item.start - titleOffset,
+      end: item.end - titleOffset,
+      name: '#' + item.hashtag_name
+    }))
+    .filter((item) => item.start >= 0 && item.end > item.start && item.end <= body.length)
+    .sort((a, b) => a.start - b.start)
+
+  const nodes: RichTextNode[] = []
+  let cursor = 0
+
+  for (const tag of hashtags) {
+    if (tag.start < cursor) continue
+    const before = body.slice(cursor, tag.start)
+    appendTextSegments(before, nodes)
+    nodes.push(createHashtagNode(tag.name))
+    cursor = tag.end
+  }
+
+  appendTextSegments(body.slice(cursor), nodes)
+  return createRichTextDocument(nodes, { platform: 'douyin' })
+}
+
+/**
+ * 将文本按换行拆分为 text 节点和 lineBreak 节点并推入目标数组
+ */
+function appendTextSegments (
+  text: string,
+  target: RichTextNode[]
+) {
+  if (!text) return
+  const parts = text.split(/(\r?\n)/)
+  for (const part of parts) {
+    if (part === '\r\n' || part === '\n') {
+      target.push(createLineBreakNode())
+    } else if (part) {
+      target.push(createTextNode(part))
+    }
+  }
+}
+
+/**
+ * 提取博主 IP 属地
+ * @param Detail_Data - 作品详情数据
+ * @returns IP 属地文本（如 "重庆"），不存在时返回 undefined
+ */
+function extractIpLocation (Detail_Data: any): string | undefined {
+  let raw: string | undefined = Detail_Data.user_info?.data?.user?.ip_location
+  if (!raw) raw = Detail_Data.ip_location
+  if (!raw || typeof raw !== 'string') return undefined
+  const label = raw.replace(/^IP属地[：:]?\s*/, '').trim()
+  return label || undefined
+}
+
+/**
+ * 从 suggest_words 中随机选择一条热点词
+ * @param Detail_Data - 作品详情数据
+ * @returns `{ hint_text, word }` 或 undefined
+ */
+function extractSuggestWord (Detail_Data: any): { hint_text: string; word: string } | undefined {
+  const groups = Detail_Data.suggest_words?.suggest_words
+  if (!Array.isArray(groups) || groups.length === 0) return undefined
+  const group = groups[0]
+  const words: Array<{ word?: string }> = Array.isArray(group?.words) ? group.words : []
+  if (words.length === 0) return undefined
+  const pick = words[Math.floor(Math.random() * words.length)]
+  if (!pick?.word) return undefined
+  return {
+    hint_text: group.hint_text ?? '大家都在搜：',
+    word: pick.word
+  }
+}
+
+/**
+ * 从抖音图片对象中提取第一个可用 URL。
+ * @param images - 可能存在的多种封面对象
+ * @returns 可直接渲染的图片 URL，不存在时返回 undefined
+ */
+function pickImageUrl (...images: any[]): string | undefined {
+  for (const image of images) {
+    const url = image?.url_list?.find((item: unknown): item is string => typeof item === 'string' && item.length > 0)
+    if (url) return url
+  }
+  return undefined
+}
+
+/**
+ * 安全解析 music.extra JSON。
+ * @param extra - 抖音 music.extra 原始字符串
+ * @returns 解析后的对象，解析失败时返回空对象
+ */
+function parseMusicExtra (extra: unknown): Record<string, any> {
+  if (typeof extra !== 'string' || extra.length === 0) return {}
+  try {
+    return JSON.parse(extra)
+  } catch {
+    return {}
+  }
+}
+
+/**
+ * 构建图文作品 BGM 展示信息。
+ * 优先使用 matched_pgc_sound 的标准曲目信息，再回退到原声/作者字段和 extra 中的映射标题。
+ * @param music - 抖音作品 music 字段
+ * @returns 可传给模板的音乐信息；无有效音乐数据时返回 undefined
+ */
+function buildMusicInfo (music: any): { author: string; title: string; cover?: string } | undefined {
+  if (!music || typeof music !== 'object') return undefined
+
+  const extra = parseMusicExtra(music.extra)
+  const matched = music.matched_pgc_sound
+  const title = matched?.title || matched?.mixed_title || extra.music_display_mapping_title || music.title
+  const author = matched?.author || matched?.mixed_author || music.author || music.owner_nickname
+  const cover = pickImageUrl(
+    matched?.cover_medium,
+    music.cover_hd,
+    music.cover_large,
+    music.cover_medium,
+    music.cover_thumb,
+    music.avatar_large,
+    music.avatar_medium,
+    music.avatar_thumb
+  )
+
+  if (!title && !author && !cover) return undefined
+
+  return {
+    title: title || '未知音乐',
+    author: author || '未知作者',
+    cover
+  }
 }
 
 /**
@@ -142,16 +375,30 @@ export interface RenderWorkImageOptions {
 }
 
 /**
+ * 根据作品类型计算默认推送标签
+ * @param workTypeInfo - 作品类型信息
+ * @returns 视频/图文/合辑/文章/直播 之一的推送标签
+ */
+function getDefaultPushLabel (workTypeInfo: DouyinWorkTypeInfo): string {
+  if (workTypeInfo.isVideo) return '视频作品推送'
+  if (workTypeInfo.isArticle) return '文章作品推送'
+  if (workTypeInfo.isCollection) return '合辑作品推送'
+  if (workTypeInfo.isImage) return '图文作品推送'
+  if (workTypeInfo.isLive) return '直播动态推送'
+  return '作品动态推送'
+}
+
+/**
  * 渲染作品推送图片
- * 根据作品类型（文章/视频/图文）自动选择对应模板进行渲染
- * 支持视频、图集、文章三种作品类型，未知类型返回空数组
+ * 根据作品类型（文章/视频/图文/合辑）自动选择对应模板进行渲染
+ * 推送类型标签按优先级：调用方显式传入 → 根据作品主/子类型自动计算
  * @param options - 渲染参数
  * @returns 渲染后的图片元素数组
  */
 export async function renderWorkImage (options: RenderWorkImageOptions): Promise<ImageElement[]> {
   const { e, Detail_Data, create_time, shareLink, skipWatermark = false } = options
-  const dynamicTypeLabel = options.dynamicTypeLabel ?? '作品动态推送'
   const workTypeInfo = getWorkTypeInfo(Detail_Data)
+  const dynamicTypeLabel = options.dynamicTypeLabel ?? getDefaultPushLabel(workTypeInfo)
   const coverUrl = getWorkCoverUrl(workTypeInfo, Detail_Data)
   const formatTime = format(fromUnixTime(create_time), 'yyyy-MM-dd HH:mm')
   const user = Detail_Data.user_info.data.user
@@ -187,14 +434,27 @@ export async function renderWorkImage (options: RenderWorkImageOptions): Promise
     }
 
     case DouyinWorkMainType.VIDEO: {
+      const rawDesc = Detail_Data.desc ?? ''
+      const { title, body } = splitTitleAndBody(rawDesc)
+      const titleOffset = rawDesc.length - body.length
+      const richDesc = title || body
+        ? buildDescRichText(desc(body), Detail_Data.text_extra, titleOffset)
+        : undefined
+
       return await Render(e, 'douyin/video-work', {
         image_url: coverUrl,
-        desc: desc(Detail_Data.desc),
+        title: title || undefined,
+        desc: desc(rawDesc),
+        rich_desc: richDesc,
+        ip_location: extractIpLocation(Detail_Data),
+        suggest_word: extractSuggestWord(Detail_Data),
+        music: buildMusicInfo(Detail_Data.music),
+        duration: Detail_Data.duration,
         dianzan: Count(Detail_Data.statistics.digg_count),
         pinglun: Count(Detail_Data.statistics.comment_count),
         share: Count(Detail_Data.statistics.share_count),
         shouchang: Count(Detail_Data.statistics.collect_count),
-        create_time: formatTime,
+        create_time,
         avater_url: avatarUrl,
         share_url: shareLink,
         username: user.nickname,
@@ -211,15 +471,25 @@ export async function renderWorkImage (options: RenderWorkImageOptions): Promise
       const cover = Detail_Data.images?.[0]?.url_list[2]
         ?? Detail_Data.images?.[0]?.url_list[1]
         ?? coverUrl
+      const rawDesc = Detail_Data.desc ?? ''
+      const { title, body } = splitTitleAndBody(rawDesc)
+      const titleOffset = rawDesc.length - body.length
+      const richDesc = title || body
+        ? buildDescRichText(desc(body), Detail_Data.text_extra, titleOffset)
+        : undefined
       return await Render(e, 'douyin/image-work', {
-        image_url: cover,
-        image_list: buildImageList(Detail_Data.images),
-        desc: desc(Detail_Data.desc),
+        image_list: buildImageList(Detail_Data.images, cover),
+        title: title || undefined,
+        desc: desc(rawDesc),
+        rich_desc: richDesc,
+        ip_location: extractIpLocation(Detail_Data),
+        suggest_word: extractSuggestWord(Detail_Data),
+        music: buildMusicInfo(Detail_Data.music),
         dianzan: Count(Detail_Data.statistics.digg_count),
         pinglun: Count(Detail_Data.statistics.comment_count),
         share: Count(Detail_Data.statistics.share_count),
         shouchang: Count(Detail_Data.statistics.collect_count),
-        create_time: formatTime,
+        create_time,
         avater_url: avatarUrl,
         share_url: shareLink,
         username: user.nickname,

--- a/packages/core/src/platform/douyin/push/render.ts
+++ b/packages/core/src/platform/douyin/push/render.ts
@@ -96,6 +96,27 @@ function cdnAvatar (uri: string): string {
 }
 
 /**
+ * 构建图文作品图片列表
+ * 从作品详情中提取全部图片 URL（排除封面首图），优先取中分辨率 url_list[1]
+ * 限制最多返回 3 张预览图，并提供作品总图数供前端视觉锚点使用
+ * @param images - 作品原始图片数组，每项包含 url_list（多分辨率 URL）
+ * @returns 图片列表数据，若作品无多图则返回 undefined
+ */
+function buildImageList (images: Array<{ url_list: string[] }> | null | undefined): {
+  images: string[]
+  total_count: number
+} | undefined {
+  if (!images || images.length <= 1) return undefined
+
+  const total_count = images.length
+  const previews = images.slice(1, 4).map(
+    (img) => img.url_list[1] ?? img.url_list[0] ?? img.url_list[2] ?? ''
+  ).filter(Boolean)
+
+  return { images: previews, total_count }
+}
+
+/**
  * 获取用户抖音号
  * @param user - 用户对象，包含 unique_id 和 short_id
  * @returns 优先返回抖音号（unique_id），为空则返回短 ID
@@ -187,8 +208,12 @@ export async function renderWorkImage (options: RenderWorkImageOptions): Promise
     }
 
     case DouyinWorkMainType.IMAGE: {
+      const cover = Detail_Data.images?.[0]?.url_list[2]
+        ?? Detail_Data.images?.[0]?.url_list[1]
+        ?? coverUrl
       return await Render(e, 'douyin/image-work', {
-        image_url: coverUrl,
+        image_url: cover,
+        image_list: buildImageList(Detail_Data.images),
         desc: desc(Detail_Data.desc),
         dianzan: Count(Detail_Data.statistics.digg_count),
         pinglun: Count(Detail_Data.statistics.comment_count),

--- a/packages/richtext/src/parse/index.ts
+++ b/packages/richtext/src/parse/index.ts
@@ -3,6 +3,7 @@ import type {
   RichTextCodeBlockNode,
   RichTextDocument,
   RichTextEmojiNode,
+  RichTextHashtagNode,
   RichTextHeadingNode,
   RichTextImageNode,
   RichTextLineBreakNode,
@@ -168,6 +169,16 @@ export const createLinkCardNode = (
 })
 
 /**
+ * 创建 hashtag 节点。
+ *
+ * 纯文本高亮，不带任何图标。适用于抖音等平台的 #话题# 展示。
+ */
+export const createHashtagNode = (text: string): RichTextHashtagNode => ({
+  type: 'hashtag',
+  text
+})
+
+/**
  * 合并相邻文本节点并丢弃空文本节点。
  *
  * 这样 core 可以按匹配过程简单 push 节点，最后统一整理，避免前端拿到碎片过多的数据。
@@ -212,6 +223,7 @@ export const extractRichTextPlainText = (document: RichTextDocument): string => 
       case 'webLink':
       case 'vote':
       case 'viewPicture':
+      case 'hashtag':
       case 'emoji':
         return 'text' in node ? (node as any).text ?? '' : (node as any).name ?? ''
       case 'heading':

--- a/packages/richtext/src/react/index.tsx
+++ b/packages/richtext/src/react/index.tsx
@@ -364,6 +364,17 @@ const renderNodeToReact = (
         </span>
       )
 
+    case 'hashtag':
+      return (
+        <span
+          key={`hashtag-${index}`}
+          className={options.hashtag?.className}
+          data-richtext-node='hashtag'
+        >
+          {node.text}
+        </span>
+      )
+
     case 'at':
       return (
         <span

--- a/packages/richtext/src/types.ts
+++ b/packages/richtext/src/types.ts
@@ -20,6 +20,7 @@ export type RichTextInlineNode =
   | RichTextWebLinkNode
   | RichTextVoteNode
   | RichTextViewPictureNode
+  | RichTextHashtagNode
 
 /** 块级节点。 */
 export type RichTextBlockNode =
@@ -154,6 +155,18 @@ export interface RichTextViewPictureNode {
   text: string
 }
 
+/**
+ * Hashtag 话题节点。
+ *
+ * 纯文本高亮，不带任何图标。用于抖音等平台的 #话题# 标签展示。
+ * 与 topic 节点的区别：topic 带有 B站风格的 # 图标，hashtag 只做纯文字高亮。
+ */
+export interface RichTextHashtagNode {
+  type: 'hashtag'
+  /** 话题文本（包含 # 号） */
+  text: string
+}
+
 /** 标题节点。 */
 export interface RichTextHeadingNode {
   type: 'heading'
@@ -285,6 +298,8 @@ export interface RichTextRenderOptions {
   codeBlock?: RichTextNodeStyleConfig
   /** 链接卡片节点 */
   linkCard?: RichTextNodeStyleConfig
+  /** hashtag 话题节点 */
+  hashtag?: RichTextNodeStyleConfig
   /** 图标缩放比例，默认 1。用于在不同字体大小下保持图标比例一致。 */
   iconScale?: number
 }

--- a/packages/template/src/components/platforms/douyin/ImageWork.tsx
+++ b/packages/template/src/components/platforms/douyin/ImageWork.tsx
@@ -1,25 +1,56 @@
-import { ChatIcon, HeartIcon, ShareIcon, UsersIcon } from '@phosphor-icons/react'
-import { format } from 'date-fns'
-import { Bookmark, Hash, Maximize } from 'lucide-react'
+import { renderRichTextToReact } from '@kkk/richtext'
+import { BookmarkIcon, ChatIcon, HeartIcon, ImageIcon, MapPinIcon, MusicNoteIcon, ShareFatIcon, UserPlusIcon, UsersIcon, UsersThreeIcon, VideoCameraIcon } from '@phosphor-icons/react'
+import { format, formatDistanceToNow, fromUnixTime } from 'date-fns'
+import { zhCN } from 'date-fns/locale'
+import { Clock3, Hash, Maximize } from 'lucide-react'
 import React from 'react'
 
-import type { DouyinImageWorkProps } from '../../../types/platforms/douyin/imageWork'
+import type { DouyinImageMediaType, DouyinImageWorkProps } from '../../../types/platforms/douyin/imageWork'
 import { cn } from '../../../utils/cn'
 import { generateQRCode } from '../../../utils/QRcode'
 import { DefaultLayout } from '../../layouts/DefaultLayout'
 
-const DouyinAvatarUserInfo: React.FC<{
-  avatarUrl: string
-  username: string
-  douyinId: string
-  useDarkTheme?: boolean
-}> = ({ avatarUrl, username, douyinId, useDarkTheme }) => {
+type Props = Omit<DouyinImageWorkProps, 'templateType' | 'templateName'>
+
+/** 抖音实况图标，来源于根目录 noun-live-photo-710576.svg 的 React 化精简版。 */
+const LivePhotoIcon: React.FC<{ size?: number; className?: string }> = ({ size = 28, className }) => (
+  <svg
+    width={size}
+    height={size}
+    viewBox='0 0 100 100'
+    fill='none'
+    xmlns='http://www.w3.org/2000/svg'
+    className={className}
+    aria-hidden='true'
+  >
+    <circle cx='50' cy='50' r='37' stroke='currentColor' strokeWidth='6' strokeDasharray='2 9' strokeLinecap='round' />
+    <circle cx='50' cy='50' r='25' stroke='currentColor' strokeWidth='6' />
+    <circle cx='50' cy='50' r='10' fill='currentColor' />
+  </svg>
+)
+
+/** 首图媒体类型徽标配置。 */
+const imageMediaTypeMeta = {
+  static: { label: '静态', icon: ImageIcon },
+  live: { label: '动图', icon: LivePhotoIcon },
+  clip: { label: '短片', icon: VideoCameraIcon }
+} satisfies Record<DouyinImageMediaType, {
+  label: string
+  icon: React.FC<{ size?: number; className?: string; weight?: 'fill' }>
+}>
+
+const DouyinAvatarUserInfo: React.FC<Props> = (props) => {
+  const { avater_url, username, create_time, useDarkTheme, dynamicTYPE } = props.data
+  const publishTime = formatDistanceToNow(fromUnixTime(create_time), {
+    addSuffix: true,
+    locale: zhCN
+  })
   return (
     <div className='flex gap-10 items-center justify-between px-0 pb-0 pl-24 pr-10'>
       <div className='flex gap-10 items-center'>
         <div className='flex justify-center items-center bg-white rounded-full w-35 h-35'>
           <img
-            src={avatarUrl}
+            src={avater_url}
             alt='头像'
             className='rounded-full w-33 h-33 shadow-large'
             referrerPolicy='no-referrer'
@@ -31,54 +62,108 @@ const DouyinAvatarUserInfo: React.FC<{
             {username}
           </div>
           <div className='flex gap-2 items-center text-4xl font-normal whitespace-nowrap text-muted'>
-            <Hash size={40} />
-            <span className='select-text'>{douyinId}</span>
+            <Clock3 size={40} />
+            <span className='select-text'>{publishTime}</span>
           </div>
         </div>
       </div>
-      <div className='shrink-0'>
+      <div className='shrink-0 flex flex-col items-end gap-2'>
         <img
           src={useDarkTheme ? '/image/douyin/dylogo-light.svg' : '/image/douyin/dylogo-dark.svg'}
           alt='抖音'
           className='h-20 w-auto object-contain'
         />
+        {dynamicTYPE && (
+          <div className='px-6 py-2 rounded-full bg-surface-secondary text-2xl font-medium text-muted select-text tracking-widest'>
+            {dynamicTYPE}
+          </div>
+        )}
       </div>
     </div>
   )
 }
 
-const DouyinCoverImage: React.FC<{
-  imageUrl: string
-  imageList?: { images: string[]; total_count: number }
-}> = ({ imageUrl, imageList }) => {
-  const previews = imageList?.images ?? []
-  const totalCount = imageList?.total_count ?? 1
+const DouyinCoverImage: React.FC<Props> = (props) => {
+  const { image_list, music } = props.data
+  const imageItems = image_list.images
+  const cover = imageItems[0]
+  const previews = imageItems.slice(1)
+  const totalCount = image_list.total_count
   const previewItems = previews.slice(0, 2)
+  if (!cover?.url) return null
+
+  const firstMediaType = cover?.media_type ?? 'static'
+  const firstMediaMeta = imageMediaTypeMeta[firstMediaType]
+  const FirstMediaIcon = firstMediaMeta.icon
+  const firstMediaBadge = (
+    <div className='absolute top-7 right-7 z-20 flex items-center gap-2 px-4 py-2 rounded-2xl bg-black/50 backdrop-blur-sm text-white shadow-large'>
+      <FirstMediaIcon size={34} className='text-white' weight='fill' />
+      <span className='text-3xl font-medium select-text'>{firstMediaMeta.label}</span>
+    </div>
+  )
+  const musicBadge = music && (
+    <div className='absolute left-7 bottom-7 z-20 flex items-center gap-4 max-w-[72%] p-3 rounded-3xl bg-black/45 backdrop-blur-2xl border border-white/20 shadow-large overflow-hidden'>
+      <div className='relative shrink-0 w-18 h-18'>
+        {music.cover
+          ? (
+            <>
+              <img
+                src={music.cover}
+                alt=''
+                className='absolute inset-0 w-full h-full rounded-2xl object-cover blur-md scale-110 opacity-70'
+                referrerPolicy='no-referrer'
+                crossOrigin='anonymous'
+              />
+              <img
+                src={music.cover}
+                alt='BGM封面'
+                className='relative z-10 w-full h-full rounded-2xl object-cover'
+                referrerPolicy='no-referrer'
+                crossOrigin='anonymous'
+              />
+            </>
+          )
+          : (
+            <div className='flex items-center justify-center w-full h-full rounded-2xl bg-white/15 text-white'>
+              <MusicNoteIcon size={36} weight='fill' />
+            </div>
+          )}
+      </div>
+      <div className='flex flex-col gap-1 min-w-0 pr-2 text-white'>
+        <span className='text-3xl font-semibold truncate select-text'>{music.title}</span>
+        <span className='text-2xl text-white/85 truncate select-text'>{music.author}</span>
+      </div>
+    </div>
+  )
 
   if (previewItems.length === 0) {
     return (
       <div className='px-20'>
-        <div className='overflow-hidden rounded-5xl shadow-large'>
+        <div className='relative overflow-hidden rounded-5xl shadow-large'>
           <img
-            src={imageUrl}
+            src={cover.url}
             alt='图文封面'
             className='object-contain w-full h-auto'
             referrerPolicy='no-referrer'
             crossOrigin='anonymous'
           />
+          {firstMediaBadge}
+          {musicBadge}
         </div>
       </div>
     )
   }
 
-  const stack: Array<{ url: string; opacity: number; shift: number }> = [
-    { url: imageUrl, opacity: 1, shift: 0 },
-    ...previewItems.map((url, idx) => ({
-      url,
-      opacity: idx === 0 ? 0.55 : 0.1,
+  const stack: Array<{ url: string; filter: string; shift: number }> = [
+    { url: cover.url, filter: 'none', shift: 0 },
+    ...previewItems.map((item, idx) => ({
+      url: item.url,
+      filter: idx === 0
+        ? 'brightness(0.88) saturate(0.86) contrast(0.96) blur(1px) opacity(0.8)'
+        : 'brightness(0.78) saturate(0.68) contrast(0.9) blur(3px) opacity(0.6)',
       shift: (idx + 1) * 16
     }))
-  ]
+  ].filter((item) => item.url)
 
   return (
     <div className='px-20'>
@@ -104,6 +189,8 @@ const DouyinCoverImage: React.FC<{
                     <span className='text-3xl font-medium text-white select-text'>共 {totalCount} 张</span>
                   </div>
                 )}
+                {firstMediaBadge}
+                {musicBadge}
               </div>
             )
             : (
@@ -112,14 +199,14 @@ const DouyinCoverImage: React.FC<{
                 className='absolute inset-0 overflow-hidden rounded-5xl shadow-large'
                 style={{
                   transform: `translate(${item.shift}px, ${item.shift * 2}px)`,
-                  zIndex: stack.length - idx,
-                  opacity: item.opacity
+                  zIndex: stack.length - idx
                 }}
               >
                 <img
                   src={item.url}
                   alt={`预览图 ${idx + 1}`}
                   className='w-full h-full object-cover object-center'
+                  style={{ filter: item.filter }}
                   referrerPolicy='no-referrer'
                   crossOrigin='anonymous'
                 />
@@ -131,67 +218,84 @@ const DouyinCoverImage: React.FC<{
   )
 }
 
-const DouyinDynamicContent: React.FC<{ desc: string }> = ({ desc }) => {
+const DouyinDynamicContent: React.FC<Props> = (props) => {
+  const { title, desc, rich_desc } = props.data
+  const bodyNode = rich_desc
+    ? renderRichTextToReact(rich_desc, {
+      hashtag: {
+        className: 'text-[#04498d] dark:text-[#face15] font-medium'
+      }
+    })
+    : desc
+
   return (
     <div className='flex flex-col px-20 w-full leading-relaxed'>
+      {title && (
+        <div className='text-[72px] font-bold leading-tight mb-8 text-foreground select-text' style={{ wordBreak: 'break-word', overflowWrap: 'break-word' }}>
+          {title}
+        </div>
+      )}
       <div
-        className='text-[60px] tracking-[0.5px] leading-[1.6] whitespace-pre-wrap text-foreground select-text'
-        style={{
-          wordBreak: 'break-word',
-          overflowWrap: 'break-word'
-        }}
-        dangerouslySetInnerHTML={{ __html: desc }}
-      />
+        className='text-[56px] tracking-[0.5px] leading-[1.7] whitespace-pre-wrap text-foreground select-text'
+        style={{ wordBreak: 'break-word', overflowWrap: 'break-word' }}
+      >
+        {bodyNode}
+      </div>
     </div>
   )
 }
 
-const DouyinDynamicStatus: React.FC<{
-  dianzan: string
-  pinglun: string
-  shouchang: string
-  share: string
-  publishTime: string
-  renderTime: string
-}> = ({ dianzan, pinglun, shouchang, share, renderTime }) => {
+const DouyinDynamicStatus: React.FC<Props> = (props) => {
+  const { dianzan, pinglun, shouchang, share, ip_location, suggest_word } = props.data
+  const renderTime = format(new Date(), 'yyyy-MM-dd HH:mm:ss')
   const stats = [
     { icon: HeartIcon, value: dianzan, label: '点赞' },
     { icon: ChatIcon, value: pinglun, label: '评论' },
-    { icon: Bookmark, value: shouchang, label: '收藏', isLucide: true },
-    { icon: ShareIcon, value: share, label: '分享' }
+    { icon: BookmarkIcon, value: shouchang, label: '收藏' },
+    { icon: ShareFatIcon, value: share, label: '分享' }
   ]
 
   return (
     <div className='flex flex-col gap-10 px-18 w-full leading-relaxed'>
-      <div className='flex gap-6 items-center text-5xl font-light tracking-normal select-text text-foreground/70'>
+      <div className='flex gap-6 items-center text-5xl tracking-normal select-text text-foreground/70'>
         {stats.map((stat, idx) => {
           const Icon = stat.icon
           return (
             <React.Fragment key={stat.label}>
               {idx > 0 && <span>·</span>}
-              <div className='flex gap-2 items-center'>
-                {stat.isLucide
-                  ? <Icon size={50} />
-                  : <Icon size={50} weight='fill' className='mt-2' />
-                }
-                {stat.value}{stat.label}
+              <div className='flex gap-2 items-end'>
+                <Icon size={50} weight='fill' className='mt-2' />
+                <span className='font-medium'>{stat.value}</span>
+                <span className='text-3xl font-light'>{stat.label}</span>
               </div>
             </React.Fragment>
           )
         })}
       </div>
-      <div className='flex gap-2 items-center text-5xl font-light tracking-normal select-text text-foreground/70'>
-        <Maximize size={48} />
+      {ip_location && (
+        <div className='flex gap-12 items-center font-light select-text text-foreground/70'>
+          <div className='flex gap-2 items-center'>
+            <MapPinIcon size={50} weight='fill' className='mt-1' />
+            <span className='text-5xl font-medium'>{ip_location}</span>
+          </div>
+          {suggest_word && (
+            <div className='flex gap-2 items-center py-3.5 px-6 bg-foreground/5 dark:bg-foreground/10 rounded-full text-4xl font-light select-text text-foreground/70'>
+              <span className='text-muted'>{suggest_word.hint_text}</span>
+              <span className='text-[#04498d] dark:text-[#face15] font-medium'>{suggest_word.word}</span>
+            </div>
+          )}
+        </div>
+      )}
+      <div className='flex gap-3 items-center text-4xl font-light tracking-normal select-text text-foreground/70'>
+        <Maximize size={44} />
         图片生成于: {renderTime}
       </div>
     </div>
   )
 }
 
-const DouyinCoCreatorList: React.FC<{
-  info?: DouyinImageWorkProps['data']['cooperation_info']
-}> = ({ info }) => {
-  const creators = info?.co_creators ?? []
+const DouyinCoCreatorList: React.FC<Props> = (props) => {
+  const creators = props.data.cooperation_info?.co_creators ?? []
   if (creators.length === 0) return null
 
   const items = creators.slice(0, 50)
@@ -266,20 +370,12 @@ const DouyinCoCreatorList: React.FC<{
   )
 }
 
-const DouyinDynamicFooter: React.FC<{
-  avatarUrl: string
-  username: string
-  douyinId: string
-  dianzan: string
-  following: string
-  fans: string
-  shareUrl: string
-  useDarkTheme?: boolean
-}> = ({ avatarUrl, username, douyinId, dianzan, following, fans, shareUrl, useDarkTheme }) => {
+const DouyinDynamicFooter: React.FC<Props> = (props) => {
+  const { avater_url, username, 抖音号, 获赞, 关注, 粉丝, share_url, useDarkTheme } = props.data
   const stats = [
-    { icon: HeartIcon, iconSize: 36, label: '获赞', value: dianzan },
-    { icon: UsersIcon, iconSize: 36, label: '关注', value: following },
-    { icon: UsersIcon, iconSize: 36, label: '粉丝', value: fans, filled: true }
+    { icon: HeartIcon, iconSize: 36, label: '获赞', value: 获赞 },
+    { icon: UserPlusIcon, iconSize: 36, label: '关注', value: 关注 },
+    { icon: UsersThreeIcon, iconSize: 36, label: '粉丝', value: 粉丝 }
   ]
 
   return (
@@ -289,7 +385,7 @@ const DouyinDynamicFooter: React.FC<{
           <div className='relative shrink-0'>
             <div className='flex justify-center items-center bg-white rounded-full w-35 h-35'>
               <img
-                src={avatarUrl}
+                src={avater_url}
                 alt='头像'
                 className='rounded-full w-33 h-33 shadow-large'
                 referrerPolicy='no-referrer'
@@ -303,7 +399,7 @@ const DouyinDynamicFooter: React.FC<{
             </div>
             <div className='flex gap-2 items-center text-4xl text-muted'>
               <Hash size={32} />
-              <span className='select-text'>抖音号: {douyinId}</span>
+              <span className='select-text'>抖音号: {抖音号}</span>
             </div>
           </div>
         </div>
@@ -314,7 +410,7 @@ const DouyinDynamicFooter: React.FC<{
             return (
               <div key={stat.label} className='flex flex-col gap-1 items-start px-6 py-3 rounded-2xl bg-surface'>
                 <div className='flex gap-1 items-center'>
-                  <Icon size={stat.iconSize} weight={stat.filled ? 'fill' : undefined} />
+                  <Icon size={stat.iconSize} weight='fill' />
                   <span className='text-muted'>{stat.label}</span>
                 </div>
                 <div className='w-full h-px bg-border' />
@@ -327,7 +423,7 @@ const DouyinDynamicFooter: React.FC<{
 
       <div className='flex flex-col items-center gap-4'>
         <img
-          src={generateQRCode(shareUrl, useDarkTheme)}
+          src={generateQRCode(share_url, useDarkTheme)}
           alt='二维码'
           className='h-auto w-75 rounded-2xl'
         />
@@ -336,9 +432,7 @@ const DouyinDynamicFooter: React.FC<{
   )
 }
 
-export const DouyinImageWork: React.FC<Omit<DouyinImageWorkProps, 'templateType' | 'templateName'>> = React.memo((props) => {
-  const renderTime = format(new Date(), 'yyyy-MM-dd HH:mm:ss')
-
+export const DouyinImageWork: React.FC<Props> = React.memo((props) => {
   const coCreatorCount =
     props.data.cooperation_info?.co_creator_nums ??
     (props.data.cooperation_info?.co_creators?.length ?? undefined)
@@ -349,31 +443,21 @@ export const DouyinImageWork: React.FC<Omit<DouyinImageWorkProps, 'templateType'
       <div className='p-4'>
         <div className='h-25' />
 
-        <DouyinAvatarUserInfo
-          avatarUrl={props.data.avater_url}
-          username={props.data.username}
-          douyinId={props.data.抖音号}
-          useDarkTheme={props.data.useDarkTheme}
-        />
+        <DouyinAvatarUserInfo {...props} />
 
         <div className='h-15' />
 
-        <DouyinDynamicContent desc={props.data.desc} />
+        <DouyinDynamicContent {...props} />
 
         <div className='h-15' />
 
-        <DouyinCoverImage imageUrl={props.data.image_url} imageList={props.data.image_list} />
+        <DouyinCoverImage {...props} />
 
-        <div className='h-20' />
+        <div className={cn(
+          props.data.image_list.images.length > 2 ? 'h-25' : 'h-20'
+        )} />
 
-        <DouyinDynamicStatus
-          dianzan={props.data.dianzan}
-          pinglun={props.data.pinglun}
-          shouchang={props.data.shouchang}
-          share={props.data.share}
-          publishTime={props.data.create_time}
-          renderTime={renderTime}
-        />
+        <DouyinDynamicStatus {...props} />
 
         <div className={cn(
           hasCoCreators && 'h-23',
@@ -388,21 +472,12 @@ export const DouyinImageWork: React.FC<Omit<DouyinImageWorkProps, 'templateType'
                 <span className='text-3xl font-medium leading-none select-text'>{coCreatorCount}人共创</span>
               </div>
             </div>
-            <DouyinCoCreatorList info={props.data.cooperation_info} />
+            <DouyinCoCreatorList {...props} />
             <div className='h-15' />
           </>
         )}
 
-        <DouyinDynamicFooter
-          avatarUrl={props.data.avater_url}
-          username={props.data.username}
-          douyinId={props.data.抖音号}
-          dianzan={props.data.获赞}
-          following={props.data.关注}
-          fans={props.data.粉丝}
-          shareUrl={props.data.share_url}
-          useDarkTheme={props.data.useDarkTheme}
-        />
+        <DouyinDynamicFooter {...props} />
       </div>
     </DefaultLayout>
   )

--- a/packages/template/src/components/platforms/douyin/ImageWork.tsx
+++ b/packages/template/src/components/platforms/douyin/ImageWork.tsx
@@ -1,158 +1,194 @@
+import { ChatIcon, HeartIcon, ShareIcon, UsersIcon } from '@phosphor-icons/react'
 import { format } from 'date-fns'
-import { Bookmark, Clock, Eye, Hash, Heart, Maximize, MessageCircle, Share2, Users } from 'lucide-react'
+import { Bookmark, Hash, Maximize } from 'lucide-react'
 import React from 'react'
 
-import type { DouyinImageWorkProps } from '../../../types/platforms/douyin'
+import type { DouyinImageWorkProps } from '../../../types/platforms/douyin/imageWork'
+import { cn } from '../../../utils/cn'
 import { generateQRCode } from '../../../utils/QRcode'
 import { DefaultLayout } from '../../layouts/DefaultLayout'
 
-/**
- * 抖音Logo头部组件
- */
-const DouyinHeader: React.FC<{ useDarkTheme?: boolean }> = ({ useDarkTheme }) => {
+const DouyinAvatarUserInfo: React.FC<{
+  avatarUrl: string
+  username: string
+  douyinId: string
+  useDarkTheme?: boolean
+}> = ({ avatarUrl, username, douyinId, useDarkTheme }) => {
   return (
-    <div className='flex items-center px-12 py-15'>
-      <div className='w-[39%] h-50 bg-cover bg-center bg-fixed'>
+    <div className='flex gap-10 items-center justify-between px-0 pb-0 pl-24 pr-10'>
+      <div className='flex gap-10 items-center'>
+        <div className='flex justify-center items-center bg-white rounded-full w-35 h-35'>
+          <img
+            src={avatarUrl}
+            alt='头像'
+            className='rounded-full w-33 h-33 shadow-large'
+            referrerPolicy='no-referrer'
+            crossOrigin='anonymous'
+          />
+        </div>
+        <div className='flex flex-col gap-8 text-7xl'>
+          <div className='text-6xl font-bold select-text text-foreground'>
+            {username}
+          </div>
+          <div className='flex gap-2 items-center text-4xl font-normal whitespace-nowrap text-muted'>
+            <Hash size={40} />
+            <span className='select-text'>{douyinId}</span>
+          </div>
+        </div>
+      </div>
+      <div className='shrink-0'>
         <img
           src={useDarkTheme ? '/image/douyin/dylogo-light.svg' : '/image/douyin/dylogo-dark.svg'}
-          alt='抖音Logo'
-          className='object-contain w-full h-full'
-        />
-      </div>
-      <span className='text-[65px] ml-4 text-foreground/70'>
-        记录美好生活
-      </span>
-    </div>
-  )
-}
-
-/**
- * 图文封面组件
- */
-const CoverSection: React.FC<{ imageUrl: string }> = ({ imageUrl }) => {
-  return (
-    <div className='flex flex-col items-center my-5'>
-      <div className='flex flex-col items-center overflow-hidden shadow-large rounded-[25px] w-[90%] relative'>
-        <img
-          className='rounded-[25px] object-contain w-full h-full'
-          src={imageUrl}
-          alt='图文封面'
+          alt='抖音'
+          className='h-20 w-auto object-contain'
         />
       </div>
     </div>
   )
 }
 
-/**
- * 作品信息组件
- */
-const InfoSection: React.FC<DouyinImageWorkProps> = (props) => {
+const DouyinCoverImage: React.FC<{
+  imageUrl: string
+  imageList?: { images: string[]; total_count: number }
+}> = ({ imageUrl, imageList }) => {
+  const previews = imageList?.images ?? []
+  const totalCount = imageList?.total_count ?? 1
+  const previewItems = previews.slice(0, 2)
+
+  if (previewItems.length === 0) {
+    return (
+      <div className='px-20'>
+        <div className='overflow-hidden rounded-5xl shadow-large'>
+          <img
+            src={imageUrl}
+            alt='图文封面'
+            className='object-contain w-full h-auto'
+            referrerPolicy='no-referrer'
+            crossOrigin='anonymous'
+          />
+        </div>
+      </div>
+    )
+  }
+
+  const stack: Array<{ url: string; opacity: number; shift: number }> = [
+    { url: imageUrl, opacity: 1, shift: 0 },
+    ...previewItems.map((url, idx) => ({
+      url,
+      opacity: idx === 0 ? 0.55 : 0.1,
+      shift: (idx + 1) * 16
+    }))
+  ]
+
   return (
-    <div className='flex flex-col px-16 py-5'>
+    <div className='px-20'>
+      <div className='relative overflow-visible rounded-5xl'>
+        {stack.map((item, idx) => {
+          const isFirst = idx === 0
+          return isFirst
+            ? (
+              <div
+                key={idx}
+                className='relative overflow-hidden rounded-5xl shadow-large'
+                style={{ zIndex: stack.length }}
+              >
+                <img
+                  src={item.url}
+                  alt='图文封面'
+                  className='w-full h-auto block'
+                  referrerPolicy='no-referrer'
+                  crossOrigin='anonymous'
+                />
+                {totalCount > 1 && (
+                  <div className='absolute top-7 left-7 px-5 py-2 rounded-2xl bg-black/50 backdrop-blur-sm'>
+                    <span className='text-3xl font-medium text-white select-text'>共 {totalCount} 张</span>
+                  </div>
+                )}
+              </div>
+            )
+            : (
+              <div
+                key={idx}
+                className='absolute inset-0 overflow-hidden rounded-5xl shadow-large'
+                style={{
+                  transform: `translate(${item.shift}px, ${item.shift * 2}px)`,
+                  zIndex: stack.length - idx,
+                  opacity: item.opacity
+                }}
+              >
+                <img
+                  src={item.url}
+                  alt={`预览图 ${idx + 1}`}
+                  className='w-full h-full object-cover object-center'
+                  referrerPolicy='no-referrer'
+                  crossOrigin='anonymous'
+                />
+              </div>
+            )
+        })}
+      </div>
+    </div>
+  )
+}
+
+const DouyinDynamicContent: React.FC<{ desc: string }> = ({ desc }) => {
+  return (
+    <div className='flex flex-col px-20 w-full leading-relaxed'>
       <div
-        className='text-[70px] font-bold leading-relaxed mb-9 text-foreground select-text'
-        style={{ letterSpacing: '1.5px', wordWrap: 'break-word' }}
-        dangerouslySetInnerHTML={{ __html: props.data.desc }}
+        className='text-[60px] tracking-[0.5px] leading-[1.6] whitespace-pre-wrap text-foreground select-text'
+        style={{
+          wordBreak: 'break-word',
+          overflowWrap: 'break-word'
+        }}
+        dangerouslySetInnerHTML={{ __html: desc }}
       />
-      <div className='flex items-center gap-6 text-[45px] text-muted font-light mb-2.5 select-text'>
-        <div className='flex gap-2 items-center'>
-          <Heart className='w-11 h-11 text-like' />
-          <span>{props.data.dianzan}点赞</span>
-        </div>
-        <span>·</span>
-        <div className='flex gap-2 items-center'>
-          <MessageCircle className='w-11 h-11 text-comment' />
-          <span>{props.data.pinglun}评论</span>
-        </div>
-        <span>·</span>
-        <div className='flex gap-2 items-center'>
-          <Bookmark className='w-11 h-11' />
-          <span>{props.data.shouchang}收藏</span>
-        </div>
-        <span>·</span>
-        <div className='flex gap-2 items-center'>
-          <Share2 className='w-11 h-11 text-success' />
-          <span>{props.data.share}分享</span>
-        </div>
-      </div>
-      <div className='flex items-center gap-2 text-[45px] text-muted font-light select-text'>
-        <Clock className='w-11 h-11 text-time' />
-        <span>发布于: {props.data.create_time}</span>
-      </div>
-      <div className='flex items-center gap-2 text-[45px] text-muted font-light select-text'>
-        <Maximize className='w-11 h-11 text-time text-time' />
-        <span>图片生成于: {format(new Date(), 'yyyy-MM-dd HH:mm:ss')}</span>
-      </div>
     </div>
   )
 }
 
-/**
- * 用户信息组件
- */
-const UserInfoSection: React.FC<DouyinImageWorkProps> = (props) => {
+const DouyinDynamicStatus: React.FC<{
+  dianzan: string
+  pinglun: string
+  shouchang: string
+  share: string
+  publishTime: string
+  renderTime: string
+}> = ({ dianzan, pinglun, shouchang, share, renderTime }) => {
+  const stats = [
+    { icon: HeartIcon, value: dianzan, label: '点赞' },
+    { icon: ChatIcon, value: pinglun, label: '评论' },
+    { icon: Bookmark, value: shouchang, label: '收藏', isLucide: true },
+    { icon: ShareIcon, value: share, label: '分享' }
+  ]
+
   return (
-    <div className='flex flex-col gap-12'>
-      {/* 头像和用户名/抖音号 */}
-      <div className='flex gap-12 items-start'>
-        {/* 头像 */}
-        <div className='relative shrink-0'>
-          <div className='flex justify-center items-center bg-white rounded-full w-35 h-35'>
-            <img
-              src={props.data.avater_url}
-              alt='头像'
-              className='rounded-full w-33 h-33 shadow-large'
-            />
-          </div>
-        </div>
-        
-        {/* 用户名和抖音号 - 纵向排列 */}
-        <div className='flex flex-col gap-5'>
-          <div className='text-7xl font-bold select-text text-foreground'>
-            @{props.data.username}
-          </div>
-          <div className='flex gap-2 items-center text-4xl text-muted'>
-            <Hash size={32} className='text-muted' />
-            <span className='select-text'>抖音号: {props.data.抖音号}</span>
-          </div>
-        </div>
+    <div className='flex flex-col gap-10 px-18 w-full leading-relaxed'>
+      <div className='flex gap-6 items-center text-5xl font-light tracking-normal select-text text-foreground/70'>
+        {stats.map((stat, idx) => {
+          const Icon = stat.icon
+          return (
+            <React.Fragment key={stat.label}>
+              {idx > 0 && <span>·</span>}
+              <div className='flex gap-2 items-center'>
+                {stat.isLucide
+                  ? <Icon size={50} />
+                  : <Icon size={50} weight='fill' className='mt-2' />
+                }
+                {stat.value}{stat.label}
+              </div>
+            </React.Fragment>
+          )
+        })}
       </div>
-      
-      {/* 用户统计信息 */}
-      <div className='text-3xl flex gap-6 items-center text-foreground/70'>
-        <div className='flex flex-col gap-1 items-start px-6 py-3 rounded-2xl bg-surface'>
-          <div className='flex gap-1 items-center'>
-            <Heart size={28} className='text-like' />
-            <span className='text-muted'>获赞</span>
-          </div>
-          <div className='w-full h-px bg-border' />
-          <span className='select-text font-medium text-4xl'>{props.data.获赞}</span>
-        </div>
-        <div className='flex flex-col gap-1 items-start px-6 py-3 rounded-2xl bg-surface'>
-          <div className='flex gap-1 items-center'>
-            <Eye size={28} className='text-view' />
-            <span className='text-muted'>关注</span>
-          </div>
-          <div className='w-full h-px bg-border' />
-          <span className='select-text font-medium text-4xl'>{props.data.关注}</span>
-        </div>
-        <div className='flex flex-col gap-1 items-start px-6 py-3 rounded-2xl bg-surface'>
-          <div className='flex gap-1 items-center'>
-            <Users size={28} className='text-accent' />
-            <span className='text-muted'>粉丝</span>
-          </div>
-          <div className='w-full h-px bg-border' />
-          <span className='select-text font-medium text-4xl'>{props.data.粉丝}</span>
-        </div>
+      <div className='flex gap-2 items-center text-5xl font-light tracking-normal select-text text-foreground/70'>
+        <Maximize size={48} />
+        图片生成于: {renderTime}
       </div>
     </div>
   )
 }
 
-/**
- * 共创者信息组件
- */
-const CoCreatorsInfo: React.FC<{
+const DouyinCoCreatorList: React.FC<{
   info?: DouyinImageWorkProps['data']['cooperation_info']
 }> = ({ info }) => {
   const creators = info?.co_creators ?? []
@@ -168,7 +204,6 @@ const CoCreatorsInfo: React.FC<{
       const el = listRef.current
       if (!el) return
       const containerWidth = el.offsetWidth
-
       const ITEM_W = 152
       const GAP = 32
       const PAD_R = 8
@@ -185,45 +220,43 @@ const CoCreatorsInfo: React.FC<{
   }, [items.length])
 
   return (
-    <div className='flex flex-col pl-16 w-full'>
+    <div className='flex flex-col px-20 w-full'>
       <div
         ref={listRef}
         className='flex overflow-hidden gap-8 py-1 pr-2 w-full'
-        style={{ scrollbarWidth: 'thin' }}
       >
-        {items.slice(0, visibleCount).map((c, idx) => {
-          const avatar = c.avatar_url
-          return (
-            <div
-              key={`${c.nickname || 'creator'}-${idx}`}
-              className='flex flex-col items-center min-w-38 w-38 shrink-0'
-            >
-              <div className='flex justify-center items-center bg-white rounded-full w-30 h-30'>
-                <img
-                  src={avatar}
-                  alt='共创者头像'
-                  className='object-cover w-28 h-auto rounded-full'
-                />
-              </div>
-              <div className='overflow-hidden mt-6 w-full text-3xl font-medium leading-tight text-center truncate whitespace-nowrap select-text text-foreground/80'>
-                {c.nickname || '未提供'}
-              </div>
-              <div className='overflow-hidden mt-2 w-full text-3xl leading-tight text-center truncate whitespace-nowrap select-text text-foreground/70'>
-                {c.role_title || '未提供'}
-              </div>
+        {items.slice(0, visibleCount).map((c, idx) => (
+          <div
+            key={`${c.nickname || 'creator'}-${idx}`}
+            className='flex flex-col items-center min-w-38 w-38 shrink-0'
+          >
+            <div className='flex justify-center items-center bg-white rounded-full w-30 h-30'>
+              <img
+                src={c.avatar_url}
+                alt='共创者头像'
+                className='object-cover w-28 h-28 rounded-full'
+                referrerPolicy='no-referrer'
+                crossOrigin='anonymous'
+              />
             </div>
-          )
-        })}
+            <div className='overflow-hidden mt-6 w-full text-3xl font-medium leading-tight text-center truncate whitespace-nowrap select-text text-foreground'>
+              {c.nickname || '未提供'}
+            </div>
+            <div className='overflow-hidden mt-2 w-full text-3xl leading-tight text-center truncate whitespace-nowrap select-text text-muted'>
+              {c.role_title || '未提供'}
+            </div>
+          </div>
+        ))}
 
         {items.length > visibleCount && (
           <div className='flex flex-col items-center min-w-38 w-38 shrink-0'>
-            <div className='flex justify-center items-center rounded-full bg-surface-secondary w-38 h-38'>
+            <div className='flex justify-center items-center rounded-full bg-surface-secondary w-30 h-30'>
               <span className='text-[42px] leading-none text-muted'>···</span>
             </div>
-            <div className='overflow-hidden mt-6 w-full text-3xl font-medium leading-tight text-center truncate whitespace-nowrap select-text text-foreground/80'>
+            <div className='overflow-hidden mt-6 w-full text-3xl font-medium leading-tight text-center truncate whitespace-nowrap select-text text-foreground'>
               还有{items.length - visibleCount}人
             </div>
-            <div className='overflow-hidden mt-2 w-full text-3xl leading-tight text-center truncate whitespace-nowrap select-text text-foreground/70'>
+            <div className='overflow-hidden mt-2 w-full text-3xl leading-tight text-center truncate whitespace-nowrap select-text text-muted'>
               共创
             </div>
           </div>
@@ -233,61 +266,148 @@ const CoCreatorsInfo: React.FC<{
   )
 }
 
-/**
- * 抖音图文作品组件
- */
-export const DouyinImageWork: React.FC<Omit<DouyinImageWorkProps, 'templateType' | 'templateName'>> = (props) => {
-  const coCreatorCount =
-    props.data.cooperation_info?.co_creator_nums ??
-    (props.data.cooperation_info?.co_creators?.length ?? undefined)
+const DouyinDynamicFooter: React.FC<{
+  avatarUrl: string
+  username: string
+  douyinId: string
+  dianzan: string
+  following: string
+  fans: string
+  shareUrl: string
+  useDarkTheme?: boolean
+}> = ({ avatarUrl, username, douyinId, dianzan, following, fans, shareUrl, useDarkTheme }) => {
+  const stats = [
+    { icon: HeartIcon, iconSize: 36, label: '获赞', value: dianzan },
+    { icon: UsersIcon, iconSize: 36, label: '关注', value: following },
+    { icon: UsersIcon, iconSize: 36, label: '粉丝', value: fans, filled: true }
+  ]
 
   return (
-    <DefaultLayout {...props}>
-      <div>
-        {/* 头部Logo */}
-        <div className='h-15' />
-        <DouyinHeader useDarkTheme={props.data.useDarkTheme} />
-        <div className='h-15' />
-
-        {/* 图文封面 */}
-        <CoverSection imageUrl={props.data.image_url} />
-        <div className='h-5' />
-
-        {/* 作品信息 */}
-        <InfoSection {...props} />
-        <div className='h-25' />
-
-        <div className='flex flex-col gap-10 px-0 pt-25'>
-          <div className='w-full'>
-            {coCreatorCount && coCreatorCount > 0 && (
-              <div className='px-16 pb-8'>
-                <div className='gap-2 inline-flex items-center rounded-2xl bg-surface text-foreground/80 px-6 py-3'>
-                  <Users className='w-7 h-7' />
-                  <span className='text-3xl font-medium leading-none select-text text-foreground/80'>{coCreatorCount}人共创</span>
-                </div>
-              </div>
-            )}
-            <CoCreatorsInfo info={props.data.cooperation_info} />
-          </div>
-
-          {/* 底部信息区域 */}
-          <div className='flex justify-between items-start px-20 pb-20'>
-            {/* 左侧：用户信息 */}
-            <UserInfoSection {...props} />
-
-            {/* 右侧：二维码 */}
-            <div className='flex flex-col items-center gap-4'>
+    <div className='flex justify-between items-start px-20 pb-20'>
+      <div className='flex flex-col gap-12'>
+        <div className='flex gap-12 items-start'>
+          <div className='relative shrink-0'>
+            <div className='flex justify-center items-center bg-white rounded-full w-35 h-35'>
               <img
-                src={generateQRCode(props.data.share_url, props.data.useDarkTheme)}
-                alt='二维码'
-                className='h-auto w-75 rounded-xl'
+                src={avatarUrl}
+                alt='头像'
+                className='rounded-full w-33 h-33 shadow-large'
+                referrerPolicy='no-referrer'
+                crossOrigin='anonymous'
               />
             </div>
           </div>
+          <div className='flex flex-col gap-5'>
+            <div className='text-7xl font-bold select-text text-foreground'>
+              {username}
+            </div>
+            <div className='flex gap-2 items-center text-4xl text-muted'>
+              <Hash size={32} />
+              <span className='select-text'>抖音号: {douyinId}</span>
+            </div>
+          </div>
         </div>
+
+        <div className='text-3xl flex gap-6 items-center text-foreground/70'>
+          {stats.map((stat) => {
+            const Icon = stat.icon
+            return (
+              <div key={stat.label} className='flex flex-col gap-1 items-start px-6 py-3 rounded-2xl bg-surface'>
+                <div className='flex gap-1 items-center'>
+                  <Icon size={stat.iconSize} weight={stat.filled ? 'fill' : undefined} />
+                  <span className='text-muted'>{stat.label}</span>
+                </div>
+                <div className='w-full h-px bg-border' />
+                <span className='select-text font-medium text-4xl'>{stat.value}</span>
+              </div>
+            )
+          })}
+        </div>
+      </div>
+
+      <div className='flex flex-col items-center gap-4'>
+        <img
+          src={generateQRCode(shareUrl, useDarkTheme)}
+          alt='二维码'
+          className='h-auto w-75 rounded-2xl'
+        />
+      </div>
+    </div>
+  )
+}
+
+export const DouyinImageWork: React.FC<Omit<DouyinImageWorkProps, 'templateType' | 'templateName'>> = React.memo((props) => {
+  const renderTime = format(new Date(), 'yyyy-MM-dd HH:mm:ss')
+
+  const coCreatorCount =
+    props.data.cooperation_info?.co_creator_nums ??
+    (props.data.cooperation_info?.co_creators?.length ?? undefined)
+  const hasCoCreators = !!coCreatorCount && coCreatorCount > 0
+
+  return (
+    <DefaultLayout {...props}>
+      <div className='p-4'>
+        <div className='h-25' />
+
+        <DouyinAvatarUserInfo
+          avatarUrl={props.data.avater_url}
+          username={props.data.username}
+          douyinId={props.data.抖音号}
+          useDarkTheme={props.data.useDarkTheme}
+        />
+
+        <div className='h-15' />
+
+        <DouyinDynamicContent desc={props.data.desc} />
+
+        <div className='h-15' />
+
+        <DouyinCoverImage imageUrl={props.data.image_url} imageList={props.data.image_list} />
+
+        <div className='h-20' />
+
+        <DouyinDynamicStatus
+          dianzan={props.data.dianzan}
+          pinglun={props.data.pinglun}
+          shouchang={props.data.shouchang}
+          share={props.data.share}
+          publishTime={props.data.create_time}
+          renderTime={renderTime}
+        />
+
+        <div className={cn(
+          hasCoCreators && 'h-23',
+          !hasCoCreators && 'h-40'
+        )} />
+
+        {hasCoCreators && (
+          <>
+            <div className='px-20 pb-8'>
+              <div className='gap-2 inline-flex items-center rounded-2xl bg-surface text-foreground/80 px-6 py-3'>
+                <UsersIcon size={26} weight='fill' />
+                <span className='text-3xl font-medium leading-none select-text'>{coCreatorCount}人共创</span>
+              </div>
+            </div>
+            <DouyinCoCreatorList info={props.data.cooperation_info} />
+            <div className='h-15' />
+          </>
+        )}
+
+        <DouyinDynamicFooter
+          avatarUrl={props.data.avater_url}
+          username={props.data.username}
+          douyinId={props.data.抖音号}
+          dianzan={props.data.获赞}
+          following={props.data.关注}
+          fans={props.data.粉丝}
+          shareUrl={props.data.share_url}
+          useDarkTheme={props.data.useDarkTheme}
+        />
       </div>
     </DefaultLayout>
   )
-}
+})
+
+DouyinImageWork.displayName = 'DouyinImageWork'
 
 export default DouyinImageWork

--- a/packages/template/src/components/platforms/douyin/VideoWork.tsx
+++ b/packages/template/src/components/platforms/douyin/VideoWork.tsx
@@ -1,165 +1,134 @@
+import { ChatIcon, HeartIcon, ShareIcon, UsersIcon } from '@phosphor-icons/react'
 import { format } from 'date-fns'
-import { Bookmark, Clock, Eye, Hash, Heart, Maximize, MessageCircle, Share2, Users } from 'lucide-react'
+import { Bookmark, Hash, Maximize } from 'lucide-react'
 import React from 'react'
 
 import type { DouyinVideoWorkProps } from '../../../types/platforms/douyin'
+import { cn } from '../../../utils/cn'
 import { generateQRCode } from '../../../utils/QRcode'
 import { DefaultLayout } from '../../layouts/DefaultLayout'
 
-/**
- * 抖音Logo头部组件
- */
-const DouyinHeader: React.FC<{ useDarkTheme?: boolean }> = ({ useDarkTheme }) => {
+const DouyinAvatarUserInfo: React.FC<{
+  avatarUrl: string
+  username: string
+  douyinId: string
+  useDarkTheme?: boolean
+  subscriberRole?: string
+}> = ({ avatarUrl, username, douyinId, useDarkTheme, subscriberRole }) => {
   return (
-    <div className='flex items-center px-12 py-15'>
-      <div className='w-[39%] h-50 bg-cover bg-center bg-fixed'>
-        <img
-          src={useDarkTheme ? '/image/douyin/dylogo-light.svg' : '/image/douyin/dylogo-dark.svg'}
-          alt='抖音Logo'
-          className='object-contain w-full h-full'
-        />
-      </div>
-      <span className='text-[65px] ml-4 text-foreground/70'>
-        记录美好生活
-      </span>
-    </div>
-  )
-}
-
-/**
- * 视频封面组件
- */
-const CoverSection: React.FC<{ imageUrl: string }> = ({ imageUrl }) => {
-  return (
-    <div className='flex flex-col items-center my-5'>
-      <div className='flex flex-col items-center overflow-hidden shadow-large rounded-[25px] w-[90%] relative'>
-        <img
-          className='rounded-[25px] object-contain w-full h-full'
-          src={imageUrl}
-          alt='视频封面'
-        />
-      </div>
-    </div>
-  )
-}
-
-/**
- * 作品信息组件
- */
-const InfoSection: React.FC<DouyinVideoWorkProps> = (props) => {
-  return (
-    <div className='flex flex-col px-16 py-5'>
-      <div
-        className='text-[70px] font-bold leading-relaxed mb-9 text-foreground select-text'
-        style={{ letterSpacing: '1.5px', wordWrap: 'break-word' }}
-        dangerouslySetInnerHTML={{ __html: props.data.desc }}
-      />
-      <div className='flex items-center gap-6 text-[45px] text-muted font-light mb-2.5 select-text'>
-        <div className='flex gap-2 items-center'>
-          <Heart className='w-11 h-11 text-like' />
-          <span>{props.data.dianzan}点赞</span>
+    <div className='flex gap-10 items-center justify-between px-0 pb-0 pl-24 pr-10'>
+      <div className='flex gap-10 items-center'>
+        <div className='flex justify-center items-center bg-white rounded-full w-35 h-35'>
+          <img
+            src={avatarUrl}
+            alt='头像'
+            className='rounded-full w-33 h-33 shadow-large'
+            referrerPolicy='no-referrer'
+            crossOrigin='anonymous'
+          />
         </div>
-        <span>·</span>
-        <div className='flex gap-2 items-center'>
-          <MessageCircle className='w-11 h-11 text-comment' />
-          <span>{props.data.pinglun}评论</span>
-        </div>
-        <span>·</span>
-        <div className='flex gap-2 items-center'>
-          <Bookmark className='w-11 h-11' />
-          <span>{props.data.shouchang}收藏</span>
-        </div>
-        <span>·</span>
-        <div className='flex gap-2 items-center'>
-          <Share2 className='w-11 h-11 text-success' />
-          <span>{props.data.share}分享</span>
-        </div>
-      </div>
-      <div className='flex items-center gap-2 text-[45px] text-muted font-light select-text'>
-        <Clock className='w-11 h-11 text-time' />
-        <span>发布于: {props.data.create_time}</span>
-      </div>
-      <div className='flex items-center gap-2 text-[45px] text-muted font-light select-text'>
-        <Maximize className='w-11 h-11 text-time text-time' />
-        <span>图片生成于: {format(new Date(), 'yyyy-MM-dd HH:mm:ss')}</span>
-      </div>
-    </div>
-  )
-}
-
-/**
- * 用户信息组件
- */
-const UserInfoSection: React.FC<DouyinVideoWorkProps> = (props) => {
-  return (
-    <div className='flex flex-col gap-12'>
-      {/* 头像和用户名/抖音号 */}
-      <div className='flex gap-12 items-start'>
-        {/* 头像 */}
-        <div className='relative shrink-0'>
-          <div className='flex justify-center items-center bg-white rounded-full w-35 h-35'>
-            <img
-              src={props.data.avater_url}
-              alt='头像'
-              className='rounded-full w-33 h-33 shadow-large'
-            />
+        <div className='flex flex-col gap-8 text-7xl'>
+          <div className='text-6xl font-bold select-text text-foreground'>
+            {username}
           </div>
-        </div>
-        
-        {/* 用户名和抖音号 - 纵向排列 */}
-        <div className='flex flex-col gap-5'>
-          <div className='text-7xl font-bold select-text text-foreground'>
-            @{props.data.username}
-          </div>
-          <div className='flex gap-2 items-center text-4xl text-muted'>
-            <Hash size={32} />
-            <span className='select-text'>抖音号: {props.data.抖音号}</span>
-            {props.data.cooperation_info?.subscriber_role && (
-              <span className='ml-5 px-3 py-1 rounded-xl bg-surface-secondary text-3xl'>{props.data.cooperation_info.subscriber_role}</span>
+          <div className='flex gap-2 items-center text-4xl font-normal whitespace-nowrap text-muted'>
+            <Hash size={40} />
+            <span className='select-text'>{douyinId}</span>
+            {subscriberRole && (
+              <span className='ml-5 px-3 py-1 rounded-xl bg-surface-secondary text-3xl text-foreground'>{subscriberRole}</span>
             )}
           </div>
         </div>
       </div>
-      
-      {/* 用户统计信息 */}
-      <div className='text-3xl flex gap-6 items-center text-foreground/70'>
-        <div className='flex flex-col gap-1 items-start px-6 py-3 rounded-2xl bg-surface'>
-          <div className='flex gap-1 items-center'>
-            <Heart size={28} className='text-like' />
-            <span className='text-muted'>获赞</span>
-          </div>
-          <div className='w-full h-px bg-border' />
-          <span className='select-text font-medium text-4xl'>{props.data.获赞}</span>
-        </div>
-        <div className='flex flex-col gap-1 items-start px-6 py-3 rounded-2xl bg-surface'>
-          <div className='flex gap-1 items-center'>
-            <Eye size={28} className='text-view' />
-            <span className='text-muted'>关注</span>
-          </div>
-          <div className='w-full h-px bg-border' />
-          <span className='select-text font-medium text-4xl'>{props.data.关注}</span>
-        </div>
-        <div className='flex flex-col gap-1 items-start px-6 py-3 rounded-2xl bg-surface'>
-          <div className='flex gap-1 items-center'>
-            <Users size={28} className='text-accent' />
-            <span className='text-muted'>粉丝</span>
-          </div>
-          <div className='w-full h-px bg-border' />
-          <span className='select-text font-medium text-4xl'>{props.data.粉丝}</span>
-        </div>
+      <div className='shrink-0'>
+        <img
+          src={useDarkTheme ? '/image/douyin/dylogo-light.svg' : '/image/douyin/dylogo-dark.svg'}
+          alt='抖音'
+          className='h-20 w-auto object-contain'
+        />
       </div>
     </div>
   )
 }
 
-/**
- * 共创者信息组件
- */
-const CoCreatorsInfo: React.FC<{
+const DouyinVideoCover: React.FC<{ imageUrl: string }> = ({ imageUrl }) => {
+  return (
+    <div className='px-20'>
+      <div className='relative overflow-hidden rounded-5xl shadow-large'>
+        <img
+          src={imageUrl}
+          alt='视频封面'
+          className='object-contain w-full h-auto block'
+          referrerPolicy='no-referrer'
+          crossOrigin='anonymous'
+        />
+      </div>
+    </div>
+  )
+}
+
+const DouyinDynamicContent: React.FC<{ desc: string }> = ({ desc }) => {
+  return (
+    <div className='flex flex-col px-20 w-full leading-relaxed'>
+      <div
+        className='text-[60px] tracking-[0.5px] leading-[1.6] whitespace-pre-wrap text-foreground select-text'
+        style={{
+          wordBreak: 'break-word',
+          overflowWrap: 'break-word'
+        }}
+        dangerouslySetInnerHTML={{ __html: desc }}
+      />
+    </div>
+  )
+}
+
+const DouyinDynamicStatus: React.FC<{
+  dianzan: string
+  pinglun: string
+  shouchang: string
+  share: string
+  renderTime: string
+}> = ({ dianzan, pinglun, shouchang, share, renderTime }) => {
+  const stats = [
+    { icon: HeartIcon, value: dianzan, label: '点赞' },
+    { icon: ChatIcon, value: pinglun, label: '评论' },
+    { icon: Bookmark, value: shouchang, label: '收藏', isLucide: true },
+    { icon: ShareIcon, value: share, label: '分享' }
+  ]
+
+  return (
+    <div className='flex flex-col gap-10 px-18 w-full leading-relaxed'>
+      <div className='flex gap-6 items-center text-5xl font-light tracking-normal select-text text-foreground/70'>
+        {stats.map((stat, idx) => {
+          const Icon = stat.icon
+          return (
+            <React.Fragment key={stat.label}>
+              {idx > 0 && <span>·</span>}
+              <div className='flex gap-2 items-center'>
+                {stat.isLucide
+                  ? <Icon size={50} />
+                  : <Icon size={50} weight='fill' className='mt-2' />
+                }
+                {stat.value}{stat.label}
+              </div>
+            </React.Fragment>
+          )
+        })}
+      </div>
+      <div className='flex gap-2 items-center text-5xl font-light tracking-normal select-text text-foreground/70'>
+        <Maximize size={48} />
+        图片生成于: {renderTime}
+      </div>
+    </div>
+  )
+}
+
+const DouyinCoCreatorList: React.FC<{
   info?: DouyinVideoWorkProps['data']['cooperation_info']
   subscriberNickname?: string
 }> = ({ info, subscriberNickname }) => {
-  const creators = (info?.co_creators ?? []).filter(c => !subscriberNickname || c.nickname !== subscriberNickname)
+  const allCreators = info?.co_creators ?? []
+  const creators = allCreators.filter(c => !subscriberNickname || c.nickname !== subscriberNickname)
   if (creators.length === 0) return null
 
   const items = creators.slice(0, 50)
@@ -172,7 +141,6 @@ const CoCreatorsInfo: React.FC<{
       const el = listRef.current
       if (!el) return
       const containerWidth = el.offsetWidth
-
       const ITEM_W = 152
       const GAP = 32
       const PAD_R = 8
@@ -189,45 +157,43 @@ const CoCreatorsInfo: React.FC<{
   }, [items.length])
 
   return (
-    <div className='flex flex-col pl-16 w-full'>
+    <div className='flex flex-col px-20 w-full'>
       <div
         ref={listRef}
         className='flex overflow-hidden gap-8 py-1 pr-2 w-full'
-        style={{ scrollbarWidth: 'thin' }}
       >
-        {items.slice(0, visibleCount).map((c, idx) => {
-          const avatar = c.avatar_url
-          return (
-            <div
-              key={`${c.nickname || 'creator'}-${idx}`}
-              className='flex flex-col items-center min-w-42 w-42 shrink-0'
-            >
-              <div className='flex justify-center items-center bg-white rounded-full w-30 h-30'>
-                <img
-                  src={avatar}
-                  alt='共创者头像'
-                  className='object-cover w-28 h-auto rounded-full'
-                />
-              </div>
-              <div className='overflow-hidden mt-6 w-full text-3xl font-medium leading-tight text-center truncate whitespace-nowrap select-text text-foreground'>
-                {c.nickname || '未提供'}
-              </div>
-              <div className='overflow-hidden mt-2 w-full text-3xl leading-tight text-center truncate whitespace-nowrap select-text text-foreground/70'>
-                {c.role_title || '未提供'}
-              </div>
+        {items.slice(0, visibleCount).map((c, idx) => (
+          <div
+            key={`${c.nickname || 'creator'}-${idx}`}
+            className='flex flex-col items-center min-w-38 w-38 shrink-0'
+          >
+            <div className='flex justify-center items-center bg-white rounded-full w-30 h-30'>
+              <img
+                src={c.avatar_url}
+                alt='共创者头像'
+                className='object-cover w-28 h-28 rounded-full'
+                referrerPolicy='no-referrer'
+                crossOrigin='anonymous'
+              />
             </div>
-          )
-        })}
+            <div className='overflow-hidden mt-6 w-full text-3xl font-medium leading-tight text-center truncate whitespace-nowrap select-text text-foreground'>
+              {c.nickname || '未提供'}
+            </div>
+            <div className='overflow-hidden mt-2 w-full text-3xl leading-tight text-center truncate whitespace-nowrap select-text text-muted'>
+              {c.role_title || '未提供'}
+            </div>
+          </div>
+        ))}
 
         {items.length > visibleCount && (
           <div className='flex flex-col items-center min-w-38 w-38 shrink-0'>
             <div className='flex justify-center items-center rounded-full bg-surface-secondary w-30 h-30'>
               <span className='text-[42px] leading-none text-muted'>···</span>
             </div>
-            <div className='overflow-hidden mt-6 w-full text-3xl font-medium leading-tight text-center truncate whitespace-nowrap select-text text-foreground/80'>
+            <div className='overflow-hidden mt-6 w-full text-3xl font-medium leading-tight text-center truncate whitespace-nowrap select-text text-foreground'>
               还有{items.length - visibleCount}人
             </div>
-            <div className='overflow-hidden mt-2 w-full text-3xl leading-tight text-center truncate whitespace-nowrap select-text text-foreground/70'>
+            <div className='overflow-hidden mt-2 w-full text-3xl leading-tight text-center truncate whitespace-nowrap select-text text-muted'>
               共创
             </div>
           </div>
@@ -237,61 +203,148 @@ const CoCreatorsInfo: React.FC<{
   )
 }
 
-/**
- * 抖音视频作品组件
- */
-export const DouyinVideoWork: React.FC<Omit<DouyinVideoWorkProps, 'templateType' | 'templateName'>> = (props) => {
-  const coCreatorCount =
-    props.data.cooperation_info?.co_creator_nums ??
-    (props.data.cooperation_info?.co_creators?.length ?? undefined)
+const DouyinDynamicFooter: React.FC<{
+  avatarUrl: string
+  username: string
+  douyinId: string
+  dianzan: string
+  following: string
+  fans: string
+  shareUrl: string
+  useDarkTheme?: boolean
+}> = ({ avatarUrl, username, douyinId, dianzan, following, fans, shareUrl, useDarkTheme }) => {
+  const stats = [
+    { icon: HeartIcon, iconSize: 36, label: '获赞', value: dianzan },
+    { icon: UsersIcon, iconSize: 36, label: '关注', value: following },
+    { icon: UsersIcon, iconSize: 36, label: '粉丝', value: fans, filled: true }
+  ]
 
   return (
-    <DefaultLayout {...props}>
-      <div>
-        {/* 头部Logo */}
-        <div className='h-15' />
-        <DouyinHeader useDarkTheme={props.data.useDarkTheme} />
-        <div className='h-15' />
-
-        {/* 视频封面 */}
-        <CoverSection imageUrl={props.data.image_url} />
-        <div className='h-5' />
-
-        {/* 作品信息 */}
-        <InfoSection {...props} />
-        <div className='h-25' />
-
-        <div className='flex flex-col gap-10 px-0 pt-25'>
-          <div className='w-full'>
-            {coCreatorCount && coCreatorCount > 0 && (
-              <div className='px-16 pb-8'>
-                <div className='gap-2 inline-flex items-center rounded-2xl bg-surface text-foreground/80 px-6 py-3'>
-                  <Users className='w-7 h-7' />
-                  <span className='text-3xl font-medium leading-none select-text text-foreground/80'>{coCreatorCount}人共创</span>
-                </div>
-              </div>
-            )}
-            <CoCreatorsInfo info={props.data.cooperation_info} subscriberNickname={props.data.username} />
-          </div>
-
-          {/* 底部信息区域 */}
-          <div className='flex justify-between items-start px-20 pb-20'>
-            {/* 左侧：用户信息 */}
-            <UserInfoSection {...props} />
-
-            {/* 右侧：二维码 */}
-            <div className='flex flex-col items-center gap-4'>
+    <div className='flex justify-between items-start px-20 pb-20'>
+      <div className='flex flex-col gap-12'>
+        <div className='flex gap-12 items-start'>
+          <div className='relative shrink-0'>
+            <div className='flex justify-center items-center bg-white rounded-full w-35 h-35'>
               <img
-                src={generateQRCode(props.data.share_url, props.data.useDarkTheme)}
-                alt='二维码'
-                className='h-auto w-75 rounded-xl'
+                src={avatarUrl}
+                alt='头像'
+                className='rounded-full w-33 h-33 shadow-large'
+                referrerPolicy='no-referrer'
+                crossOrigin='anonymous'
               />
             </div>
           </div>
+          <div className='flex flex-col gap-5'>
+            <div className='text-7xl font-bold select-text text-foreground'>
+              {username}
+            </div>
+            <div className='flex gap-2 items-center text-4xl text-muted'>
+              <Hash size={32} />
+              <span className='select-text'>抖音号: {douyinId}</span>
+            </div>
+          </div>
         </div>
+
+        <div className='text-3xl flex gap-6 items-center text-foreground/70'>
+          {stats.map((stat) => {
+            const Icon = stat.icon
+            return (
+              <div key={stat.label} className='flex flex-col gap-1 items-start px-6 py-3 rounded-2xl bg-surface'>
+                <div className='flex gap-1 items-center'>
+                  <Icon size={stat.iconSize} weight={stat.filled ? 'fill' : undefined} />
+                  <span className='text-muted'>{stat.label}</span>
+                </div>
+                <div className='w-full h-px bg-border' />
+                <span className='select-text font-medium text-4xl'>{stat.value}</span>
+              </div>
+            )
+          })}
+        </div>
+      </div>
+
+      <div className='flex flex-col items-center gap-4'>
+        <img
+          src={generateQRCode(shareUrl, useDarkTheme)}
+          alt='二维码'
+          className='h-auto w-75 rounded-2xl'
+        />
+      </div>
+    </div>
+  )
+}
+
+export const DouyinVideoWork: React.FC<Omit<DouyinVideoWorkProps, 'templateType' | 'templateName'>> = React.memo((props) => {
+  const renderTime = format(new Date(), 'yyyy-MM-dd HH:mm:ss')
+
+  const coCreatorCount =
+    props.data.cooperation_info?.co_creator_nums ??
+    (props.data.cooperation_info?.co_creators?.length ?? undefined)
+  const hasCoCreators = !!coCreatorCount && coCreatorCount > 0
+
+  return (
+    <DefaultLayout {...props}>
+      <div className='p-4'>
+        <div className='h-25' />
+
+        <DouyinAvatarUserInfo
+          avatarUrl={props.data.avater_url}
+          username={props.data.username}
+          douyinId={props.data.抖音号}
+          useDarkTheme={props.data.useDarkTheme}
+          subscriberRole={props.data.cooperation_info?.subscriber_role}
+        />
+
+        <div className='h-15' />
+
+        <DouyinDynamicContent desc={props.data.desc} />
+
+        <div className='h-15' />
+
+        <DouyinVideoCover imageUrl={props.data.image_url} />
+
+        <div className='h-20' />
+
+        <DouyinDynamicStatus
+          dianzan={props.data.dianzan}
+          pinglun={props.data.pinglun}
+          shouchang={props.data.shouchang}
+          share={props.data.share}
+          renderTime={renderTime}
+        />
+
+        <div className={cn(
+          hasCoCreators && 'h-23',
+          !hasCoCreators && 'h-40'
+        )} />
+
+        {hasCoCreators && (
+          <>
+            <div className='px-20 pb-8'>
+              <div className='gap-2 inline-flex items-center rounded-2xl bg-surface text-foreground/80 px-6 py-3'>
+                <UsersIcon size={26} weight='fill' />
+                <span className='text-3xl font-medium leading-none select-text'>{coCreatorCount}人共创</span>
+              </div>
+            </div>
+            <DouyinCoCreatorList info={props.data.cooperation_info} subscriberNickname={props.data.username} />
+            <div className='h-15' />
+          </>
+        )}
+
+        <DouyinDynamicFooter
+          avatarUrl={props.data.avater_url}
+          username={props.data.username}
+          douyinId={props.data.抖音号}
+          dianzan={props.data.获赞}
+          following={props.data.关注}
+          fans={props.data.粉丝}
+          shareUrl={props.data.share_url}
+          useDarkTheme={props.data.useDarkTheme}
+        />
       </div>
     </DefaultLayout>
   )
-}
+})
+
+DouyinVideoWork.displayName = 'DouyinVideoWork'
 
 export default DouyinVideoWork

--- a/packages/template/src/components/platforms/douyin/VideoWork.tsx
+++ b/packages/template/src/components/platforms/douyin/VideoWork.tsx
@@ -1,26 +1,43 @@
-import { ChatIcon, HeartIcon, ShareIcon, UsersIcon } from '@phosphor-icons/react'
-import { format } from 'date-fns'
-import { Bookmark, Hash, Maximize } from 'lucide-react'
+import { renderRichTextToReact } from '@kkk/richtext'
+import { BookmarkIcon, ChatIcon, HeartIcon, MapPinIcon, MusicNoteIcon, PlayIcon, ShareFatIcon, UserPlusIcon, UsersIcon, UsersThreeIcon } from '@phosphor-icons/react'
+import { format, formatDistanceToNow, fromUnixTime } from 'date-fns'
+import { zhCN } from 'date-fns/locale'
+import { Clock3, Hash, Maximize } from 'lucide-react'
 import React from 'react'
 
-import type { DouyinVideoWorkProps } from '../../../types/platforms/douyin'
+import type { DouyinVideoWorkProps } from '../../../types/platforms/douyin/videoWork'
 import { cn } from '../../../utils/cn'
 import { generateQRCode } from '../../../utils/QRcode'
 import { DefaultLayout } from '../../layouts/DefaultLayout'
 
-const DouyinAvatarUserInfo: React.FC<{
-  avatarUrl: string
-  username: string
-  douyinId: string
-  useDarkTheme?: boolean
-  subscriberRole?: string
-}> = ({ avatarUrl, username, douyinId, useDarkTheme, subscriberRole }) => {
+type Props = Omit<DouyinVideoWorkProps, 'templateType' | 'templateName'>
+
+function formatDuration (duration?: number): string | undefined {
+  if (typeof duration !== 'number' || !Number.isFinite(duration) || duration < 0) return undefined
+
+  const totalSeconds = Math.floor(duration / 1000)
+  const hours = Math.floor(totalSeconds / 3600)
+  const minutes = Math.floor((totalSeconds % 3600) / 60)
+  const seconds = totalSeconds % 60
+  const pad = (value: number) => value.toString().padStart(2, '0')
+
+  if (hours > 0) return `${pad(hours)}:${pad(minutes)}:${pad(seconds)}`
+  return `${pad(minutes)}:${pad(seconds)}`
+}
+
+const DouyinAvatarUserInfo: React.FC<Props> = (props) => {
+  const { avater_url, username, create_time, useDarkTheme, dynamicTYPE } = props.data
+  const subscriberRole = props.data.cooperation_info?.subscriber_role
+  const publishTime = formatDistanceToNow(fromUnixTime(create_time), {
+    addSuffix: true,
+    locale: zhCN
+  })
   return (
     <div className='flex gap-10 items-center justify-between px-0 pb-0 pl-24 pr-10'>
       <div className='flex gap-10 items-center'>
         <div className='flex justify-center items-center bg-white rounded-full w-35 h-35'>
           <img
-            src={avatarUrl}
+            src={avater_url}
             alt='头像'
             className='rounded-full w-33 h-33 shadow-large'
             referrerPolicy='no-referrer'
@@ -32,103 +49,178 @@ const DouyinAvatarUserInfo: React.FC<{
             {username}
           </div>
           <div className='flex gap-2 items-center text-4xl font-normal whitespace-nowrap text-muted'>
-            <Hash size={40} />
-            <span className='select-text'>{douyinId}</span>
+            <Clock3 size={40} />
+            <span className='select-text'>{publishTime}</span>
             {subscriberRole && (
               <span className='ml-5 px-3 py-1 rounded-xl bg-surface-secondary text-3xl text-foreground'>{subscriberRole}</span>
             )}
           </div>
         </div>
       </div>
-      <div className='shrink-0'>
+      <div className='shrink-0 flex flex-col items-end gap-2'>
         <img
           src={useDarkTheme ? '/image/douyin/dylogo-light.svg' : '/image/douyin/dylogo-dark.svg'}
           alt='抖音'
           className='h-20 w-auto object-contain'
         />
+        {dynamicTYPE && (
+          <div className='px-6 py-2 rounded-full bg-surface-secondary text-2xl font-medium text-muted select-text tracking-widest'>
+            {dynamicTYPE}
+          </div>
+        )}
       </div>
     </div>
   )
 }
 
-const DouyinVideoCover: React.FC<{ imageUrl: string }> = ({ imageUrl }) => {
+const DouyinVideoCover: React.FC<Props> = (props) => {
+  const { image_url, music, duration } = props.data
+  const durationText = formatDuration(duration)
+  const musicBadge = music && (
+    <div className='absolute left-7 bottom-7 z-20 flex items-center gap-4 max-w-[72%] p-3 rounded-3xl bg-black/45 backdrop-blur-2xl border border-white/20 shadow-large overflow-hidden'>
+      <div className='relative shrink-0 w-18 h-18'>
+        {music.cover
+          ? (
+            <>
+              <img
+                src={music.cover}
+                alt=''
+                className='absolute inset-0 w-full h-full rounded-2xl object-cover blur-md scale-110 opacity-70'
+                referrerPolicy='no-referrer'
+                crossOrigin='anonymous'
+              />
+              <img
+                src={music.cover}
+                alt='BGM封面'
+                className='relative z-10 w-full h-full rounded-2xl object-cover'
+                referrerPolicy='no-referrer'
+                crossOrigin='anonymous'
+              />
+            </>
+          )
+          : (
+            <div className='flex items-center justify-center w-full h-full rounded-2xl bg-white/15 text-white'>
+              <MusicNoteIcon size={36} weight='fill' />
+            </div>
+          )}
+      </div>
+      <div className='flex flex-col gap-1 min-w-0 pr-2 text-white'>
+        <span className='text-3xl font-semibold truncate select-text'>{music.title}</span>
+        <span className='text-2xl text-white/85 truncate select-text'>{music.author}</span>
+      </div>
+    </div>
+  )
+
   return (
     <div className='px-20'>
       <div className='relative overflow-hidden rounded-5xl shadow-large'>
         <img
-          src={imageUrl}
+          src={image_url}
           alt='视频封面'
           className='object-contain w-full h-auto block'
           referrerPolicy='no-referrer'
           crossOrigin='anonymous'
         />
+        <div className='absolute bottom-8 right-10 z-20 flex items-center justify-center text-white mix-blend-difference'>
+          <svg width='0' height='0' className='absolute'>
+            <filter id='douyin-play-inner-blur' colorInterpolationFilters='sRGB'>
+              <feGaussianBlur in='SourceGraphic' stdDeviation='30' result='blur' />
+              <feComposite in='blur' in2='SourceAlpha' operator='in' />
+            </filter>
+          </svg>
+          <PlayIcon size={150} weight='fill' aria-label='播放' style={{ filter: 'url(#douyin-play-inner-blur)' }} />
+        </div>
+        {durationText && (
+          <div className='absolute top-7 left-7 z-20 px-5 py-2 rounded-2xl bg-black/50 backdrop-blur-sm'>
+            <span className='text-3xl font-medium text-white select-text'>{durationText}</span>
+          </div>
+        )}
+        {musicBadge}
       </div>
     </div>
   )
 }
 
-const DouyinDynamicContent: React.FC<{ desc: string }> = ({ desc }) => {
+const DouyinDynamicContent: React.FC<Props> = (props) => {
+  const { title, desc, rich_desc } = props.data
+  const bodyNode = rich_desc
+    ? renderRichTextToReact(rich_desc, {
+      hashtag: {
+        className: 'text-[#04498d] dark:text-[#face15] font-medium'
+      }
+    })
+    : desc
+
   return (
     <div className='flex flex-col px-20 w-full leading-relaxed'>
+      {title && (
+        <div className='text-[72px] font-bold leading-tight mb-8 text-foreground select-text' style={{ wordBreak: 'break-word', overflowWrap: 'break-word' }}>
+          {title}
+        </div>
+      )}
       <div
-        className='text-[60px] tracking-[0.5px] leading-[1.6] whitespace-pre-wrap text-foreground select-text'
-        style={{
-          wordBreak: 'break-word',
-          overflowWrap: 'break-word'
-        }}
-        dangerouslySetInnerHTML={{ __html: desc }}
-      />
+        className='text-[56px] tracking-[0.5px] leading-[1.7] whitespace-pre-wrap text-foreground select-text'
+        style={{ wordBreak: 'break-word', overflowWrap: 'break-word' }}
+      >
+        {bodyNode}
+      </div>
     </div>
   )
 }
 
-const DouyinDynamicStatus: React.FC<{
-  dianzan: string
-  pinglun: string
-  shouchang: string
-  share: string
-  renderTime: string
-}> = ({ dianzan, pinglun, shouchang, share, renderTime }) => {
+const DouyinDynamicStatus: React.FC<Props> = (props) => {
+  const { dianzan, pinglun, shouchang, share, ip_location, suggest_word } = props.data
+  const renderTime = format(new Date(), 'yyyy-MM-dd HH:mm:ss')
   const stats = [
     { icon: HeartIcon, value: dianzan, label: '点赞' },
     { icon: ChatIcon, value: pinglun, label: '评论' },
-    { icon: Bookmark, value: shouchang, label: '收藏', isLucide: true },
-    { icon: ShareIcon, value: share, label: '分享' }
+    { icon: BookmarkIcon, value: shouchang, label: '收藏' },
+    { icon: ShareFatIcon, value: share, label: '分享' }
   ]
 
   return (
     <div className='flex flex-col gap-10 px-18 w-full leading-relaxed'>
-      <div className='flex gap-6 items-center text-5xl font-light tracking-normal select-text text-foreground/70'>
+      <div className='flex gap-6 items-center text-5xl tracking-normal select-text text-foreground/70'>
         {stats.map((stat, idx) => {
           const Icon = stat.icon
           return (
             <React.Fragment key={stat.label}>
               {idx > 0 && <span>·</span>}
-              <div className='flex gap-2 items-center'>
-                {stat.isLucide
-                  ? <Icon size={50} />
-                  : <Icon size={50} weight='fill' className='mt-2' />
-                }
-                {stat.value}{stat.label}
+              <div className='flex gap-2 items-end'>
+                <Icon size={50} weight='fill' className='mt-2' />
+                <span className='font-medium'>{stat.value}</span>
+                <span className='text-3xl font-light'>{stat.label}</span>
               </div>
             </React.Fragment>
           )
         })}
       </div>
-      <div className='flex gap-2 items-center text-5xl font-light tracking-normal select-text text-foreground/70'>
-        <Maximize size={48} />
+      {ip_location && (
+        <div className='flex gap-12 items-center font-light select-text text-foreground/70'>
+          <div className='flex gap-2 items-center'>
+            <MapPinIcon size={50} weight='fill' className='mt-1' />
+            <span className='text-5xl font-medium'>{ip_location}</span>
+          </div>
+          {suggest_word && (
+            <div className='flex gap-2 items-center py-3.5 px-6 bg-foreground/5 dark:bg-foreground/10 rounded-full text-4xl font-light select-text text-foreground/70'>
+              <span className='text-muted'>{suggest_word.hint_text}</span>
+              <span className='text-[#04498d] dark:text-[#face15] font-medium'>{suggest_word.word}</span>
+            </div>
+          )}
+        </div>
+      )}
+      <div className='flex gap-3 items-center text-4xl font-light tracking-normal select-text text-foreground/70'>
+        <Maximize size={44} />
         图片生成于: {renderTime}
       </div>
     </div>
   )
 }
 
-const DouyinCoCreatorList: React.FC<{
-  info?: DouyinVideoWorkProps['data']['cooperation_info']
-  subscriberNickname?: string
-}> = ({ info, subscriberNickname }) => {
-  const allCreators = info?.co_creators ?? []
-  const creators = allCreators.filter(c => !subscriberNickname || c.nickname !== subscriberNickname)
+const DouyinCoCreatorList: React.FC<Props> = (props) => {
+  const subscriberNickname = props.data.username
+  const allCreators = props.data.cooperation_info?.co_creators ?? []
+  const creators = allCreators.filter(c => c.nickname !== subscriberNickname)
   if (creators.length === 0) return null
 
   const items = creators.slice(0, 50)
@@ -203,20 +295,12 @@ const DouyinCoCreatorList: React.FC<{
   )
 }
 
-const DouyinDynamicFooter: React.FC<{
-  avatarUrl: string
-  username: string
-  douyinId: string
-  dianzan: string
-  following: string
-  fans: string
-  shareUrl: string
-  useDarkTheme?: boolean
-}> = ({ avatarUrl, username, douyinId, dianzan, following, fans, shareUrl, useDarkTheme }) => {
+const DouyinDynamicFooter: React.FC<Props> = (props) => {
+  const { avater_url, username, 抖音号, 获赞, 关注, 粉丝, share_url, useDarkTheme } = props.data
   const stats = [
-    { icon: HeartIcon, iconSize: 36, label: '获赞', value: dianzan },
-    { icon: UsersIcon, iconSize: 36, label: '关注', value: following },
-    { icon: UsersIcon, iconSize: 36, label: '粉丝', value: fans, filled: true }
+    { icon: HeartIcon, iconSize: 36, label: '获赞', value: 获赞 },
+    { icon: UserPlusIcon, iconSize: 36, label: '关注', value: 关注 },
+    { icon: UsersThreeIcon, iconSize: 36, label: '粉丝', value: 粉丝 }
   ]
 
   return (
@@ -226,7 +310,7 @@ const DouyinDynamicFooter: React.FC<{
           <div className='relative shrink-0'>
             <div className='flex justify-center items-center bg-white rounded-full w-35 h-35'>
               <img
-                src={avatarUrl}
+                src={avater_url}
                 alt='头像'
                 className='rounded-full w-33 h-33 shadow-large'
                 referrerPolicy='no-referrer'
@@ -240,7 +324,7 @@ const DouyinDynamicFooter: React.FC<{
             </div>
             <div className='flex gap-2 items-center text-4xl text-muted'>
               <Hash size={32} />
-              <span className='select-text'>抖音号: {douyinId}</span>
+              <span className='select-text'>抖音号: {抖音号}</span>
             </div>
           </div>
         </div>
@@ -251,7 +335,7 @@ const DouyinDynamicFooter: React.FC<{
             return (
               <div key={stat.label} className='flex flex-col gap-1 items-start px-6 py-3 rounded-2xl bg-surface'>
                 <div className='flex gap-1 items-center'>
-                  <Icon size={stat.iconSize} weight={stat.filled ? 'fill' : undefined} />
+                  <Icon size={stat.iconSize} weight='fill' />
                   <span className='text-muted'>{stat.label}</span>
                 </div>
                 <div className='w-full h-px bg-border' />
@@ -264,7 +348,7 @@ const DouyinDynamicFooter: React.FC<{
 
       <div className='flex flex-col items-center gap-4'>
         <img
-          src={generateQRCode(shareUrl, useDarkTheme)}
+          src={generateQRCode(share_url, useDarkTheme)}
           alt='二维码'
           className='h-auto w-75 rounded-2xl'
         />
@@ -273,9 +357,7 @@ const DouyinDynamicFooter: React.FC<{
   )
 }
 
-export const DouyinVideoWork: React.FC<Omit<DouyinVideoWorkProps, 'templateType' | 'templateName'>> = React.memo((props) => {
-  const renderTime = format(new Date(), 'yyyy-MM-dd HH:mm:ss')
-
+export const DouyinVideoWork: React.FC<Props> = React.memo((props) => {
   const coCreatorCount =
     props.data.cooperation_info?.co_creator_nums ??
     (props.data.cooperation_info?.co_creators?.length ?? undefined)
@@ -286,31 +368,19 @@ export const DouyinVideoWork: React.FC<Omit<DouyinVideoWorkProps, 'templateType'
       <div className='p-4'>
         <div className='h-25' />
 
-        <DouyinAvatarUserInfo
-          avatarUrl={props.data.avater_url}
-          username={props.data.username}
-          douyinId={props.data.抖音号}
-          useDarkTheme={props.data.useDarkTheme}
-          subscriberRole={props.data.cooperation_info?.subscriber_role}
-        />
+        <DouyinAvatarUserInfo {...props} />
 
         <div className='h-15' />
 
-        <DouyinDynamicContent desc={props.data.desc} />
+        <DouyinDynamicContent {...props} />
 
         <div className='h-15' />
 
-        <DouyinVideoCover imageUrl={props.data.image_url} />
+        <DouyinVideoCover {...props} />
 
         <div className='h-20' />
 
-        <DouyinDynamicStatus
-          dianzan={props.data.dianzan}
-          pinglun={props.data.pinglun}
-          shouchang={props.data.shouchang}
-          share={props.data.share}
-          renderTime={renderTime}
-        />
+        <DouyinDynamicStatus {...props} />
 
         <div className={cn(
           hasCoCreators && 'h-23',
@@ -325,21 +395,12 @@ export const DouyinVideoWork: React.FC<Omit<DouyinVideoWorkProps, 'templateType'
                 <span className='text-3xl font-medium leading-none select-text'>{coCreatorCount}人共创</span>
               </div>
             </div>
-            <DouyinCoCreatorList info={props.data.cooperation_info} subscriberNickname={props.data.username} />
+            <DouyinCoCreatorList {...props} />
             <div className='h-15' />
           </>
         )}
 
-        <DouyinDynamicFooter
-          avatarUrl={props.data.avater_url}
-          username={props.data.username}
-          douyinId={props.data.抖音号}
-          dianzan={props.data.获赞}
-          following={props.data.关注}
-          fans={props.data.粉丝}
-          shareUrl={props.data.share_url}
-          useDarkTheme={props.data.useDarkTheme}
-        />
+        <DouyinDynamicFooter {...props} />
       </div>
     </DefaultLayout>
   )

--- a/packages/template/src/types/platforms/bilibili/videoInfo.ts
+++ b/packages/template/src/types/platforms/bilibili/videoInfo.ts
@@ -109,4 +109,6 @@ export interface VideoHeaderProps {
 export interface QRCodeSectionProps {
   /** 分享链接 */
   share_url: string
+  /** 是否使用深色主题 */
+  useDarkTheme: boolean
 }

--- a/packages/template/src/types/platforms/douyin/imageWork.ts
+++ b/packages/template/src/types/platforms/douyin/imageWork.ts
@@ -1,20 +1,48 @@
+import type { RichTextDocument } from '@kkk/richtext'
+
 import type { BaseComponentProps } from '../../index'
+
+/** 抖音图文中单张媒体的类型。 */
+export type DouyinImageMediaType = 'static' | 'live' | 'clip'
 
 /**
  * 抖音图文作品组件属性接口
  */
 export interface DouyinImageWorkProps extends BaseComponentProps<{
-  /** 图文封面URL（首图，兼容旧数据） */
-  image_url: string
-  /** 图文图片列表（排除封面后的预览图，最多 3 张） */
-  image_list?: {
-    /** 图片 URL 列表（已排除封面首图，按原顺序排列） */
-    images: string[]
+  /** 图文图片列表（首项为封面，后续最多 2 张预览图） */
+  image_list: {
+    /** 图片列表，按原始顺序排列 */
+    images: Array<{
+      /** 图片 URL */
+      url: string
+      /** 媒体类型 */
+      media_type: DouyinImageMediaType
+    }>
     /** 作品总图片数（包含封面） */
     total_count: number
   }
+  /** 标题（从描述中按首个句号拆分） */
+  title?: string
   /** 描述内容 */
   desc: string
+  /** 富文本描述（去除标题后的正文，含 topic/lineBreak 节点） */
+  rich_desc?: RichTextDocument
+  /** IP 属地 */
+  ip_location?: string
+  /** 热点搜索词 */
+  suggest_word?: {
+    hint_text: string
+    word: string
+  }
+  /** 背景音乐信息 */
+  music?: {
+    /** 音乐作者 */
+    author: string
+    /** 音乐标题 */
+    title: string
+    /** 音乐封面 URL */
+    cover?: string
+  }
   /** 点赞数 */
   dianzan: string
   /** 评论数 */
@@ -23,8 +51,8 @@ export interface DouyinImageWorkProps extends BaseComponentProps<{
   shouchang: string
   /** 分享数 */
   share: string
-  /** 创建时间 */
-  create_time: string
+  /** 创建时间（Unix 时间戳，秒） */
+  create_time: number
   /** 用户头像URL */
   avater_url: string
   /** 用户名 */

--- a/packages/template/src/types/platforms/douyin/imageWork.ts
+++ b/packages/template/src/types/platforms/douyin/imageWork.ts
@@ -4,8 +4,15 @@ import type { BaseComponentProps } from '../../index'
  * 抖音图文作品组件属性接口
  */
 export interface DouyinImageWorkProps extends BaseComponentProps<{
-  /** 图文封面URL */
+  /** 图文封面URL（首图，兼容旧数据） */
   image_url: string
+  /** 图文图片列表（排除封面后的预览图，最多 3 张） */
+  image_list?: {
+    /** 图片 URL 列表（已排除封面首图，按原顺序排列） */
+    images: string[]
+    /** 作品总图片数（包含封面） */
+    total_count: number
+  }
   /** 描述内容 */
   desc: string
   /** 点赞数 */

--- a/packages/template/src/types/platforms/douyin/videoWork.ts
+++ b/packages/template/src/types/platforms/douyin/videoWork.ts
@@ -1,3 +1,5 @@
+import type { RichTextDocument } from '@kkk/richtext'
+
 import type { BaseComponentProps } from '../../index'
 
 /**
@@ -6,8 +8,30 @@ import type { BaseComponentProps } from '../../index'
 export interface DouyinVideoWorkProps extends BaseComponentProps<{
   /** 视频封面URL */
   image_url: string
+  /** 标题（从描述中按首个句号拆分） */
+  title?: string
   /** 描述内容 */
   desc: string
+  /** 富文本描述（去除标题后的正文，含 topic/lineBreak 节点） */
+  rich_desc?: RichTextDocument
+  /** IP 属地 */
+  ip_location?: string
+  /** 热点搜索词 */
+  suggest_word?: {
+    hint_text: string
+    word: string
+  }
+  /** 背景音乐信息 */
+  music?: {
+    /** 音乐作者 */
+    author: string
+    /** 音乐标题 */
+    title: string
+    /** 音乐封面 URL */
+    cover?: string
+  }
+  /** 视频时长（毫秒） */
+  duration?: number
   /** 点赞数 */
   dianzan: string
   /** 评论数 */
@@ -16,8 +40,8 @@ export interface DouyinVideoWorkProps extends BaseComponentProps<{
   shouchang: string
   /** 分享数 */
   share: string
-  /** 创建时间 */
-  create_time: string
+  /** 创建时间（Unix 时间戳，秒） */
+  create_time: number
   /** 用户头像URL */
   avater_url: string
   /** 用户名 */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -833,8 +833,8 @@ importers:
         specifier: 1.2.0
         version: 1.2.0
       '@ikenxuan/watermark':
-        specifier: 1.1.5
-        version: 1.1.5(@react-spectrum/provider@3.11.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(tailwind-merge@3.4.0)(tailwindcss@4.3.0)
+        specifier: 1.1.6
+        version: 1.1.6
       '@types/react':
         specifier: '*'
         version: 19.2.15
@@ -2285,12 +2285,6 @@ packages:
       react:
         optional: true
 
-  '@gsap/react@2.1.2':
-    resolution: {integrity: sha512-JqliybO1837UcgH2hVOM4VO+38APk3ECNrsuSM4MuXp+rbf+/2IG2K1YJiqfTcXQHH7XlA0m3ykniFYstfq0Iw==}
-    peerDependencies:
-      gsap: ^3.12.5
-      react: 19.2.6
-
   '@gwhitney/detect-indent@7.0.1':
     resolution: {integrity: sha512-7bQW+gkKa2kKZPeJf6+c6gFK9ARxQfn+FKy9ScTBppyKRWH2KzsmweXUoklqeEiHiNVWaeP5csIdsNq6w7QhzA==}
     engines: {node: '>=12.20'}
@@ -2596,13 +2590,6 @@ packages:
       react-dom: 19.2.6
       tailwindcss: '>=4.0.0'
 
-  '@heroui/react@3.0.5':
-    resolution: {integrity: sha512-kBb3aUcSAJOraPOb2MbOS1yNUcSCc6vnl0zTtzuWvJZabWgSff5Y9FNyXNjk/d56vm2ermfXa/gfBYqTUtRTzA==}
-    peerDependencies:
-      react: 19.2.6
-      react-dom: 19.2.6
-      tailwindcss: '>=4.0.0'
-
   '@heroui/react@3.1.0':
     resolution: {integrity: sha512-q+K3Kz5h2ceOEMPuNORLGX1Pqh4McN30y31eykzZZjLbmta4nwi4sDMVAv7/w8QWnWVDOucusXz5x9s5N656nA==}
     peerDependencies:
@@ -2694,11 +2681,6 @@ packages:
 
   '@heroui/styles@3.0.3':
     resolution: {integrity: sha512-DtN5QWfLVxy6DSDNgtUuHVU/h4G+dfoDHHxGVZRW6plCEh1Rc5Yc7YW7b8JBiYCknSRx/fqLXpas3Fe5Q5XJSw==}
-    peerDependencies:
-      tailwindcss: '>=4.0.0'
-
-  '@heroui/styles@3.0.5':
-    resolution: {integrity: sha512-5DI5sa7GGe1Uw8PCBhooAIGoqZbcR0ilamPjzgv94qVgolGs9+FqbeNp2bcbyoHJn9+HLKQMYiIa44LwH0VLww==}
     peerDependencies:
       tailwindcss: '>=4.0.0'
 
@@ -2975,30 +2957,30 @@ packages:
   '@ikenxuan/qrcode@1.2.0':
     resolution: {integrity: sha512-VSQV+SvzqnG/EEgv/bCbokZR1ZUMBlV0UTbgF1veD1yZ9wHh8+Uzb/MZDinZnv6leNeXhEtkUx/shxEjN7jGxQ==}
 
-  '@ikenxuan/watermark-darwin-arm64@1.1.5':
-    resolution: {integrity: sha512-Qz1nZRKBuRR6IA2bC+0HWirlO+syfKDpQrHLuXDKU8hJFlEt31VODc2Tr5Vigaw/2cHdgY7++Q2jJtvjwDqK9g==}
+  '@ikenxuan/watermark-darwin-arm64@1.1.6':
+    resolution: {integrity: sha512-7Swe+ABcwwgZCuQ64j5G9cVBKFYx+jdSk4g3y3uMtJwg/+vIavN1hfrFM/SWmrxH68z12ruyd0hPd2TJQAZRIg==}
     cpu: [arm64]
     os: [darwin]
 
-  '@ikenxuan/watermark-linux-arm64-gnu@1.1.5':
-    resolution: {integrity: sha512-gpp4g4kuVWWZmgkJIUWSsGchJcGG50RkogThXtOPTF0lagZKv96K1dWUnB4SXitVs2Qw0fSHiOfAY5MiVGgjFw==}
+  '@ikenxuan/watermark-linux-arm64-gnu@1.1.6':
+    resolution: {integrity: sha512-hAEE5lPFsQBwM4QnqRfzFMVG1WTVdzhGbuISGRAyJgbk8qbgZn3NAhKe/ILbEitcRQJdAO0kVJZfaQyNnCVdkw==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@ikenxuan/watermark-linux-x64-gnu@1.1.5':
-    resolution: {integrity: sha512-pUNZ/Y1d4RGBXC9HI8x7g5Jo8+XiscZp9yNwVP1sIupc/1N4j39PIrWBmb0XnYNaJIKLD+rPP/RJSu1P7mtNtg==}
+  '@ikenxuan/watermark-linux-x64-gnu@1.1.6':
+    resolution: {integrity: sha512-p6CbXSjypeLwpEedzPN9nVyR55bQw3aEcuyPCN1gyMVdqwLRHiX0j+sFkdo6Bx+EOYE2ELS0eElRmK9xdW+BlQ==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@ikenxuan/watermark-win32-x64-msvc@1.1.5':
-    resolution: {integrity: sha512-9UPfe+4vh3jUhrUW5by+GqUMsWwfkhXFNZNQZhT33Cjw2LRMkwjsURpE0gdRGf77X617rijY+pO/fz/u+WezYA==}
+  '@ikenxuan/watermark-win32-x64-msvc@1.1.6':
+    resolution: {integrity: sha512-J6jv5HjcyJbiNZL4VptbBknyDMyPngnTWuGCQ0otYas1exAxJ1PjHrjWCdpxFM27IIAwzWpO8wo/kznudCGurg==}
     cpu: [x64]
     os: [win32]
 
-  '@ikenxuan/watermark@1.1.5':
-    resolution: {integrity: sha512-kkYgN2CwYfGzz2ULDBCO12vKowSb6jk0+bzYaEJvdZOzM+dL3xp8Kj1zWSXfpajI5zzOb02VxkiDXPOKvx5KMw==}
+  '@ikenxuan/watermark@1.1.6':
+    resolution: {integrity: sha512-2/N1BSuw9ijtCmzhsc2OyHxs3X5XS4079tTFNy4CB8ko7Wl537uqxZkpI2KXo4TO9LDZ4lxfKCm7oNgousp7/w==}
 
   '@ikenxuan/xhshow-ts@1.0.6':
     resolution: {integrity: sha512-2Qo2tWzU6grC7bsTwohnp9KJA9wqDTAb2bbhaBOqBdAlM44zp9qlSAe2+UTYqDZaxrpne8SCT11biizVUJuosQ==}
@@ -5439,8 +5421,8 @@ packages:
       react: 19.2.6
       react-dom: 19.2.6
 
-  '@react-grab/cli@0.1.37':
-    resolution: {integrity: sha512-1ln28VkVHUbd5qy+ccXG68voWc0mgZMhBnwG0umxfD+wbkXUcvRzVrLjSqao7N8hCrDqp+Pt5j9Tsqef+9yQQQ==}
+  '@react-grab/cli@0.1.39':
+    resolution: {integrity: sha512-+2Q9W0OE0MwPb4mBmwZPSs9QgHN0fhf2SVqNuib7tr5JmzEtDo1SWSsFjQ50QiwRTJzIY8I5IZTg6vVb1jOFLw==}
     hasBin: true
 
   '@react-spectrum/button@3.18.0':
@@ -6946,15 +6928,6 @@ packages:
 
   '@tanstack/virtual-core@3.15.0':
     resolution: {integrity: sha512-0AwPGx0I8QxPYjAxShT/+z+ZOe9u8mW5rsXvivCTjRfRmz9a43+3mRyi4wwlyoUqOC56q/jatKa0Bh9M99BEHQ==}
-
-  '@tauri-apps/api@2.11.0':
-    resolution: {integrity: sha512-7CinYODhky9lmO23xHnUFv0Xt43fbtWMyxZcLcRBlFkcgXKuEirBvHpmtJ89YMhyeGcq20Wuc47Fa4XjyniywA==}
-
-  '@tauri-apps/plugin-dialog@2.7.1':
-    resolution: {integrity: sha512-OK1UBXYt+ojcmxMktzzuyonYIFta8CmAASpX+CA+DTGK24KlHjhYI6x2iOJ/TjZF4N7/ACK1oFmEOjIY9IhzOQ==}
-
-  '@tauri-apps/plugin-shell@2.3.5':
-    resolution: {integrity: sha512-jewtULhiQ7lI7+owCKAjc8tYLJr92U16bPOeAa472LHJdgaibLP83NcfAF2e+wkEcA53FxKQAZ7byDzs2eeizg==}
 
   '@tootallnate/quickjs-emscripten@0.23.0':
     resolution: {integrity: sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==}
@@ -11688,8 +11661,8 @@ packages:
   oxc-resolver@11.19.1:
     resolution: {integrity: sha512-qE/CIg/spwrTBFt5aKmwe3ifeDdLfA2NESN30E42X/lII5ClF8V7Wt6WIJhcGZjp0/Q+nQ+9vgxGk//xZNX2hg==}
 
-  oxlint-plugin-react-doctor@0.2.9:
-    resolution: {integrity: sha512-wnmC4OBbog9IQuZY2evNNe1P5IacUDLnYqOOpOSq8Adb+kjFmNxPPG8SMH+/OWkKld3NVC5KMM2pSw+oxnEIUw==}
+  oxlint-plugin-react-doctor@0.2.14:
+    resolution: {integrity: sha512-E3Xb6NFycmmyJlLE7wNLN1kScunwsiHAwf1XCOUSgnSB7sV4dvQbcAVTVoOz2n1yGSPOmcMwBdLPTepVNBZ+OQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
 
   oxlint@1.67.0:
@@ -12218,8 +12191,8 @@ packages:
       react: 19.2.6
       react-dom: 19.2.6
 
-  react-doctor@0.2.9:
-    resolution: {integrity: sha512-lfTA5OOQmy95nreKad+UueFAsVLxtjRTwZQpo50VAfsFytpDjiAb+caB2DV+Tdga8pk9th18DUZjTuSDWFFvZQ==}
+  react-doctor@0.2.14:
+    resolution: {integrity: sha512-IsdCwvd9SFCnsvcS5mKzhEA2FauW0xc2yZlrHCjfRzUEleXeDzKXRhhLXXxg9cZHzjBQl49Rkqo/+t3XwPDR4A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
@@ -12248,8 +12221,8 @@ packages:
   react-fast-compare@3.2.2:
     resolution: {integrity: sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==}
 
-  react-grab@0.1.37:
-    resolution: {integrity: sha512-XVAc/qPyxsDT8Putu9UnP7iVHmAORMzvaN/3GDTOfbuLIRXWdOt7vebPOzM9RVTVUjucXv0135JI++kSVPSfYg==}
+  react-grab@0.1.39:
+    resolution: {integrity: sha512-5ZzlW7YDLVeR/244ZHB7eukEjE3X0g4wT1uVYHq39HwoNcWeQWKpwYfptIBeydDhcgPBggMaXxQaqZJkyqM4xA==}
     hasBin: true
     peerDependencies:
       react: 19.2.6
@@ -15685,11 +15658,6 @@ snapshots:
     optionalDependencies:
       react: 19.2.6
 
-  '@gsap/react@2.1.2(gsap@3.15.0)(react@19.2.6)':
-    dependencies:
-      gsap: 3.15.0
-      react: 19.2.6
-
   '@gwhitney/detect-indent@7.0.1': {}
 
   '@heroui/accordion@2.2.29(@heroui/system@2.4.28(@heroui/theme@2.4.26(tailwindcss@3.4.19(tsx@4.22.3)(yaml@2.9.0)))(@react-spectrum/provider@3.11.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(framer-motion@11.18.2(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@heroui/theme@2.4.26(tailwindcss@3.4.19(tsx@4.22.3)(yaml@2.9.0)))(@react-spectrum/provider@3.11.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(framer-motion@11.18.2(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
@@ -16292,28 +16260,6 @@ snapshots:
       - '@types/react'
       - '@types/react-dom'
 
-  '@heroui/react@3.0.5(@react-spectrum/provider@3.11.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss@4.3.0)':
-    dependencies:
-      '@heroui/styles': 3.0.5(tailwind-merge@3.4.0)(tailwindcss@4.3.0)
-      '@radix-ui/react-avatar': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@react-aria/i18n': 3.13.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@react-aria/ssr': 3.10.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@react-aria/utils': 3.34.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@react-stately/utils': 3.12.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@react-types/color': 3.2.0(@react-spectrum/provider@3.11.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@react-types/shared': 3.34.0(react@19.2.6)
-      input-otp: 1.4.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      react: 19.2.6
-      react-aria-components: 1.17.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      react-dom: 19.2.6(react@19.2.6)
-      tailwind-merge: 3.4.0
-      tailwind-variants: 3.2.2(tailwind-merge@3.4.0)(tailwindcss@4.3.0)
-      tailwindcss: 4.3.0
-    transitivePeerDependencies:
-      - '@react-spectrum/provider'
-      - '@types/react'
-      - '@types/react-dom'
-
   '@heroui/react@3.1.0(@react-spectrum/provider@3.11.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss@4.3.0)':
     dependencies:
       '@heroui/styles': 3.1.0(tailwind-merge@3.4.0)(tailwindcss@4.3.0)
@@ -16466,14 +16412,6 @@ snapshots:
   '@heroui/styles@3.0.3(tailwind-merge@3.6.0)(tailwindcss@4.3.0)':
     dependencies:
       tailwind-variants: 3.2.2(tailwind-merge@3.6.0)(tailwindcss@4.3.0)
-      tailwindcss: 4.3.0
-      tw-animate-css: 1.4.0
-    transitivePeerDependencies:
-      - tailwind-merge
-
-  '@heroui/styles@3.0.5(tailwind-merge@3.4.0)(tailwindcss@4.3.0)':
-    dependencies:
-      tailwind-variants: 3.2.2(tailwind-merge@3.4.0)(tailwindcss@4.3.0)
       tailwindcss: 4.3.0
       tw-animate-css: 1.4.0
     transitivePeerDependencies:
@@ -16888,42 +16826,24 @@ snapshots:
 
   '@ikenxuan/qrcode@1.2.0': {}
 
-  '@ikenxuan/watermark-darwin-arm64@1.1.5':
+  '@ikenxuan/watermark-darwin-arm64@1.1.6':
     optional: true
 
-  '@ikenxuan/watermark-linux-arm64-gnu@1.1.5':
+  '@ikenxuan/watermark-linux-arm64-gnu@1.1.6':
     optional: true
 
-  '@ikenxuan/watermark-linux-x64-gnu@1.1.5':
+  '@ikenxuan/watermark-linux-x64-gnu@1.1.6':
     optional: true
 
-  '@ikenxuan/watermark-win32-x64-msvc@1.1.5':
+  '@ikenxuan/watermark-win32-x64-msvc@1.1.6':
     optional: true
 
-  '@ikenxuan/watermark@1.1.5(@react-spectrum/provider@3.11.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(tailwind-merge@3.4.0)(tailwindcss@4.3.0)':
-    dependencies:
-      '@gsap/react': 2.1.2(gsap@3.15.0)(react@19.2.6)
-      '@heroui/react': 3.0.5(@react-spectrum/provider@3.11.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss@4.3.0)
-      '@heroui/styles': 3.0.5(tailwind-merge@3.4.0)(tailwindcss@4.3.0)
-      '@tauri-apps/api': 2.11.0
-      '@tauri-apps/plugin-dialog': 2.7.1
-      '@tauri-apps/plugin-shell': 2.3.5
-      gsap: 3.15.0
-      lucide-react: 1.16.0(react@19.2.6)
-      react: 19.2.6
-      react-dom: 19.2.6(react@19.2.6)
-      react-zoom-pan-pinch: 4.0.3(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+  '@ikenxuan/watermark@1.1.6':
     optionalDependencies:
-      '@ikenxuan/watermark-darwin-arm64': 1.1.5
-      '@ikenxuan/watermark-linux-arm64-gnu': 1.1.5
-      '@ikenxuan/watermark-linux-x64-gnu': 1.1.5
-      '@ikenxuan/watermark-win32-x64-msvc': 1.1.5
-    transitivePeerDependencies:
-      - '@react-spectrum/provider'
-      - '@types/react'
-      - '@types/react-dom'
-      - tailwind-merge
-      - tailwindcss
+      '@ikenxuan/watermark-darwin-arm64': 1.1.6
+      '@ikenxuan/watermark-linux-arm64-gnu': 1.1.6
+      '@ikenxuan/watermark-linux-x64-gnu': 1.1.6
+      '@ikenxuan/watermark-win32-x64-msvc': 1.1.6
 
   '@ikenxuan/xhshow-ts@1.0.6':
     dependencies:
@@ -19774,8 +19694,9 @@ snapshots:
       react-aria: 3.48.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react-dom: 19.2.6(react@19.2.6)
 
-  '@react-grab/cli@0.1.37':
+  '@react-grab/cli@0.1.39':
     dependencies:
+      agent-install: 0.0.5
       commander: 14.0.3
       ignore: 7.0.5
       jsonc-parser: 3.3.1
@@ -21288,16 +21209,6 @@ snapshots:
   '@tanstack/virtual-core@3.11.3': {}
 
   '@tanstack/virtual-core@3.15.0': {}
-
-  '@tauri-apps/api@2.11.0': {}
-
-  '@tauri-apps/plugin-dialog@2.7.1':
-    dependencies:
-      '@tauri-apps/api': 2.11.0
-
-  '@tauri-apps/plugin-shell@2.3.5':
-    dependencies:
-      '@tauri-apps/api': 2.11.0
 
   '@tootallnate/quickjs-emscripten@0.23.0': {}
 
@@ -27803,7 +27714,7 @@ snapshots:
       - '@emnapi/runtime'
     optional: true
 
-  oxlint-plugin-react-doctor@0.2.9:
+  oxlint-plugin-react-doctor@0.2.14:
     dependencies:
       '@typescript-eslint/types': 8.60.0
       eslint-scope: 9.1.2
@@ -28410,7 +28321,7 @@ snapshots:
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
 
-  react-doctor@0.2.9(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(eslint@9.39.4(jiti@2.6.1)):
+  react-doctor@0.2.14(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       '@effect/platform-node-shared': 4.0.0-beta.70(effect@4.0.0-beta.70)
       agent-install: 0.0.5
@@ -28419,7 +28330,7 @@ snapshots:
       effect: 4.0.0-beta.70
       eslint-plugin-react-hooks: 7.1.1(eslint@9.39.4(jiti@2.6.1))
       oxlint: 1.67.0
-      oxlint-plugin-react-doctor: 0.2.9
+      oxlint-plugin-react-doctor: 0.2.14
       prompts: 2.4.2
       typescript: 6.0.3
     transitivePeerDependencies:
@@ -28457,9 +28368,9 @@ snapshots:
 
   react-fast-compare@3.2.2: {}
 
-  react-grab@0.1.37(react@19.2.6):
+  react-grab@0.1.39(react@19.2.6):
     dependencies:
-      '@react-grab/cli': 0.1.37
+      '@react-grab/cli': 0.1.39
       bippy: 0.5.41(react@19.2.6)
     optionalDependencies:
       react: 19.2.6
@@ -28663,9 +28574,9 @@ snapshots:
       preact: 10.29.1
       prompts: 2.4.2
       react: 19.2.6
-      react-doctor: 0.2.9(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(eslint@9.39.4(jiti@2.6.1))
+      react-doctor: 0.2.14(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(eslint@9.39.4(jiti@2.6.1))
       react-dom: 19.2.6(react@19.2.6)
-      react-grab: 0.1.37(react@19.2.6)
+      react-grab: 0.1.39(react@19.2.6)
     optionalDependencies:
       esbuild: 0.28.0
       unplugin: 3.0.0


### PR DESCRIPTION
## Summary by Sourcery

Refine Douyin push rendering by introducing shared render helpers, enhancing image/video work templates, and adding a development-only command to preview different push card types.

New Features:
- Support stacked multi-image previews for Douyin image works using additional image list metadata.
- Add a development-only test command to preview Douyin push cards for works, favorites, recommendations, and live status without affecting production data.

Enhancements:
- Redesign Douyin image and video work templates with updated layout, typography, icons, and clearer user/co-creator sections.
- Extract Douyin push rendering logic into dedicated helper functions for works, favorites, recommendations, and live streams to simplify push handling and reuse formatting utilities.
- Improve handling of co-creator metadata, including subscriber role detection and normalized avatar URLs, across Douyin templates.
- Refine Douyin push type labelling and control flow for better readability and future extension.