### PR TITLE
fix: 手机展示配置页面时，底部弹窗改为覆盖全屏。

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -123,5 +123,5 @@
     "web": "./lib/web.config.js",
     "ts-web": "./src/web.config.ts"
   },
-  "timestamp": "2026-06-25T21:36:17.646Z"
+  "timestamp": "2026-06-25T21:42:27.174Z"
 }

--- a/packages/web/src/components/common/ConfigPanel.tsx
+++ b/packages/web/src/components/common/ConfigPanel.tsx
@@ -3,7 +3,7 @@
  * 配置项直接在前端硬编码，不依赖 Karin schema 数据。
  */
 
-import { Button, Description, Form, Spinner, Tabs, Tooltip, toast, useOverlayState } from '@heroui/react'
+import { Button, Form, Spinner, Tabs, Tooltip, toast, useOverlayState } from '@heroui/react'
 import { useMemoizedFn, useRequest, useSetState, useUpdateEffect } from 'ahooks'
 import equal from 'fast-deep-equal'
 import gsap from 'gsap'
@@ -238,12 +238,12 @@ const ConfigPanel = ({ device = 'desktop' }: ConfigPanelProps) => {
         isOpen={diffState.isOpen}
         onOpenChange={diffState.setOpen}
       />
-      <div className={classes.header}>
+      {/* <div className={classes.header}>
         <div className={classes.headerCopy}>
           <h2 className="text-2xl font-bold">配置管理</h2>
           <Description>用户偏好设置</Description>
         </div>
-      </div>
+      </div> */}
       <Form className={classes.form} onSubmit={handleFormSubmit}>
         <Tabs className="w-full min-w-0 max-w-full" selectedKey={activeFile} onSelectionChange={handleTabChange}>
           <Tabs.ListContainer className={classes.tabsListContainer} data-config-tabs-scroll="true" data-scrollbar="none">

--- a/packages/web/src/components/common/config-panel/fieldRenderers.tsx
+++ b/packages/web/src/components/common/config-panel/fieldRenderers.tsx
@@ -319,7 +319,7 @@ export const createConfigFieldRenderers = ({
     renderPageHeader: (title, description) => (
       <div className={`mb-6 ${device === 'mobile' ? 'pr-36' : ''}`} data-config-section>
         <h2 className="text-2xl font-bold">{title}</h2>
-        <div className="mt-2.5">
+        <div className="mt-3">
           <Description>{description}</Description>
         </div>
       </div>

--- a/packages/web/src/components/pushlist/CronEditor.tsx
+++ b/packages/web/src/components/pushlist/CronEditor.tsx
@@ -1022,7 +1022,7 @@ const CronEditor = ({ value, onChange, disabled = false, device = 'desktop' }: C
         <div className="flex gap-2">
           <TextField fullWidth isDisabled value={value}>
             <Label className="sr-only">定时推送时间</Label>
-            <Input placeholder="*/10 * * * *" aria-label="定时任务表达式" />
+            <Input placeholder="*/10 * * * *" variant='secondary' aria-label="定时任务表达式" />
           </TextField>
           <Button isDisabled={disabled} variant="secondary" onPress={() => setIsOpen(true)}>
             <Clock className="size-4" aria-hidden="true" />

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -14,6 +14,14 @@
   }
 }
 
+@media (max-width: 767px) {
+  .drawer__dialog[data-placement='bottom'] {
+    height: var(--visual-viewport-height, 100dvh);
+    max-height: var(--visual-viewport-height, 100dvh);
+    border-radius: 0;
+  }
+}
+
 /*
  * jsondiffpatch GitHub 风格 diff 主题。
  * 亮色模式使用 GitHub 经典 diff 背景色，深色模式使用 GitHub dark 的暗色调。


### PR DESCRIPTION
## Summary by Sourcery

Adjust mobile configuration panel layout and cron editor input styling for better small-screen usability.

Bug Fixes:
- Ensure bottom-placed drawer dialog covers the full screen on mobile viewports.

Enhancements:
- Hide the redundant configuration panel header in favor of per-section headers.
- Increase spacing above configuration section descriptions for improved readability.
- Use the secondary input variant for the cron expression preview field in the cron editor for better visual hierarchy.

Chores:
- Update core package timestamp metadata.