### PR TITLE
refactor(douyin): replace Puppeteer login with HTTP passport flow

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -7,7 +7,3 @@ sass_binary_site=https://registry.npmmirror.com/-/binary/node-sass
 sharp_binary_host=https://registry.npmmirror.com/-/binary/sharp
 sharp_libvips_binary_host=https://registry.npmmirror.com/-/binary/sharp-libvips
 canvas_binary_host_mirror=https://registry.npmmirror.com/-/binary/canvas
-# 19以下版本
-puppeteer_download_host=https://registry.npmmirror.com/mirrors
-# 20以上版本
-PUPPETEER_DOWNLOAD_BASE_URL = https://registry.npmmirror.com/binaries/chrome-for-testing

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -70,8 +70,7 @@
   },
   "dependencies": {
     "@ikenxuan/qrcode": "1.5.0",
-    "@ikenxuan/watermark": "1.3.1",
-    "fingerprint-injector": "^2.1.88"
+    "@ikenxuan/watermark": "1.3.1"
   },
   "devDependencies": {
     "@heroui/react": "3.2.4",
@@ -86,7 +85,6 @@
     "@karinjs/template-react": "0.1.1",
     "@kkk/richtext": "workspace:*",
     "@phosphor-icons/react": "^2.1.10",
-    "@snapka/puppeteer": "^0.2.7",
     "@thesvg/icons": "^3.0.18",
     "@types/cors": "^2.8.19",
     "@types/express": "5.0.6",

--- a/packages/core/src/platform/douyin/login.ts
+++ b/packages/core/src/platform/douyin/login.ts
@@ -1,588 +1,171 @@
-import fs from 'node:fs'
-import { platform } from 'node:os'
-import path from 'node:path'
+import { karin, logger, type Message } from 'node-karin'
 
-import { scanSync } from '@ikenxuan/qrcode'
-import { snapka } from '@snapka/puppeteer'
-import { newInjectedPage } from 'fingerprint-injector'
-import { karin, karinPathTemp, logger, Message } from 'node-karin'
-
-import { Common, Render, Root } from '@/module'
+import { Render } from '@/module'
 import { reloadAmagiConfig } from '@/module/utils/amagiClient'
 import { Config } from '@/module/utils/Config'
 
-type Page = Awaited<ReturnType<Awaited<ReturnType<typeof snapka.launch>>['browser']['newPage']>>
+import { DouyinLoginClient, DouyinLoginError, type JsonRecord, readNumber, readString } from './login/client'
 
-/**
- * 截图函数
- * @param page Puppeteer 页面对象
- * @param screenshotPath 截图保存路径
- */
-const safeScreenshot = async (page: Page, screenshotPath: string) => {
+const LOGIN_TIMEOUT = 120_000
+const VERIFY_TIMEOUT = 60_000
+
+function sleep(timeout: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, timeout))
+}
+
+function normalizeInterval(value: unknown): number {
+  const parsed = typeof value === 'number' ? value : typeof value === 'string' ? Number(value) : 3000
+  const milliseconds = Number.isFinite(parsed) && parsed > 0 ? (parsed < 100 ? parsed * 1000 : parsed) : 3000
+  return Math.min(Math.max(milliseconds, 1000), 10_000)
+}
+
+async function withTimeout<T>(promise: Promise<T>, timeout: number, message: string): Promise<T> {
+  let timer: NodeJS.Timeout | undefined
   try {
-    await page.screenshot({
-      path: screenshotPath
+    return await Promise.race([
+      promise,
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(() => reject(new DouyinLoginError(message)), timeout)
+      })
+    ])
+  } finally {
+    if (timer) clearTimeout(timer)
+  }
+}
+
+function remoteErrorMessage(data: JsonRecord, fallback: string): string {
+  return readString(data, 'description') || readString(data, 'message') || fallback
+}
+
+async function recallMessages(e: Message, messageIds: Set<string>): Promise<void> {
+  await Promise.all(
+    [...messageIds].map(async (messageId) => {
+      try {
+        await e.bot.recallMsg(e.contact, messageId)
+      } catch (error) {
+        logger.debug(`撤回抖音登录消息失败: ${String(error)}`)
+      }
     })
-    logger.debug(`截图已保存: ${screenshotPath}`)
-  } catch (error) {
-    logger.warn('截图失败（已忽略）:', error)
+  )
+  messageIds.clear()
+}
+
+async function handleSmsVerification(
+  e: Message,
+  client: DouyinLoginClient,
+  verifyData: JsonRecord,
+  messageIds: Set<string>
+): Promise<void> {
+  const sent = await client.sendSmsCode(verifyData)
+  const sendErrorCode = readNumber(sent, 'error_code') ?? 0
+  if (sendErrorCode !== 0) {
+    throw new DouyinLoginError(`发送短信验证码失败：${remoteErrorMessage(sent, `error_code=${sendErrorCode}`)}`)
+  }
+
+  const mobile = readString(sent, 'mobile') || '扫码账号绑定的手机号'
+  const tip = await e.reply(`账号需要二次验证，6 位短信验证码已发送至 ${mobile}\n请在 60 秒内回复验证码`, {
+    reply: true
+  })
+  messageIds.add(tip.messageId)
+
+  let attempts = 0
+  while (attempts < 2) {
+    const context = await withTimeout(karin.ctx(e, { reply: true }), VERIFY_TIMEOUT, '验证码输入超时，登录失败')
+    if (!context) throw new DouyinLoginError('未收到验证码，登录失败')
+
+    const code = context.msg.trim()
+    if (!/^\d{6}$/.test(code)) {
+      const invalid = await e.reply('验证码必须是 6 位数字，请重新发送', { reply: true })
+      messageIds.add(invalid.messageId)
+      continue
+    }
+
+    attempts++
+    const result = await client.validateSmsCode(verifyData, code)
+    const errorCode = readNumber(result, 'error_code') ?? 0
+    if (errorCode === 0) {
+      logger.mark('抖音短信二次验证通过，继续等待登录确认')
+      return
+    }
+
+    if (attempts < 2) {
+      const retry = await e.reply(`验证码错误，请重新发送（剩余 1 次）`, { reply: true })
+      messageIds.add(retry.messageId)
+      continue
+    }
+
+    throw new DouyinLoginError(`验证码验证失败：${remoteErrorMessage(result, `error_code=${errorCode}`)}`)
   }
 }
 
 export const douyinLogin = async (e: Message) => {
-  const msg_id: string[] = []
-  const puppeteer = await snapka.launch({
-    headless: 'new',
-    protocolTimeout: 60000,
-    args: [
-      '--disable-blink-features=AutomationControlled', // 禁用自动化控制特征，避免网站检测到自动化工具
-      '--mute-audio', // 静音处理，防止页面播放音频
-      '--window-size=800,600', // 设置浏览器窗口大小为 800x600 像素
-      '--disable-gpu', // 禁用 GPU 加速，减少资源占用和潜在兼容性问题
-      '--no-sandbox', // 禁用沙箱模式，某些环境下需要（如容器环境）
-      '--disable-setuid-sandbox', // 禁用 setuid 沙箱，与 --no-sandbox 配合使用
-      '--no-zygote', // 禁用 zygote 进程，减少内存占用和启动时间
-      '--disable-extensions', // 禁用浏览器扩展，减少资源消耗
-      '--disable-dev-shm-usage', // 禁用 /dev/shm 内存共享，解决某些环境下的内存限制问题
-      '--disable-background-networking', // 禁用后台网络活动，减少不必要的网络请求
-      '--disable-sync', // 禁用同步功能，如书签、设置等同步
-      '--disable-crash-reporter', // 禁用崩溃报告器，减少资源占用
-      '--disable-translate', // 禁用页面自动翻译功能
-      '--disable-notifications', // 禁用浏览器通知，避免弹窗干扰
-      '--disable-device-discovery-notifications', // 禁用设备发现通知（如附近的打印机等）
-      '--disable-accelerated-2d-canvas', // 禁用加速的 2D 画布，减少 GPU 依赖
-      '--autoplay-policy=user-gesture-required', // 设置自动播放策略为需要用户交互
-      '--disable-web-security', // 禁用 Web 安全策略（如跨域限制），减少检查开销
-      '--disable-features=IsolateOrigins,site-per-process', // 禁用-features=IsolateOrigins,site-per-process', // 禁用源隔离和站点进程隔离，减少进程数量
-      '--disable-site-isolation-trials', // 禁用站点隔离试验功能
-      '--disable-features=VizDisplayCompositor', // 禁用 Viz 显示合成器，简化渲染流程
-      '--js-flags=--max-old-space-size=128', // 限制 V8 引擎的最大堆内存为 128MB
-      '--disable-software-rasterizer', // 禁用软件光栅化器，减少 CPU 资源占用
-      '--disable-webgl', // 禁用 WebGL 3D 图形 API
-      '--disable-webgl2', // 禁用 WebGL2 3D 图形 API
-      '--disable-3d-apis', // 禁用所有 3D 相关 API，减少资源消耗
-      '--disable-accelerated-video-decode', // 禁用硬件加速视频解码
-      '--disable-background-timer-throttling', // 禁用后台定时器节流，确保定时器正常运行
-      '--disable-backgrounding-occluded-windows', // 禁用被遮挡窗口的后台处理，保持活跃状态
-      '--disable-breakpad', // 禁用 Breakpad 崩溃报告系统
-      '--disable-component-extensions-with-background-pages', // 禁用带有背景页面的组件扩展
-      '--disable-features=TranslateUI,BlinkGenPropertyTrees', // 禁用翻译 UI 和 Blink 属性树生成
-      '--disable-ipc-flooding-protection', // 禁用 IPC 洪水保护，提高进程间通信效率
-      '--disable-renderer-backgrounding' // 禁用渲染器进程的后台处理，保持渲染性能
-    ],
-    ignoreDefaultArgs: ['--enable-automation']
-  })
+  const messageIds = new Set<string>()
+  const client = new DouyinLoginClient()
 
-  // const pageTest = await browser.newPage()
+  try {
+    logger.mark('正在通过抖音 Passport 接口获取登录二维码...')
+    const qrCode = await client.createQrCode()
+    const qrContent = readString(qrCode, 'qrcode_index_url') || readString(qrCode, 'qrcode') || qrCode.token
+    const loginQrCode = await Render(e, 'douyin/qrcodeImg', { share_url: qrContent })
+    const qrMessage = await e.reply(loginQrCode, { reply: true })
+    messageIds.add(qrMessage.messageId)
 
-  // await injector.attachFingerprintToPuppeteer(pageTest, fingerprint)
-  // await pageTest.goto('https://bot.sannysoft.com')
-  // await pageTest.screenshot({ path: 'testresult.png', fullPage: true })
+    const deadline = Date.now() + LOGIN_TIMEOUT
+    let scanned = false
+    let verified = false
 
-  /** 根据当前系统平台选择操作系统类型 */
-  const getOperatingSystem = (): 'windows' | 'macos' | 'linux' => {
-    const os = platform()
-    if (os === 'win32') return 'windows'
-    if (os === 'darwin') return 'macos'
-    return 'linux'
-  }
+    logger.mark('抖音登录二维码已发送，开始轮询扫码状态')
+    while (Date.now() < deadline) {
+      const data = await client.pollQrCode(qrCode.token)
+      const status = readString(data, 'status')
+      logger.debug(`抖音扫码登录状态: ${status || 'unknown'}`)
 
-  const page = (await newInjectedPage(puppeteer.browser, {
-    fingerprintOptions: {
-      devices: ['desktop'],
-      operatingSystems: [getOperatingSystem()]
-    }
-  })) as Page
+      if (status === 'confirmed') {
+        const cookie = client.getCookie()
+        if (!client.hasLoginCookie()) throw new DouyinLoginError('登录成功响应中缺少 sid_guard/sessionid')
 
-  // 激进地拦截资源，只保留必要的 HTML、JS 和二维码图片
-  await page.setRequestInterception(true)
-  page.on('request', async (request) => {
-    const resourceType = request.resourceType()
-    const url = request.url()
-
-    // 记录登录相关的请求
-    if (url.includes('passport') || url.includes('login') || url.includes('qrconnect') || url.includes('qrcode')) {
-      logger.debug(`[请求] ${resourceType}: ${url}`)
-    }
-
-    // 阻止明确不需要的资源
-    const shouldBlock =
-      resourceType === 'media' || // 视频/音频（Puppeteer 已识别的媒体类型）
-      resourceType === 'font' || // 字体
-      resourceType === 'stylesheet' || // CSS
-      // 通过 URL 特征识别视频
-      /\.(mp4|webm|m3u8|flv|avi|mov|wmv|mkv)(\?|$)/i.test(url) || // 视频文件扩展名
-      url.includes('/aweme/') || // 抖音视频相关路径
-      url.includes('/video/') || // 通用视频路径
-      url.includes('v.douyin.com') || // 抖音视频域名
-      // 阻止大图片但保留二维码
-      (resourceType === 'image' &&
-        !url.includes('qrcode') &&
-        !url.includes('data:image') &&
-        (url.includes('.jpg') || url.includes('.jpeg') || url.includes('.webp')))
-
-    if (shouldBlock) {
-      if (url.includes('passport') || url.includes('login') || url.includes('qrconnect')) {
-        logger.warn(`[拦截] 登录相关请求被拦截: ${url}`)
+        await Config.Modify('amagi', 'cookies.douyin', cookie)
+        const reloaded = reloadAmagiConfig()
+        logger.mark(`抖音登录凭证已保存，Amagi Client ${reloaded ? '已重载' : '配置未变化'}`)
+        await e.reply('登录成功！用户登录凭证已保存至配置', { reply: true })
+        return true
       }
-      request.abort()
-    } else {
-      // 允许所有其他请求（包括 API 调用）
-      request.continue()
-    }
-  })
 
-  // 禁用视频播放和其他重量级功能
-  await page.evaluateOnNewDocument(() => {
-    // 禁止 video 元素播放
-    HTMLMediaElement.prototype.play = function () {
-      return Promise.reject(new Error('Video playback blocked'))
-    }
-
-    // 禁止创建 MediaSource 对象
-    if (window.MediaSource) {
-      window.MediaSource = undefined as any
-    }
-
-    // 禁用 IntersectionObserver（防止懒加载触发）
-    window.IntersectionObserver = class {
-      observe() {}
-      unobserve() {}
-      disconnect() {}
-    } as any
-  })
-
-  // 访问首页
-  await page.goto('https://www.douyin.com', { timeout: 120000, waitUntil: 'domcontentloaded' })
-
-  // 阶段1: 获取二维码 (60秒超时)
-  let qrCodeData: { url: string | null; originalImage: string }
-  try {
-    logger.mark('开始等待二维码加载...')
-    qrCodeData = await Promise.race([
-      waitQrcode(page),
-      new Promise<never>((_, reject) => setTimeout(() => reject(new Error('QR_CODE_TIMEOUT')), 60000))
-    ])
-    logger.mark('二维码获取成功')
-  } catch (error: any) {
-    if (error.message === 'QR_CODE_TIMEOUT') {
-      logger.warn('获取二维码超时')
-      await safeScreenshot(page, path.join(karinPathTemp, Root.pluginName, 'DouyinLoginQrcodeError.png'))
-      await e.reply('获取二维码超时，请稍后重试', { reply: true })
-    } else {
-      logger.error('获取二维码失败:', error)
-      await e.reply('获取二维码失败，请查看控制台日志', { reply: true })
-    }
-    await puppeteer.browser.close()
-    return true
-  }
-
-  // 渲染并发送二维码
-  let gcInterval: NodeJS.Timeout | undefined
-  try {
-    // 根据解码结果选择传递方式
-    const renderData = qrCodeData.url
-      ? { share_url: qrCodeData.url } // 解码成功，传递URL让组件内部生成自定义二维码
-      : { share_url: qrCodeData.originalImage } // 解码失败，直接使用原始图片URL
-
-    const loginQRcode = await Render(e, 'douyin/qrcodeImg', renderData)
-
-    const base64Data = loginQRcode[0]?.file
-    if (!base64Data) {
-      throw new Error('生成二维码图片失败')
-    }
-
-    const cleanBase64 = base64Data.replace(/^base64:\/\//, '')
-    const buffer = Buffer.from(cleanBase64, 'base64')
-
-    fs.writeFileSync(`${Common.tempDri.default}DouyinLoginQrcode.png`, buffer)
-
-    const message2 = await e.reply(loginQRcode, { reply: true })
-    logger.debug('二维码图片消息ID:', message2.messageId)
-    msg_id.push(message2.messageId)
-
-    // 定期触发垃圾回收以释放内存
-    gcInterval = setInterval(async () => {
-      try {
-        await page.evaluate(() => {
-          // 尝试触发浏览器的垃圾回收
-          if ((window as any).gc) {
-            ;(window as any).gc()
-          }
-        })
-      } catch {
-        // 忽略错误
+      if (status === 'scanned' && !scanned) {
+        scanned = true
+        await recallMessages(e, messageIds)
+        const notice = await e.reply('二维码已扫描，请在手机抖音中确认登录', { reply: true })
+        messageIds.add(notice.messageId)
       }
-    }, 10000) // 每 10 秒清理一次
 
-    logger.mark('开始等待用户扫码登录...')
+      if (status === 'verify') {
+        if (!verified) {
+          await recallMessages(e, messageIds)
+          await handleSmsVerification(e, client, data, messageIds)
+          verified = true
+        }
+        await sleep(3000)
+        continue
+      }
 
-    // 阶段2: 等待用户扫码 (120秒超时，因为消息只能撤回2分钟)
-    const loginResult = await Promise.race([
-      new Promise<boolean>((resolve) => {
-        // 120秒后主动撤回二维码消息并结束
-        const timer = setTimeout(async () => {
-          logger.warn('扫码登录超时（2分钟），撤回二维码消息')
-          // 撤回二维码消息
-          await Promise.all(
-            msg_id.map(async (id) => {
-              await e.bot.recallMsg(e.contact, id)
-            })
-          )
-          resolve(false)
-        }, 120 * 1000)
+      if (status === 'expired') throw new DouyinLoginError('二维码已过期，请重新执行登录命令')
+      if (status === 'risk_limited') throw new DouyinLoginError('抖音触发风控或限流，请稍后重试')
 
-        let secondVerifyHandled = false
-        let scannedHandled = false
-        let responseCount = 0
+      const errorCode = readNumber(data, 'error_code') ?? 0
+      if (errorCode && errorCode !== 2046) {
+        throw new DouyinLoginError(`抖音登录失败：${remoteErrorMessage(data, `error_code=${errorCode}`)}`)
+      }
 
-        // 监听所有响应以调试
-        page.on('response', async (response) => {
-          responseCount++
-          const url = response.url()
-
-          // 每 10 个响应打印一次心跳
-          if (responseCount % 10 === 0) {
-            logger.debug(`[心跳] 已收到 ${responseCount} 个响应`)
-          }
-
-          // 记录所有登录相关的请求
-          if (url.includes('passport') || url.includes('login') || url.includes('qrconnect') || url.includes('qrcode')) {
-            logger.debug(`[响应] 登录相关请求: ${url}, status: ${response.status()}`)
-          }
-        })
-
-        logger.mark('响应监听器已注册')
-
-        page.on('response', async (response) => {
-          try {
-            // 监听二维码轮询接口
-            if (response.url().includes('check_qrconnect')) {
-              logger.debug(`收到登录轮询响应: ${response.url()}`)
-
-              // 检查响应头中是否包含 sid_guard（唯一登录凭证）
-              const headers = response.headers()
-              const setCookieHeaders = headers['set-cookie'] || ''
-              const hasSidGuard = setCookieHeaders.includes('sid_guard')
-
-              logger.debug(`响应头包含 sid_guard: ${hasSidGuard}`)
-
-              if (hasSidGuard) {
-                clearTimeout(timer)
-                logger.mark('检测到 sid_guard，登录成功')
-
-                // 保存 cookie
-                logger.debug('开始获取 cookies...')
-                const cookies = await puppeteer.browser.cookies()
-                logger.debug(`获取到 ${cookies.length} 个 cookies`)
-                const cookieString = cookies.map((cookie) => `${cookie.name}=${cookie.value}`).join('; ')
-
-                // 检测关键 cookie 参数
-                const hasSessionidSs = cookies.some((cookie) => cookie.name === 'sessionid_ss')
-                const hasTtwid = cookies.some((cookie) => cookie.name === 'ttwid')
-                logger.mark(`Cookie 参数检测: sessionid_ss=${hasSessionidSs}, ttwid=${hasTtwid}`)
-
-                if (!hasSessionidSs || !hasTtwid) {
-                  logger.warn('警告：缺少关键 cookie 参数！')
-                  if (!hasSessionidSs) logger.warn('  - 缺少 sessionid_ss')
-                  if (!hasTtwid) logger.warn('  - 缺少 ttwid')
-                }
-
-                logger.debug('开始保存 cookies...')
-                await Config.Modify('amagi', 'cookies.douyin', cookieString)
-                const reloaded = reloadAmagiConfig()
-                logger.debug(`cookies 保存完成，Amagi Client ${reloaded ? '已重载' : '配置未变化'}`)
-                await e.reply('登录成功！用户登录凭证已保存至配置', { reply: true })
-
-                // 批量撤回之前的消息
-                await Promise.all(
-                  msg_id.map(async (id) => {
-                    await e.bot.recallMsg(e.contact, id)
-                  })
-                )
-
-                logger.mark('关闭浏览器...')
-                await puppeteer.browser.close()
-                logger.mark('浏览器已关闭')
-                resolve(true)
-                return
-              }
-
-              // 如果没有 sid_guard，检查响应体
-              const responseBody = await response.text()
-              const jsonResponse = JSON.parse(responseBody)
-
-              logger.debug(`二维码状态：${jsonResponse.data?.status}, error_code: ${jsonResponse.data?.error_code}`)
-
-              // 检查二维码是否已被扫描（只处理一次）
-              if (jsonResponse.data?.status === 'scanned' && !scannedHandled) {
-                scannedHandled = true
-                logger.mark('检测到二维码已被扫描')
-                // 撤回二维码消息
-                await Promise.all(
-                  msg_id.map(async (id) => {
-                    await e.bot.recallMsg(e.contact, id)
-                  })
-                )
-                // 清空消息ID列表，避免重复撤回
-                msg_id.length = 0
-                // 发送授权提示
-                const authMsg = await e.reply('此二维码已被扫描，请在手机上授权以登录', { reply: true })
-                msg_id.push(authMsg.messageId)
-              }
-
-              // 检查是否需要二次验证
-              if (jsonResponse.data?.error_code === 2046 && !secondVerifyHandled) {
-                secondVerifyHandled = true
-                logger.mark('检测到需要二次验证')
-                clearTimeout(timer) // 清除扫码超时，进入2FA阶段
-
-                // 使用立即执行的异步函数，不阻塞响应监听
-                ;(async () => {
-                  try {
-                    // 等待二次验证弹窗出现
-                    await page.waitForSelector('#uc-second-verify', { timeout: 5000 })
-
-                    // 点击"接收短信验证码"按钮
-                    const clicked = await page.evaluate(() => {
-                      const xpath = "//text()[contains(., '接收短信验证码')]/ancestor::*[1]"
-                      const result = document.evaluate(xpath, document, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null)
-                      const element = result.singleNodeValue as HTMLElement
-                      if (element) {
-                        element.click()
-                        return true
-                      }
-                      return false
-                    })
-
-                    if (!clicked) {
-                      logger.warn('未找到"接收短信验证码"按钮')
-                    }
-
-                    // 等待输入框出现
-                    await new Promise((resolve) => setTimeout(resolve, 2000))
-                    const inputSelector = '#uc-second-verify input'
-                    await page.waitForSelector(inputSelector, { timeout: 10000 })
-
-                    const tipMsg = await e.reply(
-                      '此次验证需要进行 2FA\n6 位数的验证码已发送至扫码设备绑定的手机号\n请在 60 秒内发送此验证码以通过 2FA',
-                      { reply: true }
-                    )
-                    msg_id.push(tipMsg.messageId)
-
-                    // 验证码验证逻辑（最多2次机会）
-                    let verifyAttempts = 0
-                    const maxAttempts = 2
-                    let verifySuccess = false
-
-                    while (verifyAttempts < maxAttempts && !verifySuccess) {
-                      verifyAttempts++
-                      logger.debug(`验证码输入尝试 ${verifyAttempts}/${maxAttempts}`)
-
-                      // 阶段3: 等待用户输入2FA验证码 (60秒超时)
-                      const ctx = await Promise.race([
-                        karin.ctx(e, { reply: true }),
-                        new Promise<never>((_, reject) => setTimeout(() => reject(new Error('2FA_TIMEOUT')), 60000))
-                      ]).catch(async (error) => {
-                        if (error.message === '2FA_TIMEOUT') {
-                          logger.warn('2FA验证码输入超时')
-                          clearTimeout(timer)
-                          if (gcInterval) clearInterval(gcInterval)
-                          await puppeteer.browser.close()
-                          // 撤回所有之前的消息
-                          await Promise.all(
-                            msg_id.map(async (id) => {
-                              await e.bot.recallMsg(e.contact, id)
-                            })
-                          )
-                          await e.reply('验证码验证码输入超时，登录失败', { reply: true })
-                          resolve(true) // 返回true表示已处理完成
-                        }
-                        throw error
-                      })
-
-                      if (!ctx) return
-
-                      // 清空输入框
-                      await page.evaluate((selector) => {
-                        const input = document.querySelector(selector) as HTMLInputElement
-                        if (input) input.value = ''
-                      }, inputSelector)
-
-                      // 输入验证码
-                      await page.type(inputSelector, ctx.msg)
-
-                      // 监听验证码验证接口
-                      const validatePromise = new Promise<boolean>((resolveValidate) => {
-                        const validateHandler = async (resp: any) => {
-                          if (resp.url().includes('validate_code')) {
-                            try {
-                              const validateBody = await resp.text()
-                              const validateJson = JSON.parse(validateBody)
-                              logger.debug('验证码验证响应:', validateJson)
-
-                              if (validateJson.data?.error_code === 1202) {
-                                // 验证码错误
-                                logger.warn('验证码错误')
-                                page.off('response', validateHandler)
-                                resolveValidate(false)
-                              } else if (validateJson.message === 'success' || !validateJson.data?.error_code) {
-                                // 验证成功
-                                logger.mark('验证码验证成功')
-                                page.off('response', validateHandler)
-                                resolveValidate(true)
-                              }
-                            } catch (err) {
-                              logger.debug('解析验证响应失败:', err)
-                            }
-                          }
-                        }
-                        page.on('response', validateHandler)
-
-                        // 5秒超时
-                        setTimeout(() => {
-                          page.off('response', validateHandler)
-                          resolveValidate(false)
-                        }, 5000)
-                      })
-
-                      // 点击"验证"按钮
-                      await page.evaluate(() => {
-                        const elements = Array.from(document.querySelectorAll('*'))
-                        const verifyBtn = elements.find((el) => el.textContent?.trim() === '验证')
-                        if (verifyBtn) {
-                          ;(verifyBtn as HTMLElement).click()
-                        }
-                      })
-
-                      logger.mark('已提交验证码，等待验证结果...')
-
-                      // 等待验证结果
-                      verifySuccess = await validatePromise
-
-                      if (!verifySuccess && verifyAttempts < maxAttempts) {
-                        // 还有重试机会
-                        const retryMsg = await e.reply('验证码错误，请重新发送正确的 6 位数验证码（剩余机会：1次）', {
-                          reply: true
-                        })
-                        msg_id.push(retryMsg.messageId)
-                      } else if (!verifySuccess && verifyAttempts >= maxAttempts) {
-                        // 没有机会了
-                        logger.warn('验证码错误次数过多，登录失败')
-                        clearTimeout(timer)
-                        if (gcInterval) clearInterval(gcInterval)
-                        await puppeteer.browser.close()
-                        // 撤回所有之前的消息
-                        await Promise.all(
-                          msg_id.map(async (id) => {
-                            await e.bot.recallMsg(e.contact, id)
-                          })
-                        )
-                        await e.reply('验证码错误，登录失败', { reply: true })
-                        resolve(true) // 返回true表示已处理完成，避免外层再次处理
-                        return
-                      }
-                    }
-
-                    if (verifySuccess) {
-                      logger.mark('2FA验证通过，等待最终登录确认...')
-                    }
-                  } catch (err) {
-                    logger.error('二次验证处理失败:', err)
-                    clearTimeout(timer)
-                    if (gcInterval) clearInterval(gcInterval)
-                    await puppeteer.browser.close()
-                    // 撤回所有之前的消息
-                    await Promise.all(
-                      msg_id.map(async (id) => {
-                        await e.bot.recallMsg(e.contact, id)
-                      })
-                    )
-                    await e.reply('二次验证处理失败，登录失败', { reply: true })
-                    resolve(true) // 返回true表示已处理完成
-                  }
-                })()
-              }
-            }
-          } catch (error) {
-            logger.error('处理响应时出错:', error)
-          }
-        })
-      })
-    ])
-
-    if (gcInterval) clearInterval(gcInterval)
-
-    if (!loginResult) {
-      logger.warn('登录超时或失败')
-      await puppeteer.browser.close()
-      await e.reply('登录超时！二维码已失效！', { reply: true })
-      return true
-    }
-  } catch (err) {
-    logger.error('登录流程出错:', err)
-    if (gcInterval) clearInterval(gcInterval)
-    await puppeteer.browser.close()
-    await e.reply('登录过程出错，请查看控制台日志', { reply: true })
-  }
-  return true
-}
-
-/**
- * 等待二维码出现并获取二维码信息
- * @param page puppeteer的页面对象
- * @returns 包含解码URL和原始图片的对象
- */
-const waitQrcode = async (page: Page): Promise<{ url: string | null; originalImage: string }> => {
-  const qrCodeSelector = 'img[aria-label="二维码"]'
-  try {
-    await page.waitForSelector(qrCodeSelector, { timeout: 60000 })
-  } catch {
-    await safeScreenshot(page, path.join(karinPathTemp, Root.pluginName, 'DouyinLoginQrcodeError.png'))
-    throw new Error('加载超时了，或者遇到验证码了。。。')
-  }
-  logger.debug('二维码加载完成')
-  await new Promise((resolve) => setTimeout(resolve, 1000))
-
-  // 获取原始二维码图片的 src
-  const images = await page.$$eval('img', (imgs) => {
-    return imgs.map((img) => ({
-      src: img.src,
-      ariaLabel: img.getAttribute('aria-label')
-    }))
-  })
-  const qrCodeImages = images.filter((img) => img.ariaLabel === '二维码')
-  if (qrCodeImages.length === 0) {
-    throw new Error('未找到二维码')
-  }
-  const originalImage = qrCodeImages[0].src
-
-  // 直接从原始 src 下载图片进行解码
-  try {
-    let imageBuffer: Buffer
-
-    if (originalImage.startsWith('data:image')) {
-      // base64 图片
-      const base64Data = originalImage.split(',')[1]
-      imageBuffer = Buffer.from(base64Data, 'base64')
-    } else {
-      // URL 图片，需要下载
-      const response = await fetch(originalImage)
-      imageBuffer = Buffer.from(await response.arrayBuffer())
+      await sleep(normalizeInterval(data.interval))
     }
 
-    // 使用 QRCodeScanner 解析二维码
-    const qrContent = scanSync(imageBuffer)
-
-    if (qrContent) {
-      logger.mark('二维码解码成功:', qrContent)
-      return { url: qrContent, originalImage }
-    }
+    throw new DouyinLoginError('登录超时，二维码已失效')
   } catch (error) {
-    logger.warn('二维码解码失败:', error)
+    logger.error('抖音登录流程失败:', error)
+    const message = error instanceof DouyinLoginError ? error.message : '登录过程出错，请查看控制台日志'
+    await e.reply(message, { reply: true })
+    return true
+  } finally {
+    await recallMessages(e, messageIds)
   }
-
-  // 解码失败，返回 null 和原图
-  logger.warn('解码失败，将使用原始二维码图片')
-  return { url: null, originalImage }
 }

--- a/packages/core/src/platform/douyin/login/client.ts
+++ b/packages/core/src/platform/douyin/login/client.ts
@@ -1,0 +1,410 @@
+import type { IncomingHttpHeaders } from 'node:http'
+import { request } from 'node:https'
+
+import { buildCookieHeader, getCookie, hasLoginCookie, mergeCookies, setCookiesToCookieHeader } from './cookie'
+import { DOUYIN_USER_AGENT, LOGIN_STATIC_HEADERS } from './constants'
+import { encodeHexXor5, LOGIN_HOST, makeAidSign, makeCommonParams, makeSignAndQs, randomHex } from './passport'
+import { makeABogus } from './signer'
+
+export type JsonRecord = Record<string, unknown>
+
+interface RawResponse {
+  status: number
+  headers: IncomingHttpHeaders
+  body: string
+}
+
+interface PassportResponse extends RawResponse {
+  data: JsonRecord
+}
+
+export interface QrCodeData extends JsonRecord {
+  token: string
+}
+
+export interface PollData extends JsonRecord {
+  status?: string
+}
+
+export class DouyinLoginError extends Error {
+  readonly status: number
+  readonly code?: number
+
+  constructor(message: string, status = 0, code?: number) {
+    super(message)
+    this.name = 'DouyinLoginError'
+    this.status = status
+    this.code = code
+  }
+}
+
+function parseRecord(value: unknown): JsonRecord {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return {}
+  return value as JsonRecord
+}
+
+function parsePossibleRecord(value: unknown): JsonRecord {
+  if (typeof value !== 'string') return parseRecord(value)
+  try {
+    return parseRecord(JSON.parse(value))
+  } catch {
+    return {}
+  }
+}
+
+export function readString(record: JsonRecord, key: string): string {
+  const value = record[key]
+  if (typeof value === 'string') return value
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value)
+  return ''
+}
+
+export function readNumber(record: JsonRecord, key: string): number | undefined {
+  const value = record[key]
+  if (typeof value === 'number' && Number.isFinite(value)) return value
+  if (typeof value === 'string' && value.trim()) {
+    const parsed = Number(value)
+    if (Number.isFinite(parsed)) return parsed
+  }
+  return undefined
+}
+
+function firstHeader(value: string | string[] | undefined): string {
+  return Array.isArray(value) ? value[0] || '' : value || ''
+}
+
+function serializeForUrl(value: Record<string, string | number>): string {
+  return Object.entries(value)
+    .map(([key, item]) => `${key}=${encodeURIComponent(String(item))}`)
+    .join('&')
+}
+
+function parseJson(body: string): JsonRecord {
+  try {
+    return parseRecord(JSON.parse(body))
+  } catch {
+    return { raw: body }
+  }
+}
+
+function responseMessage(response: PassportResponse): string {
+  const data = parseRecord(response.data.data)
+  return (
+    readString(data, 'description') ||
+    readString(data, 'message') ||
+    readString(response.data, 'message') ||
+    `HTTP ${response.status}`
+  )
+}
+
+function requestRaw(
+  method: 'GET' | 'POST',
+  url: string,
+  headers: Record<string, string>,
+  body = '',
+  timeout = 15000
+): Promise<RawResponse> {
+  return new Promise((resolve, reject) => {
+    const target = new URL(url)
+    const req = request(
+      {
+        method,
+        hostname: target.hostname,
+        port: target.port || 443,
+        path: target.pathname + target.search,
+        headers,
+        timeout
+      },
+      (res) => {
+        const chunks: Buffer[] = []
+        res.on('data', (chunk: Buffer) => chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)))
+        res.on('end', () => {
+          resolve({
+            status: res.statusCode || 0,
+            headers: res.headers,
+            body: Buffer.concat(chunks).toString('utf8')
+          })
+        })
+      }
+    )
+
+    req.on('timeout', () => req.destroy(new Error('抖音登录请求超时')))
+    req.on('error', reject)
+    if (body) req.write(body)
+    req.end()
+  })
+}
+
+export class DouyinLoginClient {
+  private cookie = ''
+  private msToken = ''
+  private initialized = false
+
+  async initialize(): Promise<void> {
+    if (this.initialized) return
+
+    try {
+      const home = await requestRaw(
+        'GET',
+        'https://www.douyin.com/',
+        {
+          Accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+          'User-Agent': DOUYIN_USER_AGENT,
+          'sec-ch-ua': '"Not_A Brand";v="99", "Chromium";v="142"',
+          'sec-ch-ua-mobile': '?0',
+          'sec-ch-ua-platform': '"Windows"'
+        },
+        '',
+        15000
+      )
+      this.applyResponse(home)
+    } catch {
+      // 首页失败时继续尝试注册 ttwid，最终由二维码接口返回明确错误
+    }
+
+    const ttwid = await requestRaw(
+      'POST',
+      'https://ttwid.bytedance.com/ttwid/register/',
+      {
+        Accept: 'application/json, text/plain, */*',
+        'Content-Type': 'application/json',
+        'User-Agent': DOUYIN_USER_AGENT,
+        Origin: 'https://www.douyin.com',
+        Referer: 'https://www.douyin.com/'
+      },
+      JSON.stringify({ aid: 6383, service: 'www.douyin.com' })
+    )
+    this.applyResponse(ttwid)
+
+    if (!getCookie('ttwid', this.cookie)) {
+      throw new DouyinLoginError('初始化抖音登录环境失败：未获取到 ttwid', ttwid.status)
+    }
+
+    this.initialized = true
+  }
+
+  async createQrCode(): Promise<QrCodeData> {
+    await this.initialize()
+    const response = await this.passportRequest('/passport/web/get_qrcode/', {
+      next: 'https://www.douyin.com',
+      need_short_url: 'true',
+      need_logo: 'false',
+      is_new_login: '1'
+    })
+    const data = parseRecord(response.data.data)
+    const token = readString(data, 'token')
+    if (response.status !== 200 || !token) {
+      throw this.makeResponseError('获取抖音登录二维码失败', response)
+    }
+    return { ...data, token }
+  }
+
+  async pollQrCode(token: string): Promise<PollData> {
+    const response = await this.passportRequest('/passport/web/check_qrconnect/', {
+      next: 'https://www.douyin.com',
+      need_logo: 'false',
+      is_frontier: 'true',
+      token,
+      is_new_login: '1',
+      need_short_url: 'true'
+    })
+    const data = parseRecord(response.data.data)
+
+    if (response.status !== 200) throw this.makeResponseError('查询抖音扫码状态失败', response)
+
+    let status = readString(data, 'status')
+    if (!status && (readString(data, 'account_flow') === 'verify' || readNumber(data, 'error_code') === 2046)) {
+      status = 'verify'
+    }
+
+    if (status === 'confirmed') {
+      const redirect = this.getRedirectUrl(data)
+      if (redirect) await this.followSsoRedirect(redirect)
+      if (!hasLoginCookie(this.cookie)) {
+        throw new DouyinLoginError('扫码已确认，但没有获取到有效登录凭证')
+      }
+    }
+
+    if (!status && Object.keys(data).length === 0) {
+      throw this.makeResponseError('抖音扫码接口未返回有效状态', response)
+    }
+
+    return status ? { ...data, status } : data
+  }
+
+  async sendSmsCode(verifyData: JsonRecord): Promise<JsonRecord> {
+    const context = this.extractVerifyContext(verifyData)
+    const encryptUid = readString(context, 'encrypt_uid')
+    if (!encryptUid) throw new DouyinLoginError('二次验证响应缺少 encrypt_uid')
+
+    const response = await this.passportLitePost('/passport/web/send_code/', this.buildSmsBody(context))
+    if (response.status !== 200) throw this.makeResponseError('发送短信验证码失败', response)
+    return parseRecord(response.data.data)
+  }
+
+  async validateSmsCode(verifyData: JsonRecord, code: string): Promise<JsonRecord> {
+    const context = this.extractVerifyContext(verifyData)
+    const encryptUid = readString(context, 'encrypt_uid')
+    if (!encryptUid) throw new DouyinLoginError('二次验证响应缺少 encrypt_uid')
+
+    const response = await this.passportLitePost('/passport/web/validate_code/', {
+      ...this.buildSmsBody(context),
+      code: encodeHexXor5(code)
+    })
+    if (response.status !== 200) throw this.makeResponseError('提交短信验证码失败', response)
+    return parseRecord(response.data.data)
+  }
+
+  getCookie(): string {
+    return buildCookieHeader(this.cookie)
+  }
+
+  hasLoginCookie(): boolean {
+    return hasLoginCookie(this.cookie)
+  }
+
+  private applyResponse(response: RawResponse): void {
+    const setCookie = setCookiesToCookieHeader(response.headers['set-cookie'])
+    if (setCookie) this.cookie = mergeCookies(this.cookie, setCookie)
+
+    const token = firstHeader(response.headers['x-ms-token'])
+    if (token) {
+      this.msToken = token
+      this.cookie = mergeCookies(this.cookie, `msToken=${token}`)
+    }
+  }
+
+  private async passportRequest(path: string, businessParams: Record<string, string | number>): Promise<PassportResponse> {
+    const common = makeCommonParams(businessParams)
+    const { sign, qs } = makeSignAndQs(common)
+    const queryMap: Record<string, string> = { ...common, sign, qs }
+    const msToken = getCookie('msToken', this.cookie) || this.msToken
+    if (msToken) queryMap.msToken = msToken
+
+    const query = serializeForUrl(queryMap)
+    const url = `https://${LOGIN_HOST}${path}?${query}&a_bogus=${encodeURIComponent(makeABogus(query))}`
+    const traceId = common.biz_trace_id
+    const cookie = buildCookieHeader(this.cookie)
+    const headers: Record<string, string> = {
+      Accept: 'application/json, text/javascript',
+      'Content-Type': 'application/x-www-form-urlencoded',
+      Referer: 'https://www.douyin.com/',
+      'User-Agent': DOUYIN_USER_AGENT,
+      'sec-ch-ua': '"Not_A Brand";v="99", "Chromium";v="142"',
+      'sec-ch-ua-mobile': '?0',
+      'sec-ch-ua-platform': '"Windows"',
+      'x-tt-passport-aid-sign': makeAidSign(path),
+      'x-tt-passport-csrf-token': getCookie('passport_csrf_token', this.cookie) || LOGIN_STATIC_HEADERS.csrfToken,
+      'x-tt-passport-verify-portrait': LOGIN_STATIC_HEADERS.verifyPortrait,
+      'x-tt-session-dtrait': LOGIN_STATIC_HEADERS.sessionDtrait
+    }
+    if (traceId) headers['x-tt-passport-trace-id'] = traceId
+    if (cookie) headers.Cookie = cookie
+
+    const response = await requestRaw('GET', url, headers)
+    this.applyResponse(response)
+    return { ...response, data: parseJson(response.body) }
+  }
+
+  private async passportLitePost(path: string, bodyParams: Record<string, string>): Promise<PassportResponse> {
+    const traceId = randomHex(8)
+    const query = serializeForUrl({
+      passport_jssdk_version: '5.1.2',
+      passport_jssdk_type: 'lite',
+      is_from_ttaccountsdk: '1',
+      aid: '6383',
+      language: 'zh',
+      account_app_language: 'zh-CN',
+      new_authn_sdk_version: '1.0.0.420-web',
+      biz_trace_id: traceId
+    })
+    const cookie = buildCookieHeader(this.cookie)
+    const headers: Record<string, string> = {
+      Accept: 'application/json, text/javascript',
+      'Content-Type': 'application/x-www-form-urlencoded',
+      Origin: 'https://www.douyin.com',
+      Referer: 'https://www.douyin.com/',
+      'User-Agent': DOUYIN_USER_AGENT,
+      'sec-ch-ua': '"Not_A Brand";v="99", "Chromium";v="142"',
+      'sec-ch-ua-mobile': '?0',
+      'sec-ch-ua-platform': '"Windows"',
+      'x-tt-passport-aid-sign': makeAidSign(path),
+      'x-tt-passport-csrf-token': getCookie('passport_csrf_token', this.cookie) || LOGIN_STATIC_HEADERS.csrfToken,
+      'x-tt-passport-trace-id': traceId,
+      'x-tt-passport-verify-portrait': LOGIN_STATIC_HEADERS.verifyPortrait,
+      'x-tt-session-dtrait': LOGIN_STATIC_HEADERS.sessionDtrait
+    }
+    if (cookie) headers.Cookie = cookie
+
+    const response = await requestRaw('POST', `https://www.douyin.com${path}?${query}`, headers, serializeForUrl(bodyParams))
+    this.applyResponse(response)
+    return { ...response, data: parseJson(response.body) }
+  }
+
+  private buildSmsBody(context: JsonRecord): Record<string, string> {
+    return {
+      mix_mode: '1',
+      type: readString(context, 'type') || '3737',
+      encrypt_uid: readString(context, 'encrypt_uid'),
+      verify_ticket: readString(context, 'verify_ticket'),
+      copywriting_key: readString(context, 'copywriting_key') || 'qr_connect',
+      ies_safety_diversion_tag: readString(context, 'ies_safety_diversion_tag') || 'mfa',
+      new_verify_flow: readString(context, 'new_verify_flow'),
+      std_verify_flow_id: readString(context, 'std_verify_flow_id'),
+      std_verify_scene: readString(context, 'std_verify_scene') || 'account_login',
+      std_verify_template: readString(context, 'std_verify_template') || 'ato_web',
+      std_verify_token: readString(context, 'std_verify_token'),
+      std_verify_type: readString(context, 'std_verify_type') || 'MFA',
+      std_verify_way: 'mobile_sms_verify',
+      is6Digits: readString(context, 'is6Digits') || '1',
+      aid: '6383',
+      new_authn_sdk_version: '1.0.0.420-web'
+    }
+  }
+
+  private extractVerifyContext(data: JsonRecord): JsonRecord {
+    const business = parsePossibleRecord(data.biz_params)
+    const ways = Array.isArray(data.verify_ways) ? data.verify_ways : []
+    const smsWay = ways.map(parseRecord).find((way) => readString(way, 'verify_way') === 'mobile_sms_verify') || {}
+    return { ...business, ...smsWay, ...data }
+  }
+
+  private async followSsoRedirect(redirectUrl: string): Promise<void> {
+    let current = redirectUrl
+    for (let hop = 0; hop < 5; hop++) {
+      const cookie = buildCookieHeader(this.cookie)
+      const headers: Record<string, string> = {
+        Accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+        'User-Agent': DOUYIN_USER_AGENT,
+        Referer: 'https://login.douyin.com/',
+        'sec-ch-ua': '"Not_A Brand";v="99", "Chromium";v="142"',
+        'sec-ch-ua-mobile': '?0',
+        'sec-ch-ua-platform': '"Windows"'
+      }
+      if (cookie) headers.Cookie = cookie
+
+      const response = await requestRaw('GET', current, headers)
+      this.applyResponse(response)
+      const location = firstHeader(response.headers.location)
+      if (location && [301, 302, 303, 307, 308].includes(response.status)) {
+        current = new URL(location, current).toString()
+        continue
+      }
+      break
+    }
+  }
+
+  private getRedirectUrl(data: JsonRecord): string {
+    const direct = readString(data, 'redirect_url')
+    if (direct) return direct
+    const redirects = data.redirect_urls
+    if (!Array.isArray(redirects)) return ''
+    return redirects.find((item): item is string => typeof item === 'string') || ''
+  }
+
+  private makeResponseError(prefix: string, response: PassportResponse): DouyinLoginError {
+    const data = parseRecord(response.data.data)
+    const code = readNumber(data, 'error_code')
+    return new DouyinLoginError(`${prefix}：${responseMessage(response)}`, response.status, code)
+  }
+}

--- a/packages/core/src/platform/douyin/login/constants.ts
+++ b/packages/core/src/platform/douyin/login/constants.ts
@@ -1,0 +1,12 @@
+export const DOUYIN_USER_AGENT =
+  'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) ' +
+  'Chrome/151.0.0.0 Safari/537.36 Edg/151.0.0.0'
+
+export const LOGIN_STATIC_HEADERS = {
+  csrfToken: process.env.DOUYIN_PASSPORT_CSRF_TOKEN || '0954e05cf058737af0d403f8635c56ae',
+  verifyPortrait:
+    process.env.DOUYIN_PASSPORT_VERIFY_PORTRAIT || '347a0777-4f77-4763-8f59-66fbedb9d23e.login',
+  sessionDtrait:
+    process.env.DOUYIN_DTRAIT ||
+    'd0_HgaG5cbCt2TvTQfFophli7cgBIjkPxaejLZkNCkTKAp0+1hbltGQXl1ce/npOEuqubhquvwZSoskcE0tVIRBp1AXLgOXDNsve3W1bF9bwrTKwRN9a47k09pG0EEkFUT269kw3xmP1CDWUcrryk/nKJnTDfpRa59PHoz9A48o5Dck8LLR5baA5S7CWrIJSKYqwe0zGQnoqwSf90R4KWZEVb94RhUYS7CZ5/hZNdqcHoXEBcHCPCFDfTFst9pb2mn214ukL5We2+nZxgeYSs4iF8uQEmTCboa8vaXMSgIq7bmpBxyl2x0TfpPD95hMclWaGhyE2ghsiqM30bzLTWZ4LA==_B/THvsJnA9W+dXsAo3RCMcpdsHOb9d1ibvual7anfaUBo4Qp/2+3PTVlshdUJae6bF7dsmsa/UFE2UFOZNU22gqPQvF50ODK6kzR+7H7KObU4EKbmKENfaoSlnfkIPNwKZSfiBIOrdQknDnDaNK+uXfUxSp4RlClTymrwNqG67bGwG9HyMdQadhMTaIb6pF0plTcUIRUicx95qBcRUXhtLXXppDNFbp9oLIX0CQb/7DgchWZlt4ty9QirC7HCwf/xRZHTkNW8nheAH6d0DFLj8DQec25CsSvvrUyrTO0tx1EdTrFWzYpu+i93/yFGO7qI/HaUQn+UeG19G9LwQWlfLo8divuJDxU9HKXQEkPtssqF4RZyMat1Vv9uc/5zaxH1FvWhCJffWG0nx39xt7m60ZdF97GDpqVXv0w9fQOPgW6bWQgVLS1iG5dX0oJ1LXct9v6EKkIUF06oGqrs6QFmA=='
+} as const

--- a/packages/core/src/platform/douyin/login/cookie.ts
+++ b/packages/core/src/platform/douyin/login/cookie.ts
@@ -1,0 +1,64 @@
+export function parseCookie(cookie?: string): Map<string, string> {
+  const result = new Map<string, string>()
+  if (!cookie) return result
+
+  for (const pair of cookie.split(';')) {
+    const separator = pair.indexOf('=')
+    if (separator <= 0) continue
+
+    const name = pair.slice(0, separator).trim()
+    const value = pair.slice(separator + 1).trim()
+    if (!name) continue
+
+    if (value) result.set(name, value)
+    else result.delete(name)
+  }
+
+  return result
+}
+
+export function buildCookieHeader(cookie?: string): string {
+  return [...parseCookie(cookie).entries()].map(([name, value]) => `${name}=${value}`).join('; ')
+}
+
+export function mergeCookies(...cookies: Array<string | undefined>): string {
+  const result = new Map<string, string>()
+
+  for (const cookie of cookies) {
+    for (const [name, value] of parseCookie(cookie)) {
+      result.set(name, value)
+    }
+  }
+
+  return [...result.entries()].map(([name, value]) => `${name}=${value}`).join('; ')
+}
+
+export function getCookie(name: string, cookie?: string): string | undefined {
+  return parseCookie(cookie).get(name)
+}
+
+export function setCookiesToCookieHeader(setCookie?: string | string[]): string {
+  const values = Array.isArray(setCookie) ? setCookie : setCookie ? [setCookie] : []
+  const result = new Map<string, string>()
+
+  for (const line of values) {
+    const first = line.split(';', 1)[0]?.trim()
+    if (!first) continue
+
+    const separator = first.indexOf('=')
+    if (separator <= 0) continue
+
+    const name = first.slice(0, separator).trim()
+    const value = first.slice(separator + 1).trim()
+    if (!name) continue
+
+    if (value) result.set(name, value)
+    else result.delete(name)
+  }
+
+  return [...result.entries()].map(([name, value]) => `${name}=${value}`).join('; ')
+}
+
+export function hasLoginCookie(cookie: string): boolean {
+  return Boolean(getCookie('sid_guard', cookie) || getCookie('sessionid', cookie) || getCookie('sessionid_ss', cookie))
+}

--- a/packages/core/src/platform/douyin/login/passport.ts
+++ b/packages/core/src/platform/douyin/login/passport.ts
@@ -1,0 +1,149 @@
+import crypto from 'node:crypto'
+
+export const PASSPORT_APP_KEY = '163e7ce78d58971a41f5b969996d85c2'
+export const PASSPORT_AID = '6383'
+export const LOGIN_HOST = 'login.douyin.com'
+export const JSSDK_VERSION = '3.1.3'
+export const P_VER = '1.1.3'
+export const P_BD = '1.0.1.19-fix.01'
+export const P_ZT = '3.3.14'
+export const P_UI = '2.1.9-alpha.6'
+export const P_CA = '4.0.17'
+export const P_CA_REAL = '1.0.0.874'
+
+const ACCOUNT_SDK_SOURCE_INFO =
+  '7e276d64776172647760466a6b66707777606b667c273f3433292772606761776c736077273f63646976602927666d776a686061776c736077273f63646976602927766d60696961776c736077273f63646976602927756970626c6b76273f3029276c6b6b60774d606c626d71273f3d3d3129276c6b6b6077526c61716d273f3430363d29276a707160774d606c626d71273f3d3d3129276a70716077526c61716d273f3430363d29277260676269273f7e2773606b616a77273f27426a6a626960254c6b662b252d4b534c414c442c27292777606b6160776077273f27444b424940252d4b534c414c4429254b534c414c44254260436a7766602557515d253635303525496475716a7525425550252d357d35353535373040372c25416c77606671364134342573765a305a352575765a305a35292541364134342c27782927756077636a7768646b6660273f7e27716c68604a776c626c6b273f34323d333c3d30303230313c3c2b362927707660614f564d606475566c7f60273f313d363d323d33373129276b64736c6264716c6a6b516c686c6b62273f7e276160666a616061476a617c566c7f60273f323d353236352927606b71777c517c7560273f276b64736c6264716c6a6b2729276c6b6c716c64716a77517c7560273f276b64736c6264716c6a6b2729276b646860273f276d717175763f2a2a7272722b616a707c6c6b2b666a682a707660772a766069633a63776a685a7164675a6b6468603868646c6b27292777606b61607747696a666e6c6b62567164717076273f276b6a6b2867696a666e6c6b62272927766077736077516c686c6b62273f2766616b286664666d602960616260296a776c626c6b296c6b6b60772971715a646272272927627069605671647771273f3c31332b353c3c3c3c3c3c35313336373329276270696041707764716c6a6b273f276b6a6b60277878292767776a72766077273f7e2771273f27373c34373d30303d3c333d3234272927676c715a75776a716a666a69273f276364697660272927676c715a6d6069756077273f63646976607878'
+
+const sha256Hex = (value: string): string => crypto.createHash('sha256').update(value, 'utf8').digest('hex')
+
+const hmacSha256 = (key: Uint8Array, value: Uint8Array): Uint8Array =>
+  new Uint8Array(crypto.createHmac('sha256', Buffer.from(key)).update(Buffer.from(value)).digest())
+
+const hexToBytes = (hex: string): Uint8Array => {
+  const pairs = hex.match(/.{1,2}/g) ?? []
+  return Uint8Array.from(pairs.map((pair) => Number.parseInt(pair, 16)))
+}
+
+export function encodeHexXor5(value: string): string {
+  let result = ''
+  for (const byte of Buffer.from(value, 'utf8')) result += (byte ^ 5).toString(16).padStart(2, '0')
+  return result
+}
+
+function serializeParams(value: Record<string, unknown>, limit = -1): { serialized: string; keys: string[] } {
+  const keys = Object.keys(value).sort()
+  if (limit >= 0) keys.splice(limit)
+
+  return {
+    serialized: keys
+      .map((key) => {
+        const item = value[key]
+        return typeof item === 'object' ? `${key}=${JSON.stringify(item)}` : `${key}=${String(item)}`
+      })
+      .join('&'),
+    keys
+  }
+}
+
+export function makeSignAndQs(
+  params: Record<string, unknown>,
+  data: Record<string, unknown> = {},
+  appKey = PASSPORT_APP_KEY
+): { sign: string; qs: string } {
+  const { serialized: query, keys } = serializeParams(params, 10)
+  const { serialized: body } = serializeParams(data)
+  return {
+    sign: sha256Hex(`${query}&${body}&app_key=${appKey}`),
+    qs: encodeHexXor5(keys.join(','))
+  }
+}
+
+export function makePNo(params: {
+  p_ca?: string
+  p_ts?: number | string
+  p_bd?: string
+  p_zt?: string
+  p_ver?: string
+  passport_jssdk_version?: string
+}): string {
+  const values: Record<string, string> = {
+    passport_jssdk_version: params.passport_jssdk_version ?? JSSDK_VERSION,
+    p_bd: params.p_bd ?? P_BD,
+    p_ca: params.p_ca ?? '0',
+    p_ts: String(params.p_ts ?? Date.now()),
+    p_ver: params.p_ver ?? P_VER,
+    p_zt: params.p_zt ?? P_ZT
+  }
+  return sha256Hex(
+    Object.keys(values)
+      .sort()
+      .map((key) => `${key}=${values[key]}`)
+      .join('&')
+  )
+}
+
+export function todayUtcNoonTs(): number {
+  const now = new Date()
+  return Math.floor(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate(), 12) / 1000)
+}
+
+function deriveKey(keyHex: string, salt: Uint8Array, length = 32): Uint8Array {
+  let result = new Uint8Array()
+  let previous = ''
+  let counter = 0
+
+  while (result.length < length) {
+    counter++
+    const input = Uint8Array.from([...hexToBytes(previous), ...salt, counter])
+    previous = Buffer.from(hmacSha256(hexToBytes(keyHex), input)).toString('hex')
+    result = Uint8Array.from([...result, ...hexToBytes(previous)])
+  }
+
+  return result.slice(0, length)
+}
+
+export function makeAidSign(path: string, aid = PASSPORT_AID, appKey = PASSPORT_APP_KEY): string {
+  const timestamp = String(todayUtcNoonTs())
+  const firstKey = Buffer.from(hmacSha256(new TextEncoder().encode(timestamp), new TextEncoder().encode(appKey))).toString('hex')
+  const key = deriveKey(firstKey, new Uint8Array())
+  return Buffer.from(hmacSha256(key, new TextEncoder().encode(`aid=${aid}&path=${path}&ts=${timestamp}`))).toString('hex')
+}
+
+export function randomHex(length: number): string {
+  let result = ''
+  while (result.length < length) result += Math.floor(Math.random() * 16).toString(16)
+  return result
+}
+
+export function makeCommonParams(extra: Record<string, string | number> = {}): Record<string, string> {
+  const timestamp = String(Date.now())
+  const params: Record<string, string> = {
+    passport_jssdk_version: JSSDK_VERSION,
+    passport_jssdk_type: 'normal',
+    is_from_ttaccountsdk: '1',
+    aid: PASSPORT_AID,
+    language: 'zh',
+    account_app_language: 'zh-CN',
+    ts: String(todayUtcNoonTs()),
+    ...Object.fromEntries(Object.entries(extra).map(([key, value]) => [key, String(value)])),
+    is_from_iesaccountsaas: '1',
+    p_ui: P_UI,
+    p_ca: P_CA,
+    p_ca_real: P_CA_REAL,
+    account_sdk_source: 'web',
+    account_sdk_source_info: ACCOUNT_SDK_SOURCE_INFO,
+    p_js_v: JSSDK_VERSION,
+    p_js_t: 'pro',
+    p_zt: P_ZT,
+    p_ver: P_VER,
+    p_ver_real: '0',
+    request_host: encodeURIComponent('https://www.douyin.com'),
+    p_bd: P_BD,
+    p_ts: timestamp,
+    p_no: '',
+    biz_trace_id: randomHex(8),
+    device_platform: 'web_app'
+  }
+  params.p_no = makePNo({ p_ca: P_CA, p_ts: timestamp })
+  return params
+}

--- a/packages/core/src/platform/douyin/login/signer.ts
+++ b/packages/core/src/platform/douyin/login/signer.ts
@@ -1,0 +1,466 @@
+/**
+ * Copyright AngelToms
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * a_bogus 签名引擎由 ylcangel/douyin_sign 的 utils.js 逐行翻译，
+ * 登录协议结构参考 dmmdekkd/DouyinDataAPI。
+ */
+import { DOUYIN_USER_AGENT } from './constants'
+import { sm3Digest, sm3DigestTwice } from './sm3'
+
+const AB_ARRAY_SIZE = 256
+const DY_SALT = 'dhzx'
+const enterPageTs = +Date.now()
+const sdkVersion = '1.0.1.19-fix.01'
+const aid = 6383
+const pageId = 7571
+
+const onwheelx = {
+  value: '0X21',
+  writable: false,
+  enumerable: true,
+  configurable: true
+}
+
+const envWindow = {
+  innerWidth: 2048,
+  innerHeight: 960,
+  outerWidth: 2554,
+  outerHeight: 1386,
+  onwheelx: null as unknown,
+  screen: {
+    availWidth: 2560,
+    availHeight: 1392,
+    width: 2560,
+    height: 1440,
+    sizeWidth: 2560,
+    sizeHeight: 1440
+  }
+}
+const envNavigator = {
+  userAgent: DOUYIN_USER_AGENT,
+  platform: 'Win32',
+  vendorSubs: {} as Record<string, unknown>
+}
+
+function createKey(): string {
+  const keyArray: number[] = []
+  let magic = 1
+  magic /= AB_ARRAY_SIZE
+  keyArray.push(magic)
+  magic = 1
+  magic %= AB_ARRAY_SIZE
+  keyArray.push(magic)
+  magic = 14
+  magic %= AB_ARRAY_SIZE
+  keyArray.push(magic)
+  return String.fromCharCode(...keyArray)
+}
+
+function dyRc4(key: string, text: string): string {
+  const state = new Uint8Array(AB_ARRAY_SIZE)
+  const keyBytes = new Uint8Array(AB_ARRAY_SIZE)
+  const maxStateIndex = AB_ARRAY_SIZE - 1
+  for (let index = 0; index < AB_ARRAY_SIZE; index++) {
+    state[index] = maxStateIndex - index
+    keyBytes[index] = key.charCodeAt(index % key.length)
+  }
+  let j = 0
+  for (let index = 0; index < AB_ARRAY_SIZE; index++) {
+    j = (j * state[index] + j + keyBytes[index]) % AB_ARRAY_SIZE
+    const current = state[index]
+    state[index] = state[j]
+    state[j] = current
+  }
+  let i = 0
+  let k = 0
+  let cipher = ''
+  for (let index = 0; index < text.length; index++) {
+    i = (i + 1) % AB_ARRAY_SIZE
+    k = (k + state[i]) % AB_ARRAY_SIZE
+    const current = state[i]
+    state[i] = state[k]
+    state[k] = current
+    const random = state[(state[i] + state[k]) % AB_ARRAY_SIZE]
+    cipher += String.fromCharCode(text.charCodeAt(index) ^ random)
+  }
+  return cipher
+}
+
+function dyBase64(code: string, tableName: string, pad: string | null = '='): string {
+  if (pad === null) pad = '='
+  const tables: Record<string, string> = {
+    s0: 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=',
+    s1: 'Dkdpgh4ZKsQB80/Mfvw36XI1R25+WUAlEi7NLboqYTOPuzmFjJnryx9HVGcaStCe=',
+    s2: 'Dkdpgh4ZKsQB80/Mfvw36XI1R25-WUAlEi7NLboqYTOPuzmFjJnryx9HVGcaStCe=',
+    s3: 'ckdp1h4ZKsUB80/Mfvw36XIgR25+WQAlEi7NLboqYTOPuzmFjJnryx9HVGDaStCe',
+    s4: 'Dkdpgh2ZmsQB80/MfvV36XI1R45-WUAlEixNLwoqYTOPuzKFjJnry79HbGcaStCe'
+  }
+  const table = tables[tableName]
+  let encoded = ''
+  let index = 0
+  while (index < code.length) {
+    const firstOriginal = code.charCodeAt(index++)
+    const secondOriginal = code.charCodeAt(index++)
+    const thirdOriginal = code.charCodeAt(index++)
+    const first = (firstOriginal & 255) << 16
+    const second = Number.isNaN(secondOriginal) ? 0 : (secondOriginal & 255) << 8
+    const third = Number.isNaN(thirdOriginal) ? 0 : thirdOriginal & 255
+    const packed = (first | second) | third
+    encoded += table.charAt((packed & 16515072) >> 18)
+    encoded += table.charAt((packed & 258048) >> 12)
+    if (!Number.isNaN(secondOriginal)) encoded += table.charAt((packed & 4032) >> 6)
+    if (!Number.isNaN(thirdOriginal)) encoded += table.charAt(packed & 63)
+    if (Number.isNaN(secondOriginal)) encoded += pad
+    if (Number.isNaN(thirdOriginal)) encoded += pad
+  }
+  return encoded
+}
+
+function random(input: Record<string, unknown>): number[] {
+  const value = input[0] as [number, number]
+  const secondValue = input[1]
+  const firstInput = value[0]
+  const secondInput = value[1]
+  let flag = 0
+  const randomValue = Math.random() * 65535
+  let first = randomValue & 255
+  let second = (randomValue >> 8) & 255
+  if ((input.length as number) > 1) {
+    if (secondValue !== void 0) flag = input[1] as number
+  } else {
+    flag = 0
+  }
+  if (flag === 1) second = 0
+  if (flag === 2) {
+    first = (Math.random() * 240) >> 0
+    if (first > 109) {
+      first += first % 2
+      first += 1
+    }
+    second = 0
+    second |= 1 << 1
+    second |= 1 << 4
+    second |= 1 << 5
+    second |= 1 << 7
+  }
+  return [
+    (first & 170) | (firstInput & 85),
+    (first & 85) | (firstInput & 170),
+    (second & 170) | (secondInput & 85),
+    (second & 85) | (secondInput & 170)
+  ]
+}
+
+function makeVersionArray(version: string): number[] {
+  const parts = version.split('.')
+  const result = new Array<number>(parts.length)
+  for (let index = 0; index < parts.length; index++) result[index] = ~~+parts[index]
+  return result
+}
+
+function transformPayload(array: number[]): number[] {
+  const result: number[] = []
+  const mask1 = 145
+  const mask2 = 110
+  const mask3 = 66
+  const mask4 = 189
+  const mask5 = 44
+  const mask6 = 211
+  let index = 0
+  while (index < array.length) {
+    if (index + 2 < array.length) {
+      const randomValue = (Math.random() * 1000) & 255
+      result.push(
+        (randomValue & mask1) | (array[index] & mask2),
+        (randomValue & mask3) | (array[index + 1] & mask4),
+        (randomValue & mask5) | (array[index + 2] & mask6),
+        (array[index] & mask1) | (array[index + 1] & mask3) | (array[index + 2] & mask5)
+      )
+    } else {
+      result.push(array[index])
+      if (array[index + 1] !== void 0) result.push(array[index + 1])
+    }
+    index += 3
+  }
+  return result
+}
+
+export function makeABogus(uri: string): string {
+  const values: unknown[] = []
+  const ink = +Date.now() - 1
+  envNavigator.vendorSubs = { ink }
+
+  values[0] = []
+  ;(values[0] as unknown[]).length = 22
+  ;(values[0] as unknown[])[0] = {}
+  ;(values[0] as unknown[])[1] = { length: 0 }
+  ;(values[0] as unknown[])[2] = DY_SALT
+  ;(values[0] as unknown[])[3] = enterPageTs
+  ;(values[0] as unknown[])[4] = 1
+
+  values[1] = []
+  ;(values[1] as unknown[]).length = 9
+  ;(values[1] as unknown[])[0] = 1
+  ;(values[1] as unknown[])[1] = 0
+  ;(values[1] as unknown[])[2] = 8
+  ;(values[1] as unknown[])[3] = uri
+  ;(values[1] as unknown[])[4] = ''
+  ;(values[1] as unknown[])[5] = envNavigator.userAgent
+  ;(values[1] as unknown[])[6] = pageId
+  ;(values[1] as unknown[])[7] = aid
+  ;(values[1] as unknown[])[8] = sdkVersion
+
+  values[2] = 1
+  values[3] = 0
+  values[4] = 8
+  values[5] = uri.endsWith(DY_SALT) ? uri : uri + DY_SALT
+  values[6] = ''
+  values[7] = envNavigator.userAgent.trim()
+  values[8] = pageId
+  values[9] = aid
+  values[10] = sdkVersion
+
+  const urlDigest = sm3DigestTwice(values[5] as string)
+  const saltDigest = sm3DigestTwice(DY_SALT)
+  const userAgentCipher = dyRc4(createKey(), values[7] as string)
+  const encodedUserAgent = dyBase64(userAgentCipher, 's3', null)
+  const userAgentDigest = sm3Digest(encodedUserAgent)
+
+  values[11] = envNavigator.vendorSubs
+  values[12] = 3
+  envWindow.onwheelx = onwheelx as unknown
+  values[13] = envWindow.onwheelx
+  values[14] = +Date.now()
+
+  values[15] = []
+  values[16] = 1
+  values[17] = 14
+  values[18] = urlDigest
+  values[19] = saltDigest
+  values[20] = encodedUserAgent
+  values[21] = userAgentDigest
+  values[22] = ink
+  values[23] = [3, 82]
+  values[24] = 41
+  values[25] = makeVersionArray(sdkVersion)
+
+  const epoch = 1721836800000
+  const now = Date.now()
+  values[26] = ((now - epoch) / 1000 / 60 / 60 / 24 / 14) >> 0
+  values[27] = 6
+  values[28] = ((values[14] as number) - enterPageTs + 3) & 255
+  values[29] = (values[14] as number) & 255
+  values[30] = ((values[14] as number) >> 8) & 255
+  values[31] = ((values[14] as number) >> 16) & 255
+  values[32] = ((values[14] as number) >> 24) & 255
+  values[33] = ((values[14] as number) / 256 / 256 / 256 / 256) & 255
+  values[34] = ((values[14] as number) / 256 / 256 / 256 / 256 / 256) & 255
+  values[35] = ((values[16] as number) % 256) & 255
+  values[36] = ((values[16] as number) / 256) & 255
+
+  values[37] = [0, 0, 0, 0, 129]
+  values[38] = (values[37] as number[])[4] & 255
+  values[39] = ((values[37] as number[])[4] >> 8) & 255
+  values[40] = (values[37] as number[])[0]
+  values[41] = (values[37] as number[])[1]
+  values[42] = (values[37] as number[])[2]
+  values[43] = (values[37] as number[])[3]
+  values[44] = (values[17] as number) & 255
+  values[45] = ((values[17] as number) >> 8) & 255
+  values[46] = ((values[17] as number) >> 16) & 255
+  values[47] = ((values[17] as number) >> 24) & 255
+  values[48] = (values[18] as number[])[9]
+  values[49] = (values[18] as number[])[18]
+  values[50] = 3
+  values[51] = (values[18] as number[])[3]
+  values[52] = (values[19] as number[])[10]
+  values[53] = (values[19] as number[])[19]
+  values[54] = 4
+  values[55] = (values[19] as number[])[4]
+  values[56] = (values[21] as number[])[11]
+  values[57] = (values[21] as number[])[21]
+  values[58] = 5
+  values[59] = (values[21] as number[])[5]
+  values[60] = (values[22] as number) & 255
+  values[61] = ((values[22] as number) >> 8) & 255
+  values[62] = ((values[22] as number) >> 16) & 255
+  values[63] = ((values[22] as number) >> 24) & 255
+  values[64] = ((values[22] as number) / 256 / 256 / 256 / 256) & 255
+  values[65] = ((values[22] as number) / 256 / 256 / 256 / 256 / 256) & 255
+  values[66] = values[12]
+  values[67] = (values[8] as number) & 255
+  values[68] = ((values[8] as number) >> 8) & 255
+  values[69] = ((values[8] as number) >> 16) & 255
+  values[70] = ((values[8] as number) >> 24) & 255
+  values[71] = (values[9] as number) & 255
+  values[72] = ((values[9] as number) >> 8) & 255
+  values[73] = ((values[9] as number) >> 16) & 255
+  values[74] = ((values[9] as number) >> 24) & 255
+
+  const windowSnapshot: Record<string, number> = {
+    innerWidth: envWindow.innerWidth >> 0,
+    innerHeight: envWindow.innerHeight >> 0,
+    outerWidth: envWindow.outerWidth >> 0,
+    outerHeight: envWindow.outerHeight >> 0,
+    availWidth: envWindow.screen.availWidth >> 0,
+    availHeight: envWindow.screen.availHeight >> 0,
+    sizeWidth: envWindow.screen.width >> 0 === 0 ? 2560 : envWindow.screen.sizeWidth >> 0,
+    sizeHeight: envWindow.screen.height >> 0 === 0 ? 1440 : envWindow.screen.sizeHeight >> 0,
+    platform: envNavigator.platform as unknown as number
+  }
+  values[75] = windowSnapshot
+
+  let serializedWindow = ''
+  for (const key of Object.keys(windowSnapshot)) serializedWindow += windowSnapshot[key] + '|'
+  serializedWindow = serializedWindow.substring(0, serializedWindow.length - 1)
+  values[76] = serializedWindow
+
+  const windowBytes: number[] = []
+  for (let index = 0; index < serializedWindow.length; index++) windowBytes.push(serializedWindow.charCodeAt(index))
+  values[77] = windowBytes
+  values[78] = windowBytes.length
+  values[79] = (values[78] as number) & 255
+  values[80] = ((values[78] as number) >> 8) & 255
+
+  const timingValue = (((values[14] as number) + 3) & 255) + ','
+  values[81] = timingValue
+  const timingBytes: number[] = []
+  for (let index = 0; index < timingValue.length; index++) timingBytes.push(timingValue.charCodeAt(index))
+  values[82] = timingBytes
+  values[83] = timingBytes.length
+  values[84] = (values[83] as number) & 255
+  values[85] = ((values[83] as number) >> 8) & 255
+
+  const version = values[25] as number[]
+  const flaggedVersion = { 0: [version[0], version[1]], 1: 2, length: 2 }
+  values[86] = random({ 0: [version[0], version[1]], length: 1 }).concat(random(flaggedVersion))
+
+  const versionBytes = values[86] as number[]
+  values[87] =
+    (versionBytes[0] ^
+      versionBytes[1] ^
+      versionBytes[2] ^
+      versionBytes[3] ^
+      versionBytes[4] ^
+      versionBytes[5] ^
+      versionBytes[6] ^
+      versionBytes[7]) ^
+    (values[24] as number) ^
+    (values[26] as number) ^
+    (values[27] as number) ^
+    (values[28] as number) ^
+    (values[29] as number) ^
+    (values[30] as number) ^
+    (values[31] as number) ^
+    (values[32] as number) ^
+    (values[33] as number) ^
+    (values[34] as number) ^
+    (values[35] as number) ^
+    (values[36] as number) ^
+    (values[38] as number) ^
+    (values[39] as number) ^
+    (values[40] as number) ^
+    (values[41] as number) ^
+    (values[42] as number) ^
+    (values[43] as number) ^
+    (values[44] as number) ^
+    (values[45] as number) ^
+    (values[46] as number) ^
+    (values[47] as number) ^
+    (values[48] as number) ^
+    (values[49] as number) ^
+    (values[51] as number) ^
+    (values[52] as number) ^
+    (values[53] as number) ^
+    (values[55] as number) ^
+    (values[56] as number) ^
+    (values[57] as number) ^
+    (values[59] as number) ^
+    (values[60] as number) ^
+    (values[61] as number) ^
+    (values[62] as number) ^
+    (values[63] as number) ^
+    (values[64] as number) ^
+    (values[65] as number) ^
+    (values[66] as number) ^
+    (values[67] as number) ^
+    (values[68] as number) ^
+    (values[69] as number) ^
+    (values[70] as number) ^
+    (values[71] as number) ^
+    (values[72] as number) ^
+    (values[73] as number) ^
+    (values[74] as number) ^
+    (values[79] as number) ^
+    (values[80] as number) ^
+    (values[84] as number) ^
+    (values[85] as number)
+
+  const payload = [
+    values[34],
+    values[44],
+    values[56],
+    values[61],
+    values[73],
+    values[29],
+    values[70],
+    values[45],
+    values[35],
+    values[49],
+    values[38],
+    values[66],
+    values[51],
+    values[68],
+    values[28],
+    values[48],
+    values[64],
+    values[47],
+    values[30],
+    values[71],
+    values[26],
+    values[55],
+    values[31],
+    values[69],
+    values[59],
+    values[40],
+    values[62],
+    values[63],
+    values[27],
+    values[72],
+    values[41],
+    values[74],
+    values[57],
+    values[52],
+    values[42],
+    values[39],
+    values[33],
+    values[67],
+    values[53],
+    values[43],
+    values[65],
+    values[46],
+    values[36],
+    values[24],
+    values[60],
+    values[32],
+    values[79],
+    values[80],
+    values[84],
+    values[85]
+  ] as number[]
+
+  values[88] = payload.concat(windowBytes, timingBytes, [values[87] as number])
+  const prefixBytes = random({ 0: values[23] as number[], 1: 1, length: 2 })
+  const prefix = String.fromCharCode(...prefixBytes)
+  values[89] = prefix
+  values[90] = transformPayload(values[88] as number[])
+
+  const encryptionKey = String.fromCharCode(211)
+  const plainBytes = (values[86] as number[]).concat(values[90] as number[])
+  const plain = String.fromCharCode(...plainBytes)
+  values[91] = dyRc4(encryptionKey, plain)
+  values[92] = prefix + (values[91] as string)
+  values[93] = dyBase64(values[92] as string, 's4', null)
+  return values[93] as string
+}

--- a/packages/core/src/platform/douyin/login/sm3.ts
+++ b/packages/core/src/platform/douyin/login/sm3.ts
@@ -1,0 +1,171 @@
+/**
+ * Copyright AngelToms
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * 由 ylcangel/douyin_sign 的 SM3 实现移植为 TypeScript。
+ */
+function t(index: number): number {
+  return index < 16 ? 0x79cc4519 : 0x7a879d8a
+}
+
+function ff(index: number, x: number, y: number, z: number): number {
+  return index < 16 ? (x ^ y ^ z) >>> 0 : ((x & y) | (x & z) | (y & z)) >>> 0
+}
+
+function gg(index: number, x: number, y: number, z: number): number {
+  return index < 16 ? (x ^ y ^ z) >>> 0 : ((x & y) | (~x & z)) >>> 0
+}
+
+class SM3 {
+  private readonly register = new Array<number>(8)
+  private chunk: number[] = []
+  private size = 0
+
+  constructor() {
+    this.reset()
+  }
+
+  private reset(): void {
+    this.register[0] = 0x7380166f
+    this.register[1] = 0x4914b2b9
+    this.register[2] = 0x172442d7
+    this.register[3] = 0xda8a0600
+    this.register[4] = 0xa96f30bc
+    this.register[5] = 0x163138aa
+    this.register[6] = 0xe38dee4d
+    this.register[7] = 0xb0fb0e4e
+    this.chunk = []
+    this.size = 0
+  }
+
+  private stringToBytes(value: string): number[] {
+    const result: number[] = []
+    for (let index = 0; index < value.length; index++) {
+      let character = value.charCodeAt(index)
+      const bytes: number[] = []
+      do {
+        bytes.push(character & 0xff)
+        character >>= 8
+      } while (character)
+      result.push(...bytes.reverse())
+    }
+    return result
+  }
+
+  private write(message: string | number[]): void {
+    const input = typeof message === 'string' ? this.stringToBytes(message) : message
+    this.size += input.length
+    let offset = 64 - this.chunk.length
+
+    if (input.length < offset) {
+      this.chunk = this.chunk.concat(input)
+      return
+    }
+
+    this.chunk = this.chunk.concat(input.slice(0, offset))
+    while (this.chunk.length >= 64) {
+      this.compress(this.chunk)
+      this.chunk = offset < input.length ? input.slice(offset, Math.min(offset + 64, input.length)) : []
+      offset += 64
+    }
+  }
+
+  sum(message: string | number[]): number[] {
+    this.reset()
+    this.write(message)
+    this.fill()
+
+    for (let offset = 0; offset < this.chunk.length; offset += 64) {
+      this.compress(this.chunk.slice(offset, offset + 64))
+    }
+
+    const digest = new Array<number>(32)
+    for (let index = 0; index < 8; index++) {
+      let hash = this.register[index]
+      digest[index * 4 + 3] = hash & 0xff
+      hash >>>= 8
+      digest[index * 4 + 2] = hash & 0xff
+      hash >>>= 8
+      digest[index * 4 + 1] = hash & 0xff
+      hash >>>= 8
+      digest[index * 4] = hash & 0xff
+    }
+
+    this.reset()
+    return digest
+  }
+
+  private rotateLeft(value: number, offset: number): number {
+    const normalized = offset % 32
+    return ((value << normalized) | (value >>> (32 - normalized))) >>> 0
+  }
+
+  private compress(message: number[]): void {
+    const expanded = this.expand(message)
+    const register = this.register.slice()
+
+    for (let index = 0; index < 64; index++) {
+      let ss1 = this.rotateLeft(register[0], 12) + register[4] + this.rotateLeft(t(index), index)
+      ss1 = (ss1 & 0xffffffff) >>> 0
+      ss1 = this.rotateLeft(ss1, 7)
+      const ss2 = (ss1 ^ this.rotateLeft(register[0], 12)) >>> 0
+      let tt1 = ff(index, register[0], register[1], register[2]) + register[3] + ss2 + expanded[index + 68]
+      tt1 = (tt1 & 0xffffffff) >>> 0
+      let tt2 = gg(index, register[4], register[5], register[6]) + register[7] + ss1 + expanded[index]
+      tt2 = (tt2 & 0xffffffff) >>> 0
+
+      register[3] = register[2]
+      register[2] = this.rotateLeft(register[1], 9)
+      register[1] = register[0]
+      register[0] = tt1
+      register[7] = register[6]
+      register[6] = this.rotateLeft(register[5], 19)
+      register[5] = register[4]
+      register[4] = (tt2 ^ this.rotateLeft(tt2, 9) ^ this.rotateLeft(tt2, 17)) >>> 0
+    }
+
+    for (let index = 0; index < 8; index++) {
+      this.register[index] = (this.register[index] ^ register[index]) >>> 0
+    }
+  }
+
+  private fill(): void {
+    const bitLength = this.size * 8
+    let length = this.chunk.push(0x80) % 64
+    if (64 - length < 8) length -= 64
+    for (; length < 56; length++) this.chunk.push(0)
+
+    const high = Math.floor(bitLength / 0x100000000)
+    for (let index = 0; index < 4; index++) this.chunk.push((high >>> ((3 - index) * 8)) & 0xff)
+    for (let index = 0; index < 4; index++) this.chunk.push((bitLength >>> ((3 - index) * 8)) & 0xff)
+  }
+
+  private expand(bytes: number[]): number[] {
+    const words = new Array<number>(132)
+    for (let index = 0; index < 16; index++) {
+      words[index] =
+        ((bytes[index * 4] << 24) |
+          (bytes[index * 4 + 1] << 16) |
+          (bytes[index * 4 + 2] << 8) |
+          bytes[index * 4 + 3]) >>>
+        0
+    }
+
+    for (let index = 16; index < 68; index++) {
+      let value = words[index - 16] ^ words[index - 9] ^ this.rotateLeft(words[index - 3], 15)
+      value ^= this.rotateLeft(value, 15) ^ this.rotateLeft(value, 23)
+      words[index] = (value ^ this.rotateLeft(words[index - 13], 7) ^ words[index - 6]) >>> 0
+    }
+
+    for (let index = 0; index < 64; index++) words[index + 68] = (words[index] ^ words[index + 4]) >>> 0
+    return words
+  }
+}
+
+export function sm3Digest(message: string | number[]): number[] {
+  return new SM3().sum(message)
+}
+
+export function sm3DigestTwice(message: string | number[]): number[] {
+  return new SM3().sum(new SM3().sum(message))
+}

--- a/packages/core/vite.config.ts
+++ b/packages/core/vite.config.ts
@@ -74,8 +74,6 @@ export default defineConfig({
         ...[/^node-karin/],
         // @karinjs/template-react 必须打进产物（与模板组件共用同一份 React），其余 @karinjs 包保持外部
         ...[/^@karinjs\/(?!template-react)/],
-        'fingerprint-injector',
-        // '@snapka/puppeteer',
         '@ikenxuan/watermark',
         '@ikenxuan/qrcode'
       ],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -154,9 +154,6 @@ importers:
       '@ikenxuan/watermark':
         specifier: 1.3.1
         version: 1.3.1
-      fingerprint-injector:
-        specifier: ^2.1.88
-        version: 2.1.88
     devDependencies:
       '@heroui/react':
         specifier: 3.2.4
@@ -194,9 +191,6 @@ importers:
       '@phosphor-icons/react':
         specifier: ^2.1.10
         version: 2.1.10(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@snapka/puppeteer':
-        specifier: ^0.2.7
-        version: 0.2.7(supports-color@7.2.0)
       '@thesvg/icons':
         specifier: ^3.0.18
         version: 3.2.15
@@ -2148,11 +2142,6 @@ packages:
   '@primer/octicons@19.32.0':
     resolution: {integrity: sha512-a8QHSWZVOFusPWl8EzL7EyHnEtHCvfSqaHyR3fdb1XbetlyXfo4g+aZ2xEuEJH15848LGhcKn9x1PPztCUcgzA==}
 
-  '@puppeteer/browsers@2.13.2':
-    resolution: {integrity: sha512-5EUZSUIc37H6aIXyWO0Z4y8NlF8NnjgmqeQgOGiswAU7pY0HOo16ho4+alIWmSfdZnjqBRawMsP3I5YqLSn6kw==}
-    engines: {node: '>=18'}
-    hasBin: true
-
   '@quansync/fs@1.0.0':
     resolution: {integrity: sha512-4TJ3DFtlf1L5LDMaM6CanJ/0lckGNtJcMjQ1NAV6zDmA0tEHKZtxNKin8EgPaVX1YzljbxckyT2tJrpQKAtngQ==}
 
@@ -3338,27 +3327,9 @@ packages:
     resolution: {integrity: sha512-KxXvfapcixpz6rVEB6HPjOUZT22yN6v0vI0urQSk1L8MlEWPDFCZkhw2xmkyoTGYeFw7tWTZd7e3lVzRZRN/EA==}
     engines: {node: '>=18'}
 
-  '@sindresorhus/is@4.6.0':
-    resolution: {integrity: sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==}
-    engines: {node: '>=10'}
-
   '@sindresorhus/merge-streams@4.0.0':
     resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
     engines: {node: '>=18'}
-
-  '@snapka/browser-finder@0.1.12':
-    resolution: {integrity: sha512-PS6t3OiVom2u+TqcnDyWXx9EQBdMwdCgot9ZWv87R8aCwnuJYPy34xA/+maNgKf9EK5nE2c+9vLQ75V1fv8yyA==}
-
-  '@snapka/browsers@0.4.0':
-    resolution: {integrity: sha512-XQIVmV4zPTPv898gcDdsHbuAoHAaVKKCayl6KG1z/zV1/Ri5Ut+XM/74DA9dSRApFM2bPcr0esqeIPKjQeAsJA==}
-    engines: {node: '>=18'}
-    hasBin: true
-
-  '@snapka/puppeteer@0.2.7':
-    resolution: {integrity: sha512-siidYM+qzHP6nBi/V1cNrxxUjzeES4EzxgLmegZiOhafLBB9yAFGKMYtHHojJTBVAhykikXf8GM45tRq815VXA==}
-
-  '@snapka/types@0.1.5':
-    resolution: {integrity: sha512-DA8ZpY+HpWamrJU1mN/3oR6cZVOrm3tscsILXYOICaecTzvIDf51kjv5NNZkEfdRRjfLfmYKI6QObwjqD2fDug==}
 
   '@spectrum-icons/ui@3.7.1':
     resolution: {integrity: sha512-veQymocUYo5OciXQajSailOdbWe+k6+2ehfF8D4d0V923D4xOUadtT253xXZ5vEQjPat6Kyp2WDKeQNjd7kL1w==}
@@ -3585,9 +3556,6 @@ packages:
     resolution: {integrity: sha512-+3zbTks3TkWTIbuODIdYUQCT04dSyx765jrhT6BKD4K89sE/qsQ0BDBajYTGrUA9g99kJEKOpQKm+LKG0sFeQQ==}
     engines: {node: '>=18'}
 
-  '@tootallnate/quickjs-emscripten@0.23.0':
-    resolution: {integrity: sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==}
-
   '@ts-morph/common@0.27.0':
     resolution: {integrity: sha512-Wf29UqxWDpc+i61k3oIOzcUfQt79PIT9y/MWfAGlrkjg6lBC1hwDECLXPVJAhWjiGbfBCxZd65F/LIZF3+jeJQ==}
 
@@ -3800,9 +3768,6 @@ packages:
 
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
-
-  '@types/yauzl@2.10.3':
-    resolution: {integrity: sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==}
 
   '@typescript/vfs@1.6.4':
     resolution: {integrity: sha512-PJFXFS4ZJKiJ9Qiuix6Dz/OwEIqHD7Dme1UwZhTK11vR+5dqW2ACbdndWQexBzCx+CPuMe5WBYQWCsFyGlQLlQ==}
@@ -4136,17 +4101,9 @@ packages:
   add-stream@1.0.0:
     resolution: {integrity: sha512-qQLMr+8o0WC4FZGQTcJiKBVC59JylcPSrTtk6usvmIDFUOCKegapy1VHQwRbFMOFyb/inzUVqHs+eMYKDM1YeQ==}
 
-  adm-zip@0.6.0:
-    resolution: {integrity: sha512-XleryMhbuksdKtofnWZ9Sk+4CUTbms4Mb/EU32SZwToAyZ5RgVos/ki8n+yr0LWHOGKuakbXTuuYNHLQjhddgg==}
-    engines: {node: '>=14.0'}
-
   agent-base@6.0.2:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
     engines: {node: '>= 6.0.0'}
-
-  agent-base@7.1.4:
-    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
-    engines: {node: '>= 14'}
 
   ahooks@3.9.7:
     resolution: {integrity: sha512-S0lvzhbdlhK36RFBkGv+RbOM/dbbweym+BIHM/bwwuWVSVN5TuVErHPMWo4w0t1NDYg5KPp2iEf7Y7E5LASYiw==}
@@ -4231,10 +4188,6 @@ packages:
     resolution: {integrity: sha512-Q+JC7Whu8HhmTdBph/Tq59IoRtoy6KAm5zzPv00WdujX82lbAL8K7WVjne7vdCsAmbF4AYaDOPyO3k0kl8qIrw==}
     engines: {node: '>=0.10.0'}
 
-  ast-types@0.13.4:
-    resolution: {integrity: sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==}
-    engines: {node: '>=4'}
-
   ast-types@0.16.1:
     resolution: {integrity: sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==}
     engines: {node: '>=4'}
@@ -4260,14 +4213,6 @@ packages:
   axios@1.19.0:
     resolution: {integrity: sha512-ht/iuYZXEjFxLH/Hkezgd7m6JKlHHXEUSneaDz8uZe1Gj5QZtCnpyDsckvAiEnT89OEbCLmnte4R4sn7P0EKFw==}
 
-  b4a@1.8.1:
-    resolution: {integrity: sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==}
-    peerDependencies:
-      react-native-b4a: '*'
-    peerDependenciesMeta:
-      react-native-b4a:
-        optional: true
-
   babel-plugin-macros@3.1.0:
     resolution: {integrity: sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==}
     engines: {node: '>=10', npm: '>=6'}
@@ -4279,51 +4224,10 @@ packages:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
 
-  bare-events@2.9.1:
-    resolution: {integrity: sha512-Z0oHEHAFDZkffN8Qc39zNZjQlMDkPJRyyyZieU1VH7u8c5S+qHZ2S8ixdKIAxEjfHO7FJxXmJWgteOghVanIsg==}
-    peerDependencies:
-      bare-abort-controller: '*'
-    peerDependenciesMeta:
-      bare-abort-controller:
-        optional: true
-
-  bare-fs@4.7.4:
-    resolution: {integrity: sha512-y1kC+ffIx/tPLdTE693uNjHfzTfr+ravR5tvWlMXe25nELbkqV400S71qHDwbkAQ1FVEZobB1NFRzFbCCcyBCQ==}
-    engines: {bare: '>=1.16.0'}
-    peerDependencies:
-      bare-buffer: '*'
-    peerDependenciesMeta:
-      bare-buffer:
-        optional: true
-
-  bare-path@3.1.1:
-    resolution: {integrity: sha512-JprUlveX3QjApC1cTpsUOiscADftCGVWkzitbHsRqv84hzYwYHw2mbluddsq5TvI8mH/8Ov1f4BiMAdcB0oYnQ==}
-
-  bare-stream@2.13.3:
-    resolution: {integrity: sha512-Kc+brLqvEqGkjyfiwJmImAOqLZL7OsoLKuavx+hJjgVV3nLTOjloJyPMFxjUPerGGHrNH0fLU06jjykMLWrERQ==}
-    peerDependencies:
-      bare-abort-controller: '*'
-      bare-buffer: '*'
-      bare-events: '*'
-    peerDependenciesMeta:
-      bare-abort-controller:
-        optional: true
-      bare-buffer:
-        optional: true
-      bare-events:
-        optional: true
-
-  bare-url@2.4.6:
-    resolution: {integrity: sha512-iQxPClE07hETVpbRoX7JXX3v/ZQViCxe/SYCxylRLzdEx1xJAufPptfiOqR8tqiCtmbtMDANKWszzjLu1PMAZQ==}
-
   baseline-browser-mapping@2.11.7:
     resolution: {integrity: sha512-APw5YuIQAg6L9w4sHDI6j26DGFJI6RpYOhnkMPdC9lWbkKvsyPHzDsve1yd73lk21yz7Y09Kci8B2Pp9FonzWA==}
     engines: {node: '>=6.0.0'}
     hasBin: true
-
-  basic-ftp@5.3.1:
-    resolution: {integrity: sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==}
-    engines: {node: '>=10.0.0'}
 
   beautiful-mermaid@1.1.3:
     resolution: {integrity: sha512-TItrtrAyHp1vwFfFVYauWGrquouk/6SS21Aq3RsxindSYZODcN4xYrPZD6BiZRU+o5mKJzDPz9MUSMvELdylyg==}
@@ -4351,9 +4255,6 @@ packages:
     resolution: {integrity: sha512-JxV13hNrFxqjOc8alRbq9dK1MM79NEXYpma2B2J4wAtpWS5zIEIKqWPGCl7N4o7Uc7B7itylh7SuDujATRyyTw==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
-
-  buffer-crc32@0.2.13:
-    resolution: {integrity: sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==}
 
   buffer-equal-constant-time@1.0.1:
     resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
@@ -4439,11 +4340,6 @@ packages:
   chroma-js@3.2.0:
     resolution: {integrity: sha512-os/OippSlX1RlWWr+QDPcGUZs0uoqr32urfxESG9U93lhUfbnlyckte84Q8P1UQY/qth983AS1JONKmLS4T0nw==}
 
-  chromium-bidi@14.0.0:
-    resolution: {integrity: sha512-9gYlLtS6tStdRWzrtXaTMnqcM4dudNegMXJxkR0I/CXObHalYeYcAMPrL19eroNZHtJ8DQmu1E+ZNOYu/IXMXw==}
-    peerDependencies:
-      devtools-protocol: '*'
-
   citty@0.2.2:
     resolution: {integrity: sha512-+6vJA3L98yv+IdfKGZHBNiGW5KHn22e/JwID0Strsz8h4S/csAu/OuICwxrg44k5MRiZHWIo8XXuJgQTriRP4w==}
 
@@ -4466,10 +4362,6 @@ packages:
 
   cliui@6.0.0:
     resolution: {integrity: sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==}
-
-  cliui@8.0.1:
-    resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
-    engines: {node: '>=12'}
 
   clone-regexp@3.0.0:
     resolution: {integrity: sha512-ujdnoq2Kxb8s3ItNBtnYeXdm07FcU0u8ARAT1lQ2YdMwQC+cdiXX8KoqMVuglztILivceTtp4ivqGSmEmhBUJw==}
@@ -4866,10 +4758,6 @@ packages:
   dagre-d3-es@7.0.14:
     resolution: {integrity: sha512-P4rFMVq9ESWqmOgK+dlXvOtLwYg0i7u0HBGJER0LZDJT2VHIPAMZ/riPxqJceWMStH5+E61QxFra9kIS3AqdMg==}
 
-  data-uri-to-buffer@6.0.2:
-    resolution: {integrity: sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==}
-    engines: {node: '>= 14'}
-
   date-fns@4.4.0:
     resolution: {integrity: sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==}
 
@@ -4934,10 +4822,6 @@ packages:
   defu@6.1.7:
     resolution: {integrity: sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==}
 
-  degenerator@5.0.1:
-    resolution: {integrity: sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==}
-    engines: {node: '>= 14'}
-
   delaunator@4.0.1:
     resolution: {integrity: sha512-WNPWi1IRKZfCt/qIDMfERkDp93+iZEmOxN2yy4Jg+Xhv8SLk2UTqqbe1sfiipn0and9QrE914/ihdx82Y/Giag==}
 
@@ -4990,9 +4874,6 @@ packages:
 
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
-
-  devtools-protocol@0.0.1608973:
-    resolution: {integrity: sha512-Tpm17fxYzt+J7VrGdc1k8YdRqS3YV7se/M6KeemEqvUbq/n7At1rWVuXMxQgpWkdwSdIEKYbU//Bve+Shm4YNQ==}
 
   diff@8.0.4:
     resolution: {integrity: sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==}
@@ -5080,9 +4961,6 @@ packages:
     resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
     engines: {node: '>= 0.8'}
 
-  end-of-stream@1.4.5:
-    resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
-
   enhanced-resolve@5.24.4:
     resolution: {integrity: sha512-GVoi+ICHocoOIU7qVVM48wOJziRsqrsyqlI0Ce0LdowRn6v3bcH2zUa9kp85ncx0nwIb9/HOCOLS3fdThDG/XQ==}
     engines: {node: '>=10.13.0'}
@@ -5158,19 +5036,10 @@ packages:
     resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
     engines: {node: '>=12'}
 
-  escodegen@2.1.0:
-    resolution: {integrity: sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==}
-    engines: {node: '>=6.0'}
-    hasBin: true
-
   esprima@4.0.1:
     resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
     engines: {node: '>=4'}
     hasBin: true
-
-  estraverse@5.3.0:
-    resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
-    engines: {node: '>=4.0'}
 
   estree-util-attach-comments@3.0.0:
     resolution: {integrity: sha512-cKUwm/HUcTDsYh/9FgnuFqpfquUbwIqwKM26BVCGDPVgvaCl/nDCCjUfiLlx6lsEZ3Z4RFxNbOQ60pkaEwFxGw==}
@@ -5199,16 +5068,9 @@ packages:
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
 
-  esutils@2.0.3:
-    resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
-    engines: {node: '>=0.10.0'}
-
   etag@1.8.1:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
     engines: {node: '>= 0.6'}
-
-  events-universal@1.0.1:
-    resolution: {integrity: sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==}
 
   eventsource-parser@3.1.0:
     resolution: {integrity: sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==}
@@ -5258,16 +5120,8 @@ packages:
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
 
-  extract-zip@2.0.1:
-    resolution: {integrity: sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==}
-    engines: {node: '>= 10.17.0'}
-    hasBin: true
-
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
-
-  fast-fifo@1.3.2:
-    resolution: {integrity: sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==}
 
   fast-glob@3.3.3:
     resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
@@ -5278,9 +5132,6 @@ packages:
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
-
-  fd-slicer@1.1.0:
-    resolution: {integrity: sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -5328,22 +5179,6 @@ packages:
   find-up@4.1.0:
     resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
     engines: {node: '>=8'}
-
-  fingerprint-generator@2.1.88:
-    resolution: {integrity: sha512-rwYKE/UZTAnfu3DoBgFH+otrRewvkscG8TkiDY8xw7QBga0evHoL7H70HrtP/CBqjspVrfqE7ZYt7qDM3dYk+g==}
-    engines: {node: '>=16.0.0'}
-
-  fingerprint-injector@2.1.88:
-    resolution: {integrity: sha512-npQr/Nc00x3XfbT9TE6RqPLIaYbun63rCL8isGqZVp0mlWw2mAr0J81WsIW3ENZB2w/dkCA9QewA0ufoYMB0Qw==}
-    engines: {node: '>=16.0.0'}
-    peerDependencies:
-      playwright: ^1.22.2
-      puppeteer: '>= 9.x'
-    peerDependenciesMeta:
-      playwright:
-        optional: true
-      puppeteer:
-        optional: true
 
   follow-redirects@1.16.0:
     resolution: {integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==}
@@ -5529,9 +5364,6 @@ packages:
   fuzzysort@3.1.0:
     resolution: {integrity: sha512-sR9BNCjBg6LNgwvxlBd0sBABvQitkLzoVY9MYYROQVX/FvfJ4Mai9LsGhDgd8qYdds0bY77VzYd5iuB+v5rwQQ==}
 
-  generative-bayesian-network@2.1.88:
-    resolution: {integrity: sha512-kxbW6CCsiEAVdBYPont/6ZVOa47Pyfv5ldYFIvj8wmOx9uQOZ4c8wdR0jEf2pE6DeVuIAfmolm+91bYne6/3uA==}
-
   gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
@@ -5560,10 +5392,6 @@ packages:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
     engines: {node: '>= 0.4'}
 
-  get-stream@5.2.0:
-    resolution: {integrity: sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==}
-    engines: {node: '>=8'}
-
   get-stream@6.0.1:
     resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
     engines: {node: '>=10'}
@@ -5578,10 +5406,6 @@ packages:
   get-tsconfig@5.0.0-beta.5:
     resolution: {integrity: sha512-/6gFNr0N04nob252sTQxyFLi3eKFRqIg1I87YcqAMT1i6SQrSF6KujUEQrtrjMV0H/eejTCltLdDSTEMzHbnsQ==}
     engines: {node: '>=20.20.0'}
-
-  get-uri@6.0.5:
-    resolution: {integrity: sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==}
-    engines: {node: '>= 14'}
 
   get-value@2.0.6:
     resolution: {integrity: sha512-Ln0UQDlxH1BapMu3GPtf7CuYNwRZf2gwCuPqbyG6pB8WfmFpzqcy4xtAaAMUhnNqjMKTiCPZG2oMT3YSx8U2NA==}
@@ -5716,10 +5540,6 @@ packages:
   hastscript@9.0.1:
     resolution: {integrity: sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==}
 
-  header-generator@2.1.88:
-    resolution: {integrity: sha512-12GkTL1CDaPTQ6gkd8TPwxNtn7t3wSExnWU9qgWfEDh8IqpD1NAVcvzfHphIzULez8WP2DK9YQsDegajjDdTKQ==}
-    engines: {node: '>=16.0.0'}
-
   heic-decode@2.1.0:
     resolution: {integrity: sha512-0fB3O3WMk38+PScbHLVp66jcNhsZ/ErtQ6u2lMYu/YxXgbBtl+oKOhGQHa4RpvE68k8IzbWkABzHnyAIjR758A==}
     engines: {node: '>=8.0.0'}
@@ -5756,10 +5576,6 @@ packages:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
     engines: {node: '>= 0.8'}
 
-  http-proxy-agent@7.0.2:
-    resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
-    engines: {node: '>= 14'}
-
   http-proxy-middleware@4.2.0:
     resolution: {integrity: sha512-ZA+oNOoM+GLoFTIzhkJptVQov73Srep2LBqhF8hG8CIPKO3nam1jonXVQ/QUH8RbwsmaaVz2SOJdzBNBHNtKbw==}
     engines: {node: ^22.15.0 || ^24.0.0 || >=26.0.0}
@@ -5767,10 +5583,6 @@ packages:
   https-proxy-agent@5.0.1:
     resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
     engines: {node: '>= 6'}
-
-  https-proxy-agent@7.0.6:
-    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
-    engines: {node: '>= 14'}
 
   httpxy@0.5.5:
     resolution: {integrity: sha512-uDjmnPyp1q4Sgzf3w+J/Fc6UqcCEj0x4Wjp7OqK5dGhNeDgpyrAmnS6ey8QWrX3SWDon2DMKf9sBa5X9+CVyMA==}
@@ -6309,10 +6121,6 @@ packages:
   lodash.isboolean@3.0.3:
     resolution: {integrity: sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==}
 
-  lodash.isequal@4.5.0:
-    resolution: {integrity: sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==}
-    deprecated: This package is deprecated. Use require('node:util').isDeepStrictEqual instead.
-
   lodash.isinteger@4.0.4:
     resolution: {integrity: sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==}
 
@@ -6356,10 +6164,6 @@ packages:
 
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
-
-  lru-cache@7.18.3:
-    resolution: {integrity: sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==}
-    engines: {node: '>=12'}
 
   lru_map@0.4.1:
     resolution: {integrity: sha512-I+lBvqMMFfqaV8CJCISjI3wbjmwVu/VyOoU7+qtu9d7ioW5klMgsTTiUOUp+DJvfTTzKXoPbyC6YfgkNcyPSOg==}
@@ -6687,9 +6491,6 @@ packages:
     resolution: {integrity: sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==}
     engines: {node: '>= 18'}
 
-  mitt@3.0.1:
-    resolution: {integrity: sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==}
-
   mixin-deep@1.3.2:
     resolution: {integrity: sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==}
     engines: {node: '>=0.10.0'}
@@ -6741,10 +6542,6 @@ packages:
 
   neo-async@2.6.2:
     resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
-
-  netmask@2.1.1:
-    resolution: {integrity: sha512-eonl3sLUha+S1GzTPxychyhnUzKyeQkZ7jLjKrBagJgPla13F+uQ71HgpFefyHgqrjEbCPkDArxYsjY8/+gLKA==}
-    engines: {node: '>= 0.4.0'}
 
   next-themes@0.4.6:
     resolution: {integrity: sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==}
@@ -6874,10 +6671,6 @@ packages:
     resolution: {integrity: sha512-weP+BZ8MVNnlCm8c0Qdc1WSWq4Qn7I+9CJGm7Qali6g44e/PUzbjNqJX5NJ9ljlNMosfJvg1fKEGILklK9cwnw==}
     engines: {node: '>=18'}
 
-  ow@0.28.2:
-    resolution: {integrity: sha512-dD4UpyBh/9m4X2NVjA+73/ZPBRF+uF4zIMFvvQsabMiEK8x41L3rQ8EENOi35kyyoaJwNxEeJcP6Fj1H4U409Q==}
-    engines: {node: '>=12'}
-
   oxc-resolver@11.24.2:
     resolution: {integrity: sha512-FY91FiDBj7ls5MsFS9jN3tjz2o0/zsdSsymlakySaBwVJZorHhkWyICLZMKxlu1R9vYo+sd3z1jwb4J8x7bNDw==}
 
@@ -6915,10 +6708,6 @@ packages:
     resolution: {integrity: sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==}
     engines: {node: '>=6'}
 
-  p-limit@7.2.0:
-    resolution: {integrity: sha512-ATHLtwoTNDloHRFFxFJdHnG6n2WUeFjaR8XQMFdKIv0xkXjrER8/iG9iu265jOM95zXHAfv9oTkqhrfbIzosrQ==}
-    engines: {node: '>=20'}
-
   p-locate@3.0.0:
     resolution: {integrity: sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==}
     engines: {node: '>=6'}
@@ -6934,14 +6723,6 @@ packages:
   p-try@2.2.0:
     resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
     engines: {node: '>=6'}
-
-  pac-proxy-agent@7.2.0:
-    resolution: {integrity: sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==}
-    engines: {node: '>= 14'}
-
-  pac-resolver@7.0.1:
-    resolution: {integrity: sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==}
-    engines: {node: '>= 14'}
 
   package-manager-detector@1.8.0:
     resolution: {integrity: sha512-yQA4H19AmPEoMUeavPMDIe1higySl/gH/yaQrkT/s07Qp+7pp2hYz30N3z2l5BkjVkF9Ow6o0wjJamm2y7Sn0A==}
@@ -7006,9 +6787,6 @@ packages:
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
-
-  pend@1.2.0:
-    resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
 
   perfect-debounce@2.1.0:
     resolution: {integrity: sha512-LjgdTytVFXeUgtHZr9WYViYSM/g8MkcTPYDlPa3cDqMirHjKiSZPYd6DoL7pK8AJQr+uWkQvCjHNdiMqsrJs+g==}
@@ -7084,10 +6862,6 @@ packages:
     resolution: {integrity: sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==}
     engines: {node: '>=18'}
 
-  progress@2.0.3:
-    resolution: {integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==}
-    engines: {node: '>=0.4.0'}
-
   prompts@2.4.2:
     resolution: {integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==}
     engines: {node: '>= 6'}
@@ -7106,27 +6880,13 @@ packages:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
 
-  proxy-agent@6.5.0:
-    resolution: {integrity: sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==}
-    engines: {node: '>= 14'}
-
-  proxy-from-env@1.1.0:
-    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
-
   proxy-from-env@2.1.0:
     resolution: {integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==}
     engines: {node: '>=10'}
 
-  pump@3.0.4:
-    resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
-
   punycode.js@2.3.1:
     resolution: {integrity: sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==}
     engines: {node: '>=6'}
-
-  puppeteer-core@24.43.1:
-    resolution: {integrity: sha512-T5ScUMAsmhdNbgDR41AGESYeS6V9MSgetkSnVhhW+gXvzC42VesKCn5ld87gAZDJ6vLHL9GkRvY9WtQWSnwFbw==}
-    engines: {node: '>=18'}
 
   qrcode@1.5.4:
     resolution: {integrity: sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg==}
@@ -7730,10 +7490,6 @@ packages:
     resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
     engines: {node: '>= 6.0.0', npm: '>= 3.0.0'}
 
-  socks-proxy-agent@8.0.5:
-    resolution: {integrity: sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==}
-    engines: {node: '>= 14'}
-
   socks@2.8.9:
     resolution: {integrity: sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==}
     engines: {node: '>= 10.0.0', npm: '>= 3.0.0'}
@@ -7808,9 +7564,6 @@ packages:
   stdin-discarder@0.2.2:
     resolution: {integrity: sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==}
     engines: {node: '>=18'}
-
-  streamx@2.28.0:
-    resolution: {integrity: sha512-1Yowhzjf0ivGMrTIkY9hav5TxobO9qIVqUE41fiCGMGgc3CLlf4MY+9AHmZqBWgDTue0fY9zWjYFVyf6Diuobw==}
 
   string-convert@0.2.1:
     resolution: {integrity: sha512-u/1tdPl4yQnPBjnVrmdLo9gtuLvELKsAoRapekWggdiQNvvvum+jYF329d84NAa660KQw7pB2n36KrIKVoXa3A==}
@@ -7926,18 +7679,9 @@ packages:
     resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
     engines: {node: '>=6'}
 
-  tar-fs@3.1.3:
-    resolution: {integrity: sha512-/hU4AXnIdZu+Gvl1pk0oI5f5HxWsCJRtY2aFaJdk9VvyL48DWU6iU5WAIPG+wIi1YvWA6eTJvIviP/tMAZZNwQ==}
-
-  tar-stream@3.2.0:
-    resolution: {integrity: sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==}
-
   tar@7.5.22:
     resolution: {integrity: sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==}
     engines: {node: '>=18'}
-
-  teex@1.0.1:
-    resolution: {integrity: sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==}
 
   temp-dir@3.0.0:
     resolution: {integrity: sha512-nHc6S/bwIilKHNRgK/3jlhDoIHcp45YgyiwcAk46Tr0LfEqGBVpmiAyuiuxeVE44m3mXnEeVhaipLOEWmH+Njw==}
@@ -7946,9 +7690,6 @@ packages:
   tempfile@5.0.0:
     resolution: {integrity: sha512-bX655WZI/F7EoTDw9JvQURqAXiPHi8o8+yFxPF2lWYyz1aHnmMRuXWqL6YB6GmeO0o4DIYWHLgGNi/X64T+X4Q==}
     engines: {node: '>=14.18'}
-
-  text-decoder@1.2.7:
-    resolution: {integrity: sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==}
 
   throttle-debounce@5.0.2:
     resolution: {integrity: sha512-B71/4oyj61iNH0KeCamLuE2rmKuTO5byTOSVwECM5FA7TiAiAW+UqTKZ9ERueC4qvgSttUhdmq1mXC3kJqGX7A==}
@@ -8104,9 +7845,6 @@ packages:
     resolution: {integrity: sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==}
     engines: {node: '>= 18'}
 
-  typed-query-selector@2.12.2:
-    resolution: {integrity: sha512-EOPFbyIub4ngnEdqi2yOcNeDLaX/0jcE1JoAXQDDMIthap7FoN795lc/SHfIq2d416VufXpM8z/lD+WRm2gfOQ==}
-
   typedoc@0.28.20:
     resolution: {integrity: sha512-uSKqkh8Cr48vllnEy+jdaAgOeR6Y+QCBW7usgUsKj7gJEfR7stw9U/fE49LBnj2tPRKPY0c0EBJSWe9Appmplg==}
     engines: {node: '>= 18', pnpm: '>= 10'}
@@ -8250,10 +7988,6 @@ packages:
 
   v8n@1.5.1:
     resolution: {integrity: sha512-LdabyT4OffkyXFCe9UT+uMkxNBs5rcTVuZClvxQr08D5TUgo1OFKkoT65qYRCsiKBl/usHjpXvP4hHMzzDRj3A==}
-
-  vali-date@1.0.0:
-    resolution: {integrity: sha512-sgECfZthyaCKW10N0fm27cg8HYTFK5qMWgypqkXMQ4Wbl/zZKx7xZICgcoxIIE+WFAP/MBL2EFwC/YvLxw3Zeg==}
-    engines: {node: '>=0.10.0'}
 
   valibot@1.4.2:
     resolution: {integrity: sha512-gjdCvJ6d3RyHAneqxMYMW9QMCwYMb3jpOO0IyHZV1bnRHFBHrX3VkIILt5XYR0WhwHiH7Mty8ovuPZ/O3gamrg==}
@@ -8583,9 +8317,6 @@ packages:
   web-namespaces@2.0.1:
     resolution: {integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==}
 
-  webdriver-bidi-protocol@0.4.1:
-    resolution: {integrity: sha512-ARrjNjtWRRs2w4Tk7nqrf2gBI0QXWuOmMCx2hU+1jUt6d00MjMxURrhxhGbrsoiZKJrhTSTzbIrc554iKI10qw==}
-
   which-module@2.0.1:
     resolution: {integrity: sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==}
 
@@ -8611,10 +8342,6 @@ packages:
     resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}
     engines: {node: '>=8'}
 
-  wrap-ansi@7.0.0:
-    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
-    engines: {node: '>=10'}
-
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
@@ -8636,10 +8363,6 @@ packages:
 
   y18n@4.0.3:
     resolution: {integrity: sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==}
-
-  y18n@5.0.8:
-    resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
-    engines: {node: '>=10'}
 
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
@@ -8666,24 +8389,9 @@ packages:
     resolution: {integrity: sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==}
     engines: {node: '>=6'}
 
-  yargs-parser@21.1.1:
-    resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
-    engines: {node: '>=12'}
-
   yargs@15.4.1:
     resolution: {integrity: sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==}
     engines: {node: '>=8'}
-
-  yargs@17.7.3:
-    resolution: {integrity: sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==}
-    engines: {node: '>=12'}
-
-  yauzl@2.10.0:
-    resolution: {integrity: sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==}
-
-  yocto-queue@1.2.2:
-    resolution: {integrity: sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==}
-    engines: {node: '>=12.20'}
 
   yocto-spinner@1.2.2:
     resolution: {integrity: sha512-DODGl1wJjA/s5pnJFKau9lIYHT81lnhob1i3e1TjxZRxEhWRKl74nTbWE6H5KlkViQQTo/Z29YFdxzTZAMY3ng==}
@@ -10429,21 +10137,6 @@ snapshots:
     dependencies:
       object-assign: 4.1.1
 
-  '@puppeteer/browsers@2.13.2(supports-color@7.2.0)':
-    dependencies:
-      debug: 4.4.3(supports-color@7.2.0)
-      extract-zip: 2.0.1(supports-color@7.2.0)
-      progress: 2.0.3
-      proxy-agent: 6.5.0(supports-color@7.2.0)
-      semver: 7.8.5
-      tar-fs: 3.1.3
-      yargs: 17.7.3
-    transitivePeerDependencies:
-      - bare-abort-controller
-      - bare-buffer
-      - react-native-b4a
-      - supports-color
-
   '@quansync/fs@1.0.0':
     dependencies:
       quansync: 1.0.0
@@ -11595,33 +11288,7 @@ snapshots:
 
   '@simple-libs/stream-utils@1.2.0': {}
 
-  '@sindresorhus/is@4.6.0': {}
-
   '@sindresorhus/merge-streams@4.0.0': {}
-
-  '@snapka/browser-finder@0.1.12':
-    dependencies:
-      '@snapka/browsers': 0.4.0
-
-  '@snapka/browsers@0.4.0': {}
-
-  '@snapka/puppeteer@0.2.7(supports-color@7.2.0)':
-    dependencies:
-      '@snapka/browser-finder': 0.1.12
-      '@snapka/browsers': 0.4.0
-      '@snapka/types': 0.1.5
-      debug: 4.4.3(supports-color@7.2.0)
-      p-limit: 7.2.0
-      puppeteer-core: 24.43.1(supports-color@7.2.0)
-    transitivePeerDependencies:
-      - bare-abort-controller
-      - bare-buffer
-      - bufferutil
-      - react-native-b4a
-      - supports-color
-      - utf-8-validate
-
-  '@snapka/types@0.1.5': {}
 
   '@spectrum-icons/ui@3.7.1(@adobe/react-spectrum@3.47.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
@@ -11792,7 +11459,7 @@ snapshots:
       '@tailwindcss/node': 4.3.3
       '@tailwindcss/oxide': 4.3.3
       tailwindcss: 4.3.3
-      vite: 8.1.4(@types/node@24.13.3)(@vitejs/devtools@0.4.10)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
+      vite: 8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
 
   '@tailwindcss/vite@4.3.3(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))':
     dependencies:
@@ -11802,8 +11469,6 @@ snapshots:
       vite: 8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)
 
   '@thesvg/icons@3.2.15': {}
-
-  '@tootallnate/quickjs-emscripten@0.23.0': {}
 
   '@ts-morph/common@0.27.0':
     dependencies:
@@ -12049,11 +11714,6 @@ snapshots:
     dependencies:
       '@types/node': 24.13.3
 
-  '@types/yauzl@2.10.3':
-    dependencies:
-      '@types/node': 24.13.3
-    optional: true
-
   '@typescript/vfs@1.6.4(supports-color@7.2.0)(typescript@6.0.3)':
     dependencies:
       debug: 4.4.3(supports-color@7.2.0)
@@ -12126,7 +11786,7 @@ snapshots:
   '@vitejs/plugin-react@6.0.5(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))':
     dependencies:
       '@rolldown/pluginutils': 1.0.1
-      vite: 8.1.4(@types/node@24.13.3)(@vitejs/devtools@0.4.10)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
+      vite: 8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
 
   '@vitejs/plugin-react@6.0.5(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))':
     dependencies:
@@ -12355,15 +12015,11 @@ snapshots:
 
   add-stream@1.0.0: {}
 
-  adm-zip@0.6.0: {}
-
   agent-base@6.0.2(supports-color@7.2.0):
     dependencies:
       debug: 4.4.3(supports-color@7.2.0)
     transitivePeerDependencies:
       - supports-color
-
-  agent-base@7.1.4: {}
 
   ahooks@3.9.7(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
     dependencies:
@@ -12499,10 +12155,6 @@ snapshots:
 
   assign-symbols@1.0.0: {}
 
-  ast-types@0.13.4:
-    dependencies:
-      tslib: 2.8.1
-
   ast-types@0.16.1:
     dependencies:
       tslib: 2.8.1
@@ -12527,8 +12179,6 @@ snapshots:
       - debug
       - supports-color
 
-  b4a@1.8.1: {}
-
   babel-plugin-macros@3.1.0:
     dependencies:
       '@babel/runtime': 7.29.7
@@ -12539,38 +12189,7 @@ snapshots:
 
   balanced-match@4.0.4: {}
 
-  bare-events@2.9.1: {}
-
-  bare-fs@4.7.4:
-    dependencies:
-      bare-events: 2.9.1
-      bare-path: 3.1.1
-      bare-stream: 2.13.3(bare-events@2.9.1)
-      bare-url: 2.4.6
-      fast-fifo: 1.3.2
-    transitivePeerDependencies:
-      - bare-abort-controller
-      - react-native-b4a
-
-  bare-path@3.1.1: {}
-
-  bare-stream@2.13.3(bare-events@2.9.1):
-    dependencies:
-      b4a: 1.8.1
-      streamx: 2.28.0
-      teex: 1.0.1
-    optionalDependencies:
-      bare-events: 2.9.1
-    transitivePeerDependencies:
-      - react-native-b4a
-
-  bare-url@2.4.6:
-    dependencies:
-      bare-path: 3.1.1
-
   baseline-browser-mapping@2.11.7: {}
-
-  basic-ftp@5.3.1: {}
 
   beautiful-mermaid@1.1.3:
     dependencies:
@@ -12611,8 +12230,6 @@ snapshots:
       electron-to-chromium: 1.5.398
       node-releases: 2.0.51
       update-browserslist-db: 1.2.3(browserslist@4.28.7)
-
-  buffer-crc32@0.2.13: {}
 
   buffer-equal-constant-time@1.0.1: {}
 
@@ -12685,12 +12302,6 @@ snapshots:
 
   chroma-js@3.2.0: {}
 
-  chromium-bidi@14.0.0(devtools-protocol@0.0.1608973):
-    dependencies:
-      devtools-protocol: 0.0.1608973
-      mitt: 3.0.1
-      zod: 3.25.76
-
   citty@0.2.2:
     optional: true
 
@@ -12713,12 +12324,6 @@ snapshots:
       string-width: 4.2.3
       strip-ansi: 6.0.1
       wrap-ansi: 6.2.0
-
-  cliui@8.0.1:
-    dependencies:
-      string-width: 4.2.3
-      strip-ansi: 6.0.1
-      wrap-ansi: 7.0.0
 
   clone-regexp@3.0.0:
     dependencies:
@@ -13131,8 +12736,6 @@ snapshots:
       d3: 7.9.0
       lodash-es: 4.18.1
 
-  data-uri-to-buffer@6.0.2: {}
-
   date-fns@4.4.0: {}
 
   dayjs@1.11.21: {}
@@ -13175,12 +12778,6 @@ snapshots:
   define-lazy-prop@3.0.0: {}
 
   defu@6.1.7: {}
-
-  degenerator@5.0.1:
-    dependencies:
-      ast-types: 0.13.4
-      escodegen: 2.1.0
-      esprima: 4.0.1
 
   delaunator@4.0.1: {}
 
@@ -13232,8 +12829,6 @@ snapshots:
   devlop@1.1.0:
     dependencies:
       dequal: 2.0.3
-
-  devtools-protocol@0.0.1608973: {}
 
   diff@8.0.4: {}
 
@@ -13316,10 +12911,6 @@ snapshots:
   empathic@2.0.1: {}
 
   encodeurl@2.0.0: {}
-
-  end-of-stream@1.4.5:
-    dependencies:
-      once: 1.4.0
 
   enhanced-resolve@5.24.4:
     dependencies:
@@ -13413,17 +13004,7 @@ snapshots:
 
   escape-string-regexp@5.0.0: {}
 
-  escodegen@2.1.0:
-    dependencies:
-      esprima: 4.0.1
-      estraverse: 5.3.0
-      esutils: 2.0.3
-    optionalDependencies:
-      source-map: 0.6.1
-
   esprima@4.0.1: {}
-
-  estraverse@5.3.0: {}
 
   estree-util-attach-comments@3.0.0:
     dependencies:
@@ -13464,15 +13045,7 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.9
 
-  esutils@2.0.3: {}
-
   etag@1.8.1: {}
-
-  events-universal@1.0.1:
-    dependencies:
-      bare-events: 2.9.1
-    transitivePeerDependencies:
-      - bare-abort-controller
 
   eventsource-parser@3.1.0: {}
 
@@ -13568,19 +13141,7 @@ snapshots:
 
   extend@3.0.2: {}
 
-  extract-zip@2.0.1(supports-color@7.2.0):
-    dependencies:
-      debug: 4.4.3(supports-color@7.2.0)
-      get-stream: 5.2.0
-      yauzl: 2.10.0
-    optionalDependencies:
-      '@types/yauzl': 2.10.3
-    transitivePeerDependencies:
-      - supports-color
-
   fast-deep-equal@3.1.3: {}
-
-  fast-fifo@1.3.2: {}
 
   fast-glob@3.3.3:
     dependencies:
@@ -13595,10 +13156,6 @@ snapshots:
   fastq@1.20.1:
     dependencies:
       reusify: 1.1.0
-
-  fd-slicer@1.1.0:
-    dependencies:
-      pend: 1.2.0
 
   fdir@6.5.0(picomatch@4.0.5):
     optionalDependencies:
@@ -13643,17 +13200,6 @@ snapshots:
     dependencies:
       locate-path: 5.0.0
       path-exists: 4.0.0
-
-  fingerprint-generator@2.1.88:
-    dependencies:
-      generative-bayesian-network: 2.1.88
-      header-generator: 2.1.88
-      tslib: 2.8.1
-
-  fingerprint-injector@2.1.88:
-    dependencies:
-      fingerprint-generator: 2.1.88
-      tslib: 2.8.1
 
   follow-redirects@1.16.0(debug@4.4.3(supports-color@7.2.0)):
     optionalDependencies:
@@ -13756,7 +13302,7 @@ snapshots:
       next: 16.3.1(@babel/core@7.29.7(supports-color@7.2.0))(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(babel-plugin-macros@3.1.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       react: 19.2.8
       rolldown: 1.2.1
-      vite: 8.1.4(@types/node@24.13.3)(@vitejs/devtools@0.4.10)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
+      vite: 8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -13823,11 +13369,6 @@ snapshots:
 
   fuzzysort@3.1.0: {}
 
-  generative-bayesian-network@2.1.88:
-    dependencies:
-      adm-zip: 0.6.0
-      tslib: 2.8.1
-
   gensync@1.0.0-beta.2: {}
 
   get-caller-file@2.0.5: {}
@@ -13856,10 +13397,6 @@ snapshots:
       dunder-proto: 1.0.1
       es-object-atoms: 1.1.2
 
-  get-stream@5.2.0:
-    dependencies:
-      pump: 3.0.4
-
   get-stream@6.0.1: {}
 
   get-stream@9.0.1:
@@ -13874,14 +13411,6 @@ snapshots:
   get-tsconfig@5.0.0-beta.5:
     dependencies:
       resolve-pkg-maps: 1.0.0
-
-  get-uri@6.0.5(supports-color@7.2.0):
-    dependencies:
-      basic-ftp: 5.3.1
-      data-uri-to-buffer: 6.0.2
-      debug: 4.4.3(supports-color@7.2.0)
-    transitivePeerDependencies:
-      - supports-color
 
   get-value@2.0.6: {}
 
@@ -14110,13 +13639,6 @@ snapshots:
       property-information: 7.2.0
       space-separated-tokens: 2.0.2
 
-  header-generator@2.1.88:
-    dependencies:
-      browserslist: 4.28.7
-      generative-bayesian-network: 2.1.88
-      ow: 0.28.2
-      tslib: 2.8.1
-
   heic-decode@2.1.0:
     dependencies:
       libheif-js: 1.19.8
@@ -14149,13 +13671,6 @@ snapshots:
       statuses: 2.0.2
       toidentifier: 1.0.1
 
-  http-proxy-agent@7.0.2(supports-color@7.2.0):
-    dependencies:
-      agent-base: 7.1.4
-      debug: 4.4.3(supports-color@7.2.0)
-    transitivePeerDependencies:
-      - supports-color
-
   http-proxy-middleware@4.2.0(supports-color@7.2.0):
     dependencies:
       debug: 4.4.3(supports-color@7.2.0)
@@ -14169,13 +13684,6 @@ snapshots:
   https-proxy-agent@5.0.1(supports-color@7.2.0):
     dependencies:
       agent-base: 6.0.2(supports-color@7.2.0)
-      debug: 4.4.3(supports-color@7.2.0)
-    transitivePeerDependencies:
-      - supports-color
-
-  https-proxy-agent@7.0.6(supports-color@7.2.0):
-    dependencies:
-      agent-base: 7.1.4
       debug: 4.4.3(supports-color@7.2.0)
     transitivePeerDependencies:
       - supports-color
@@ -14599,8 +14107,6 @@ snapshots:
 
   lodash.isboolean@3.0.3: {}
 
-  lodash.isequal@4.5.0: {}
-
   lodash.isinteger@4.0.4: {}
 
   lodash.isnumber@3.0.3: {}
@@ -14639,8 +14145,6 @@ snapshots:
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
-
-  lru-cache@7.18.3: {}
 
   lru_map@0.4.1: {}
 
@@ -15252,8 +14756,6 @@ snapshots:
     dependencies:
       minipass: 7.1.3
 
-  mitt@3.0.1: {}
-
   mixin-deep@1.3.2:
     dependencies:
       for-in: 1.0.2
@@ -15295,8 +14797,6 @@ snapshots:
   negotiator@1.0.0: {}
 
   neo-async@2.6.2: {}
-
-  netmask@2.1.1: {}
 
   next-themes@0.4.6(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
     dependencies:
@@ -15445,14 +14945,6 @@ snapshots:
       string-width: 7.2.0
       strip-ansi: 7.2.0
 
-  ow@0.28.2:
-    dependencies:
-      '@sindresorhus/is': 4.6.0
-      callsites: 3.1.0
-      dot-prop: 6.0.1
-      lodash.isequal: 4.5.0
-      vali-date: 1.0.0
-
   oxc-resolver@11.24.2:
     optionalDependencies:
       '@oxc-resolver/binding-android-arm-eabi': 11.24.2
@@ -15530,10 +15022,6 @@ snapshots:
     dependencies:
       p-try: 2.2.0
 
-  p-limit@7.2.0:
-    dependencies:
-      yocto-queue: 1.2.2
-
   p-locate@3.0.0:
     dependencies:
       p-limit: 2.3.0
@@ -15545,24 +15033,6 @@ snapshots:
   p-timeout@7.0.1: {}
 
   p-try@2.2.0: {}
-
-  pac-proxy-agent@7.2.0(supports-color@7.2.0):
-    dependencies:
-      '@tootallnate/quickjs-emscripten': 0.23.0
-      agent-base: 7.1.4
-      debug: 4.4.3(supports-color@7.2.0)
-      get-uri: 6.0.5(supports-color@7.2.0)
-      http-proxy-agent: 7.0.2(supports-color@7.2.0)
-      https-proxy-agent: 7.0.6(supports-color@7.2.0)
-      pac-resolver: 7.0.1
-      socks-proxy-agent: 8.0.5(supports-color@7.2.0)
-    transitivePeerDependencies:
-      - supports-color
-
-  pac-resolver@7.0.1:
-    dependencies:
-      degenerator: 5.0.1
-      netmask: 2.1.1
 
   package-manager-detector@1.8.0: {}
 
@@ -15620,8 +15090,6 @@ snapshots:
   path-type@4.0.0: {}
 
   pathe@2.0.3: {}
-
-  pend@1.2.0: {}
 
   perfect-debounce@2.1.0:
     optional: true
@@ -15705,8 +15173,6 @@ snapshots:
     dependencies:
       parse-ms: 4.0.0
 
-  progress@2.0.3: {}
-
   prompts@2.4.2:
     dependencies:
       kleur: 3.0.3
@@ -15729,46 +15195,9 @@ snapshots:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
 
-  proxy-agent@6.5.0(supports-color@7.2.0):
-    dependencies:
-      agent-base: 7.1.4
-      debug: 4.4.3(supports-color@7.2.0)
-      http-proxy-agent: 7.0.2(supports-color@7.2.0)
-      https-proxy-agent: 7.0.6(supports-color@7.2.0)
-      lru-cache: 7.18.3
-      pac-proxy-agent: 7.2.0(supports-color@7.2.0)
-      proxy-from-env: 1.1.0
-      socks-proxy-agent: 8.0.5(supports-color@7.2.0)
-    transitivePeerDependencies:
-      - supports-color
-
-  proxy-from-env@1.1.0: {}
-
   proxy-from-env@2.1.0: {}
 
-  pump@3.0.4:
-    dependencies:
-      end-of-stream: 1.4.5
-      once: 1.4.0
-
   punycode.js@2.3.1: {}
-
-  puppeteer-core@24.43.1(supports-color@7.2.0):
-    dependencies:
-      '@puppeteer/browsers': 2.13.2(supports-color@7.2.0)
-      chromium-bidi: 14.0.0(devtools-protocol@0.0.1608973)
-      debug: 4.4.3(supports-color@7.2.0)
-      devtools-protocol: 0.0.1608973
-      typed-query-selector: 2.12.2
-      webdriver-bidi-protocol: 0.4.1
-      ws: 8.21.1
-    transitivePeerDependencies:
-      - bare-abort-controller
-      - bare-buffer
-      - bufferutil
-      - react-native-b4a
-      - supports-color
-      - utf-8-validate
 
   qrcode@1.5.4:
     dependencies:
@@ -16634,14 +16063,6 @@ snapshots:
 
   smart-buffer@4.2.0: {}
 
-  socks-proxy-agent@8.0.5(supports-color@7.2.0):
-    dependencies:
-      agent-base: 7.1.4
-      debug: 4.4.3(supports-color@7.2.0)
-      socks: 2.8.9
-    transitivePeerDependencies:
-      - supports-color
-
   socks@2.8.9:
     dependencies:
       ip-address: 10.3.1
@@ -16702,15 +16123,6 @@ snapshots:
   std-env@4.2.0: {}
 
   stdin-discarder@0.2.2: {}
-
-  streamx@2.28.0:
-    dependencies:
-      events-universal: 1.0.1
-      fast-fifo: 1.3.2
-      text-decoder: 1.2.7
-    transitivePeerDependencies:
-      - bare-abort-controller
-      - react-native-b4a
 
   string-convert@0.2.1: {}
 
@@ -16811,29 +16223,6 @@ snapshots:
 
   tapable@2.3.3: {}
 
-  tar-fs@3.1.3:
-    dependencies:
-      pump: 3.0.4
-      tar-stream: 3.2.0
-    optionalDependencies:
-      bare-fs: 4.7.4
-      bare-path: 3.1.1
-    transitivePeerDependencies:
-      - bare-abort-controller
-      - bare-buffer
-      - react-native-b4a
-
-  tar-stream@3.2.0:
-    dependencies:
-      b4a: 1.8.1
-      bare-fs: 4.7.4
-      fast-fifo: 1.3.2
-      streamx: 2.28.0
-    transitivePeerDependencies:
-      - bare-abort-controller
-      - bare-buffer
-      - react-native-b4a
-
   tar@7.5.22:
     dependencies:
       '@isaacs/fs-minipass': 4.0.1
@@ -16842,24 +16231,11 @@ snapshots:
       minizlib: 3.1.0
       yallist: 5.0.0
 
-  teex@1.0.1:
-    dependencies:
-      streamx: 2.28.0
-    transitivePeerDependencies:
-      - bare-abort-controller
-      - react-native-b4a
-
   temp-dir@3.0.0: {}
 
   tempfile@5.0.0:
     dependencies:
       temp-dir: 3.0.0
-
-  text-decoder@1.2.7:
-    dependencies:
-      b4a: 1.8.1
-    transitivePeerDependencies:
-      - react-native-b4a
 
   throttle-debounce@5.0.2: {}
 
@@ -17020,8 +16396,6 @@ snapshots:
       media-typer: 1.1.1
       mime-types: 3.0.2
 
-  typed-query-selector@2.12.2: {}
-
   typedoc@0.28.20(typescript@6.0.3):
     dependencies:
       '@gerrit0/mini-shiki': 3.23.0
@@ -17150,8 +16524,6 @@ snapshots:
   uuid@14.0.1: {}
 
   v8n@1.5.1: {}
-
-  vali-date@1.0.0: {}
 
   valibot@1.4.2(typescript@6.0.3):
     optionalDependencies:
@@ -17462,6 +16834,21 @@ snapshots:
       tsx: 4.23.1
       yaml: 2.9.0
 
+  vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0):
+    dependencies:
+      lightningcss: 1.33.0
+      picomatch: 4.0.5
+      postcss: 8.5.26
+      rolldown: 1.1.5
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      '@types/node': 24.13.3
+      esbuild: 0.28.1
+      fsevents: 2.3.3
+      jiti: 2.7.0
+      tsx: 4.23.1
+      yaml: 2.9.0
+
   vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0):
     dependencies:
       lightningcss: 1.33.0
@@ -17518,8 +16905,6 @@ snapshots:
 
   web-namespaces@2.0.1: {}
 
-  webdriver-bidi-protocol@0.4.1: {}
-
   which-module@2.0.1: {}
 
   which@2.0.2:
@@ -17543,12 +16928,6 @@ snapshots:
       string-width: 4.2.3
       strip-ansi: 6.0.1
 
-  wrap-ansi@7.0.0:
-    dependencies:
-      ansi-styles: 4.3.0
-      string-width: 4.2.3
-      strip-ansi: 6.0.1
-
   wrappy@1.0.2: {}
 
   ws@8.21.1: {}
@@ -17559,8 +16938,6 @@ snapshots:
       powershell-utils: 0.1.0
 
   y18n@4.0.3: {}
-
-  y18n@5.0.8: {}
 
   yallist@3.1.1: {}
 
@@ -17577,8 +16954,6 @@ snapshots:
       camelcase: 5.3.1
       decamelize: 1.2.0
 
-  yargs-parser@21.1.1: {}
-
   yargs@15.4.1:
     dependencies:
       cliui: 6.0.0
@@ -17592,23 +16967,6 @@ snapshots:
       which-module: 2.0.1
       y18n: 4.0.3
       yargs-parser: 18.1.3
-
-  yargs@17.7.3:
-    dependencies:
-      cliui: 8.0.1
-      escalade: 3.2.0
-      get-caller-file: 2.0.5
-      require-directory: 2.1.1
-      string-width: 4.2.3
-      y18n: 5.0.8
-      yargs-parser: 21.1.1
-
-  yauzl@2.10.0:
-    dependencies:
-      buffer-crc32: 0.2.13
-      fd-slicer: 1.1.0
-
-  yocto-queue@1.2.2: {}
 
   yocto-spinner@1.2.2:
     dependencies:


### PR DESCRIPTION
## 改动

- 使用抖音 Passport HTTPS 接口完成二维码获取、状态轮询、SSO 跳转和短信二次验证
- 内置 `sign` / `qs` / `p_no` / `aid-sign` / `a_bogus` / SM3 签名实现
- 保持登录 Cookie 写入配置与 Amagi Client 重载行为
- 移除 `@snapka/puppeteer`、`fingerprint-injector` 及 Puppeteer 镜像配置
- 同步更新 `pnpm-lock.yaml`

## 来源

- 登录协议结构参考 `dmmdekkd/DouyinDataAPI`
- `a_bogus` / SM3 基于 `ylcangel/douyin_sign` 的 Apache-2.0 实现翻译，源码内保留 attribution

## 验证

- 严格 TypeScript 编译检查
- SM3、XOR5、Cookie 合并、Passport 签名与 `a_bogus` helper 测试
- lockfile 使用仓库 CI 同版本的 pnpm 11.18.0 重新生成

未在真实抖音账号上完成端到端扫码测试，最终可用性仍需实际账号验证。