### PR TITLE
refactor(douyin): 用 amagi passport 接口替换 Puppeteer 登录

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -137,5 +137,5 @@
     "web": "./lib/web.config.js",
     "ts-web": "./src/web.config.ts"
   },
-  "timestamp": "2026-08-31T16:01:56.085Z"
+  "timestamp": "2026-08-31T18:07:03.407Z"
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -137,5 +137,5 @@
     "web": "./lib/web.config.js",
     "ts-web": "./src/web.config.ts"
   },
-  "timestamp": "2026-08-31T15:39:20.214Z"
+  "timestamp": "2026-08-31T16:01:56.085Z"
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -70,8 +70,7 @@
   },
   "dependencies": {
     "@ikenxuan/qrcode": "1.5.0",
-    "@ikenxuan/watermark": "1.3.1",
-    "fingerprint-injector": "^2.1.88"
+    "@ikenxuan/watermark": "1.3.1"
   },
   "devDependencies": {
     "@heroui/react": "3.2.4",
@@ -86,7 +85,6 @@
     "@karinjs/template-react": "0.1.1",
     "@kkk/richtext": "workspace:*",
     "@phosphor-icons/react": "^2.1.10",
-    "@snapka/puppeteer": "^0.2.7",
     "@thesvg/icons": "^3.0.18",
     "@types/cors": "^2.8.19",
     "@types/express": "5.0.6",
@@ -139,5 +137,5 @@
     "web": "./lib/web.config.js",
     "ts-web": "./src/web.config.ts"
   },
-  "timestamp": "2026-08-31T11:03:18.849Z"
+  "timestamp": "2026-08-31T14:59:20.934Z"
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -137,5 +137,5 @@
     "web": "./lib/web.config.js",
     "ts-web": "./src/web.config.ts"
   },
-  "timestamp": "2026-08-31T18:07:03.407Z"
+  "timestamp": "2026-08-31T18:20:02.971Z"
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -137,5 +137,5 @@
     "web": "./lib/web.config.js",
     "ts-web": "./src/web.config.ts"
   },
-  "timestamp": "2026-08-31T14:59:20.934Z"
+  "timestamp": "2026-08-31T15:39:20.214Z"
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -137,5 +137,5 @@
     "web": "./lib/web.config.js",
     "ts-web": "./src/web.config.ts"
   },
-  "timestamp": "2026-08-31T18:20:02.971Z"
+  "timestamp": "2026-09-01T14:09:10.710Z"
 }

--- a/packages/core/src/platform/douyin/douyin.ts
+++ b/packages/core/src/platform/douyin/douyin.ts
@@ -517,9 +517,13 @@ export class DouYin extends Base {
         let FPS
         const sendvideofile = true
         type VideoType = DyVideoWork['aweme_detail']['video']
-        let video: VideoType = VideoData.data.aweme_detail.video.bit_rate[0]
+        /**
+         * 图文/文章作品的 video 字段不含 bit_rate，不能无条件初始化，
+         * 否则会在这里直接抛 TypeError；仅在视频分支内赋值，其余场景保持 null。
+         */
+        let video: VideoType | null = null
         /** 按画质偏好选中、即将下载发送的那一路视频源 */
-        let selectedVideo: dyVideo = video.bit_rate[0]
+        let selectedVideo: dyVideo | null = null
         if (isVideo) {
           // 视频地址特殊判断：play_addr_h264、play_addr、
           video = VideoData.data.aweme_detail.video as VideoType
@@ -533,7 +537,10 @@ export class DouYin extends Base {
           // 只把选中项取到局部变量，不再原地覆盖 video.bit_rate：
           // video 是 aweme_detail.video 的同一个引用，覆盖它会把整个作品详情的视频源列表截断成一项，
           // 污染后面所有拿 Detail_Data 的下游（渲染、推送复用）。
-          selectedVideo = douyinProcessVideos(video.bit_rate, Config.douyin.videoQuality, Config.douyin.maxAutoVideoSize)[0]
+          selectedVideo = douyinProcessVideos(video.bit_rate, Config.douyin.videoQuality, Config.douyin.maxAutoVideoSize)[0] ?? null
+          if (!selectedVideo) {
+            throw new Error(`未找到可用的视频源，aweme_id=${VideoData.data.aweme_detail.aweme_id}`)
+          }
           // url_list[2] 是 www.douyin.com/aweme/v1/play 的包装 URL，会按 Douyin 负载均衡 302
           // 到任意 CDN，部分 CDN（如 cjjd14.com、n98-v-ncdnon）返回非 MP4 乱码字节。
           // 直接用 url_list[0] 的签名直链规避包装跳转。

--- a/packages/core/src/platform/douyin/login.ts
+++ b/packages/core/src/platform/douyin/login.ts
@@ -2,6 +2,7 @@ import fs from 'node:fs'
 
 import {
   checkPassportQrcode,
+  isSmsCodeVerifyWay,
   requestPassportQrcode,
   sendPassportVerifyCode,
   validatePassportVerifyCode,
@@ -103,14 +104,17 @@ const handleSecondVerify = async (
     return false
   }
 
-  const smsWay = verify.verifyWays.find((way) => way.verifyWay === 'mobile_sms_verify')
+  // 服务端给的验证方式因账号而异：普通账号是 mobile_sms_verify，
+  // 被判定需要辅助验证的账号是 assist_mobile_sms_verify，两者都是下行短信收码
+  const smsWay = verify.verifyWays.find((way) => isSmsCodeVerifyWay(way.verifyWay))
   if (verify.verifyWays.length > 0 && !smsWay) {
     const ways = verify.verifyWays.map((way) => way.verifyWay).join('、')
+    logger.warn(`[抖音登录] 服务端给出的验证方式均不支持: ${ways}`)
     await tracker.send(`账号触发了二次验证，但当前仅支持短信验证码，服务端给出的方式为：${ways}`)
     return false
   }
 
-  const sent = await sendPassportVerifyCode({ verify, typeMode: 'strict' }, session.cookie, requestConfig())
+  const sent = await sendPassportVerifyCode({ verify, verify_way: smsWay?.verifyWay, typeMode: 'strict' }, session.cookie, requestConfig())
   if (!sent.success) {
     await tracker.send(`短信验证码发送失败：${sent.message}`)
     return false
@@ -123,6 +127,8 @@ const handleSecondVerify = async (
   }
 
   const bizTraceId = sent.data.biz_trace_id
+  const verifyWay = sent.data.verify_way
+  logger.mark(`[抖音登录] 二次验证方式: ${verifyWay}`)
   const target = sent.data.mobile || smsWay?.mobile || '扫码设备绑定的手机号'
   await tracker.send(`此次登录需要二次验证\n6 位数验证码已发送至 ${target}\n请在 ${CODE_INPUT_TIMEOUT} 秒内直接回复该验证码`)
 
@@ -145,7 +151,7 @@ const handleSecondVerify = async (
     }
 
     const checked = await validatePassportVerifyCode(
-      { verify, code, biz_trace_id: bizTraceId, typeMode: 'strict' },
+      { verify, code, biz_trace_id: bizTraceId, verify_way: verifyWay, typeMode: 'strict' },
       session.cookie,
       requestConfig()
     )

--- a/packages/core/src/platform/douyin/login.ts
+++ b/packages/core/src/platform/douyin/login.ts
@@ -1,588 +1,295 @@
 import fs from 'node:fs'
-import { platform } from 'node:os'
-import path from 'node:path'
 
-import { scanSync } from '@ikenxuan/qrcode'
-import { snapka } from '@snapka/puppeteer'
-import { newInjectedPage } from 'fingerprint-injector'
-import { karin, karinPathTemp, logger, Message } from 'node-karin'
+import {
+  checkPassportQrcode,
+  requestPassportQrcode,
+  sendPassportVerifyCode,
+  validatePassportVerifyCode,
+  type DouyinPassportQrcodeStatus,
+  type DouyinPassportVerifyContext
+} from '@ikenxuan/amagi'
+import { karin, logger, type Message } from 'node-karin'
 
-import { Common, Render, Root } from '@/module'
+import { Common, Render } from '@/module'
 import { reloadAmagiConfig } from '@/module/utils/amagiClient'
 import { Config } from '@/module/utils/Config'
 
-type Page = Awaited<ReturnType<Awaited<ReturnType<typeof snapka.launch>>['browser']['newPage']>>
+/** 等待用户扫码的时限，与消息可撤回窗口（2 分钟）对齐 */
+const SCAN_TIMEOUT = 120_000
 
-/**
- * 截图函数
- * @param page Puppeteer 页面对象
- * @param screenshotPath 截图保存路径
- */
-const safeScreenshot = async (page: Page, screenshotPath: string) => {
-  try {
-    await page.screenshot({
-      path: screenshotPath
-    })
-    logger.debug(`截图已保存: ${screenshotPath}`)
-  } catch (error) {
-    logger.warn('截图失败（已忽略）:', error)
+/** 扫码后等待手机确认或完成二次验证的时限 */
+const CONFIRM_TIMEOUT = 180_000
+
+/** 等待用户回填短信验证码的时限（秒） */
+const CODE_INPUT_TIMEOUT = 90
+
+/** 短信验证码允许的重试次数 */
+const CODE_MAX_ATTEMPTS = 3
+
+/** 6 位数字验证码 */
+const CODE_PATTERN = /^\d{6}$/
+
+/** 登录凭证里需要确认下发的关键 cookie */
+const REQUIRED_COOKIES = ['sessionid', 'sessionid_ss', 'sid_guard', 'uid_tt', 'uid_tt_ss', 'ttwid']
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
+
+/** 复用 amagi 配置里的代理与超时，让登录请求与其它抖音请求走同一条出口 */
+const requestConfig = () => {
+  const amagi = Config.amagi
+  return {
+    timeout: amagi.timeout,
+    proxy: amagi.proxy?.switch ? amagi.proxy : (false as const)
   }
 }
 
-export const douyinLogin = async (e: Message) => {
-  const msg_id: string[] = []
-  const puppeteer = await snapka.launch({
-    headless: 'new',
-    protocolTimeout: 60000,
-    args: [
-      '--disable-blink-features=AutomationControlled', // 禁用自动化控制特征，避免网站检测到自动化工具
-      '--mute-audio', // 静音处理，防止页面播放音频
-      '--window-size=800,600', // 设置浏览器窗口大小为 800x600 像素
-      '--disable-gpu', // 禁用 GPU 加速，减少资源占用和潜在兼容性问题
-      '--no-sandbox', // 禁用沙箱模式，某些环境下需要（如容器环境）
-      '--disable-setuid-sandbox', // 禁用 setuid 沙箱，与 --no-sandbox 配合使用
-      '--no-zygote', // 禁用 zygote 进程，减少内存占用和启动时间
-      '--disable-extensions', // 禁用浏览器扩展，减少资源消耗
-      '--disable-dev-shm-usage', // 禁用 /dev/shm 内存共享，解决某些环境下的内存限制问题
-      '--disable-background-networking', // 禁用后台网络活动，减少不必要的网络请求
-      '--disable-sync', // 禁用同步功能，如书签、设置等同步
-      '--disable-crash-reporter', // 禁用崩溃报告器，减少资源占用
-      '--disable-translate', // 禁用页面自动翻译功能
-      '--disable-notifications', // 禁用浏览器通知，避免弹窗干扰
-      '--disable-device-discovery-notifications', // 禁用设备发现通知（如附近的打印机等）
-      '--disable-accelerated-2d-canvas', // 禁用加速的 2D 画布，减少 GPU 依赖
-      '--autoplay-policy=user-gesture-required', // 设置自动播放策略为需要用户交互
-      '--disable-web-security', // 禁用 Web 安全策略（如跨域限制），减少检查开销
-      '--disable-features=IsolateOrigins,site-per-process', // 禁用-features=IsolateOrigins,site-per-process', // 禁用源隔离和站点进程隔离，减少进程数量
-      '--disable-site-isolation-trials', // 禁用站点隔离试验功能
-      '--disable-features=VizDisplayCompositor', // 禁用 Viz 显示合成器，简化渲染流程
-      '--js-flags=--max-old-space-size=128', // 限制 V8 引擎的最大堆内存为 128MB
-      '--disable-software-rasterizer', // 禁用软件光栅化器，减少 CPU 资源占用
-      '--disable-webgl', // 禁用 WebGL 3D 图形 API
-      '--disable-webgl2', // 禁用 WebGL2 3D 图形 API
-      '--disable-3d-apis', // 禁用所有 3D 相关 API，减少资源消耗
-      '--disable-accelerated-video-decode', // 禁用硬件加速视频解码
-      '--disable-background-timer-throttling', // 禁用后台定时器节流，确保定时器正常运行
-      '--disable-backgrounding-occluded-windows', // 禁用被遮挡窗口的后台处理，保持活跃状态
-      '--disable-breakpad', // 禁用 Breakpad 崩溃报告系统
-      '--disable-component-extensions-with-background-pages', // 禁用带有背景页面的组件扩展
-      '--disable-features=TranslateUI,BlinkGenPropertyTrees', // 禁用翻译 UI 和 Blink 属性树生成
-      '--disable-ipc-flooding-protection', // 禁用 IPC 洪水保护，提高进程间通信效率
-      '--disable-renderer-backgrounding' // 禁用渲染器进程的后台处理，保持渲染性能
-    ],
-    ignoreDefaultArgs: ['--enable-automation']
-  })
+/**
+ * 登录过程中发出的消息，全部登记在这里，结束时统一撤回，避免二维码留在群里
+ * @param e 消息事件
+ */
+const createMessageTracker = (e: Message) => {
+  const messageIds: string[] = []
 
-  // const pageTest = await browser.newPage()
+  return {
+    /**
+     * 发送并登记一条消息
+     * @param message 消息内容
+     */
+    async send (message: Parameters<Message['reply']>[0]) {
+      const sent = await e.reply(message, { reply: true })
+      if (sent.messageId) messageIds.push(sent.messageId)
+      return sent
+    },
 
-  // await injector.attachFingerprintToPuppeteer(pageTest, fingerprint)
-  // await pageTest.goto('https://bot.sannysoft.com')
-  // await pageTest.screenshot({ path: 'testresult.png', fullPage: true })
-
-  /** 根据当前系统平台选择操作系统类型 */
-  const getOperatingSystem = (): 'windows' | 'macos' | 'linux' => {
-    const os = platform()
-    if (os === 'win32') return 'windows'
-    if (os === 'darwin') return 'macos'
-    return 'linux'
-  }
-
-  const page = (await newInjectedPage(puppeteer.browser, {
-    fingerprintOptions: {
-      devices: ['desktop'],
-      operatingSystems: [getOperatingSystem()]
-    }
-  })) as Page
-
-  // 激进地拦截资源，只保留必要的 HTML、JS 和二维码图片
-  await page.setRequestInterception(true)
-  page.on('request', async (request) => {
-    const resourceType = request.resourceType()
-    const url = request.url()
-
-    // 记录登录相关的请求
-    if (url.includes('passport') || url.includes('login') || url.includes('qrconnect') || url.includes('qrcode')) {
-      logger.debug(`[请求] ${resourceType}: ${url}`)
-    }
-
-    // 阻止明确不需要的资源
-    const shouldBlock =
-      resourceType === 'media' || // 视频/音频（Puppeteer 已识别的媒体类型）
-      resourceType === 'font' || // 字体
-      resourceType === 'stylesheet' || // CSS
-      // 通过 URL 特征识别视频
-      /\.(mp4|webm|m3u8|flv|avi|mov|wmv|mkv)(\?|$)/i.test(url) || // 视频文件扩展名
-      url.includes('/aweme/') || // 抖音视频相关路径
-      url.includes('/video/') || // 通用视频路径
-      url.includes('v.douyin.com') || // 抖音视频域名
-      // 阻止大图片但保留二维码
-      (resourceType === 'image' &&
-        !url.includes('qrcode') &&
-        !url.includes('data:image') &&
-        (url.includes('.jpg') || url.includes('.jpeg') || url.includes('.webp')))
-
-    if (shouldBlock) {
-      if (url.includes('passport') || url.includes('login') || url.includes('qrconnect')) {
-        logger.warn(`[拦截] 登录相关请求被拦截: ${url}`)
-      }
-      request.abort()
-    } else {
-      // 允许所有其他请求（包括 API 调用）
-      request.continue()
-    }
-  })
-
-  // 禁用视频播放和其他重量级功能
-  await page.evaluateOnNewDocument(() => {
-    // 禁止 video 元素播放
-    HTMLMediaElement.prototype.play = function () {
-      return Promise.reject(new Error('Video playback blocked'))
-    }
-
-    // 禁止创建 MediaSource 对象
-    if (window.MediaSource) {
-      window.MediaSource = undefined as any
-    }
-
-    // 禁用 IntersectionObserver（防止懒加载触发）
-    window.IntersectionObserver = class {
-      observe() {}
-      unobserve() {}
-      disconnect() {}
-    } as any
-  })
-
-  // 访问首页
-  await page.goto('https://www.douyin.com', { timeout: 120000, waitUntil: 'domcontentloaded' })
-
-  // 阶段1: 获取二维码 (60秒超时)
-  let qrCodeData: { url: string | null; originalImage: string }
-  try {
-    logger.mark('开始等待二维码加载...')
-    qrCodeData = await Promise.race([
-      waitQrcode(page),
-      new Promise<never>((_, reject) => setTimeout(() => reject(new Error('QR_CODE_TIMEOUT')), 60000))
-    ])
-    logger.mark('二维码获取成功')
-  } catch (error: any) {
-    if (error.message === 'QR_CODE_TIMEOUT') {
-      logger.warn('获取二维码超时')
-      await safeScreenshot(page, path.join(karinPathTemp, Root.pluginName, 'DouyinLoginQrcodeError.png'))
-      await e.reply('获取二维码超时，请稍后重试', { reply: true })
-    } else {
-      logger.error('获取二维码失败:', error)
-      await e.reply('获取二维码失败，请查看控制台日志', { reply: true })
-    }
-    await puppeteer.browser.close()
-    return true
-  }
-
-  // 渲染并发送二维码
-  let gcInterval: NodeJS.Timeout | undefined
-  try {
-    // 根据解码结果选择传递方式
-    const renderData = qrCodeData.url
-      ? { share_url: qrCodeData.url } // 解码成功，传递URL让组件内部生成自定义二维码
-      : { share_url: qrCodeData.originalImage } // 解码失败，直接使用原始图片URL
-
-    const loginQRcode = await Render(e, 'douyin/qrcodeImg', renderData)
-
-    const base64Data = loginQRcode[0]?.file
-    if (!base64Data) {
-      throw new Error('生成二维码图片失败')
-    }
-
-    const cleanBase64 = base64Data.replace(/^base64:\/\//, '')
-    const buffer = Buffer.from(cleanBase64, 'base64')
-
-    fs.writeFileSync(`${Common.tempDri.default}DouyinLoginQrcode.png`, buffer)
-
-    const message2 = await e.reply(loginQRcode, { reply: true })
-    logger.debug('二维码图片消息ID:', message2.messageId)
-    msg_id.push(message2.messageId)
-
-    // 定期触发垃圾回收以释放内存
-    gcInterval = setInterval(async () => {
-      try {
-        await page.evaluate(() => {
-          // 尝试触发浏览器的垃圾回收
-          if ((window as any).gc) {
-            ;(window as any).gc()
-          }
-        })
-      } catch {
-        // 忽略错误
-      }
-    }, 10000) // 每 10 秒清理一次
-
-    logger.mark('开始等待用户扫码登录...')
-
-    // 阶段2: 等待用户扫码 (120秒超时，因为消息只能撤回2分钟)
-    const loginResult = await Promise.race([
-      new Promise<boolean>((resolve) => {
-        // 120秒后主动撤回二维码消息并结束
-        const timer = setTimeout(async () => {
-          logger.warn('扫码登录超时（2分钟），撤回二维码消息')
-          // 撤回二维码消息
-          await Promise.all(
-            msg_id.map(async (id) => {
-              await e.bot.recallMsg(e.contact, id)
-            })
-          )
-          resolve(false)
-        }, 120 * 1000)
-
-        let secondVerifyHandled = false
-        let scannedHandled = false
-        let responseCount = 0
-
-        // 监听所有响应以调试
-        page.on('response', async (response) => {
-          responseCount++
-          const url = response.url()
-
-          // 每 10 个响应打印一次心跳
-          if (responseCount % 10 === 0) {
-            logger.debug(`[心跳] 已收到 ${responseCount} 个响应`)
-          }
-
-          // 记录所有登录相关的请求
-          if (url.includes('passport') || url.includes('login') || url.includes('qrconnect') || url.includes('qrcode')) {
-            logger.debug(`[响应] 登录相关请求: ${url}, status: ${response.status()}`)
-          }
-        })
-
-        logger.mark('响应监听器已注册')
-
-        page.on('response', async (response) => {
+    /** 撤回目前登记的全部消息 */
+    async recallAll () {
+      const pending = messageIds.splice(0, messageIds.length)
+      await Promise.all(
+        pending.map(async (id) => {
           try {
-            // 监听二维码轮询接口
-            if (response.url().includes('check_qrconnect')) {
-              logger.debug(`收到登录轮询响应: ${response.url()}`)
-
-              // 检查响应头中是否包含 sid_guard（唯一登录凭证）
-              const headers = response.headers()
-              const setCookieHeaders = headers['set-cookie'] || ''
-              const hasSidGuard = setCookieHeaders.includes('sid_guard')
-
-              logger.debug(`响应头包含 sid_guard: ${hasSidGuard}`)
-
-              if (hasSidGuard) {
-                clearTimeout(timer)
-                logger.mark('检测到 sid_guard，登录成功')
-
-                // 保存 cookie
-                logger.debug('开始获取 cookies...')
-                const cookies = await puppeteer.browser.cookies()
-                logger.debug(`获取到 ${cookies.length} 个 cookies`)
-                const cookieString = cookies.map((cookie) => `${cookie.name}=${cookie.value}`).join('; ')
-
-                // 检测关键 cookie 参数
-                const hasSessionidSs = cookies.some((cookie) => cookie.name === 'sessionid_ss')
-                const hasTtwid = cookies.some((cookie) => cookie.name === 'ttwid')
-                logger.mark(`Cookie 参数检测: sessionid_ss=${hasSessionidSs}, ttwid=${hasTtwid}`)
-
-                if (!hasSessionidSs || !hasTtwid) {
-                  logger.warn('警告：缺少关键 cookie 参数！')
-                  if (!hasSessionidSs) logger.warn('  - 缺少 sessionid_ss')
-                  if (!hasTtwid) logger.warn('  - 缺少 ttwid')
-                }
-
-                logger.debug('开始保存 cookies...')
-                await Config.Modify('amagi', 'cookies.douyin', cookieString)
-                const reloaded = reloadAmagiConfig()
-                logger.debug(`cookies 保存完成，Amagi Client ${reloaded ? '已重载' : '配置未变化'}`)
-                await e.reply('登录成功！用户登录凭证已保存至配置', { reply: true })
-
-                // 批量撤回之前的消息
-                await Promise.all(
-                  msg_id.map(async (id) => {
-                    await e.bot.recallMsg(e.contact, id)
-                  })
-                )
-
-                logger.mark('关闭浏览器...')
-                await puppeteer.browser.close()
-                logger.mark('浏览器已关闭')
-                resolve(true)
-                return
-              }
-
-              // 如果没有 sid_guard，检查响应体
-              const responseBody = await response.text()
-              const jsonResponse = JSON.parse(responseBody)
-
-              logger.debug(`二维码状态：${jsonResponse.data?.status}, error_code: ${jsonResponse.data?.error_code}`)
-
-              // 检查二维码是否已被扫描（只处理一次）
-              if (jsonResponse.data?.status === 'scanned' && !scannedHandled) {
-                scannedHandled = true
-                logger.mark('检测到二维码已被扫描')
-                // 撤回二维码消息
-                await Promise.all(
-                  msg_id.map(async (id) => {
-                    await e.bot.recallMsg(e.contact, id)
-                  })
-                )
-                // 清空消息ID列表，避免重复撤回
-                msg_id.length = 0
-                // 发送授权提示
-                const authMsg = await e.reply('此二维码已被扫描，请在手机上授权以登录', { reply: true })
-                msg_id.push(authMsg.messageId)
-              }
-
-              // 检查是否需要二次验证
-              if (jsonResponse.data?.error_code === 2046 && !secondVerifyHandled) {
-                secondVerifyHandled = true
-                logger.mark('检测到需要二次验证')
-                clearTimeout(timer) // 清除扫码超时，进入2FA阶段
-
-                // 使用立即执行的异步函数，不阻塞响应监听
-                ;(async () => {
-                  try {
-                    // 等待二次验证弹窗出现
-                    await page.waitForSelector('#uc-second-verify', { timeout: 5000 })
-
-                    // 点击"接收短信验证码"按钮
-                    const clicked = await page.evaluate(() => {
-                      const xpath = "//text()[contains(., '接收短信验证码')]/ancestor::*[1]"
-                      const result = document.evaluate(xpath, document, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null)
-                      const element = result.singleNodeValue as HTMLElement
-                      if (element) {
-                        element.click()
-                        return true
-                      }
-                      return false
-                    })
-
-                    if (!clicked) {
-                      logger.warn('未找到"接收短信验证码"按钮')
-                    }
-
-                    // 等待输入框出现
-                    await new Promise((resolve) => setTimeout(resolve, 2000))
-                    const inputSelector = '#uc-second-verify input'
-                    await page.waitForSelector(inputSelector, { timeout: 10000 })
-
-                    const tipMsg = await e.reply(
-                      '此次验证需要进行 2FA\n6 位数的验证码已发送至扫码设备绑定的手机号\n请在 60 秒内发送此验证码以通过 2FA',
-                      { reply: true }
-                    )
-                    msg_id.push(tipMsg.messageId)
-
-                    // 验证码验证逻辑（最多2次机会）
-                    let verifyAttempts = 0
-                    const maxAttempts = 2
-                    let verifySuccess = false
-
-                    while (verifyAttempts < maxAttempts && !verifySuccess) {
-                      verifyAttempts++
-                      logger.debug(`验证码输入尝试 ${verifyAttempts}/${maxAttempts}`)
-
-                      // 阶段3: 等待用户输入2FA验证码 (60秒超时)
-                      const ctx = await Promise.race([
-                        karin.ctx(e, { reply: true }),
-                        new Promise<never>((_, reject) => setTimeout(() => reject(new Error('2FA_TIMEOUT')), 60000))
-                      ]).catch(async (error) => {
-                        if (error.message === '2FA_TIMEOUT') {
-                          logger.warn('2FA验证码输入超时')
-                          clearTimeout(timer)
-                          if (gcInterval) clearInterval(gcInterval)
-                          await puppeteer.browser.close()
-                          // 撤回所有之前的消息
-                          await Promise.all(
-                            msg_id.map(async (id) => {
-                              await e.bot.recallMsg(e.contact, id)
-                            })
-                          )
-                          await e.reply('验证码验证码输入超时，登录失败', { reply: true })
-                          resolve(true) // 返回true表示已处理完成
-                        }
-                        throw error
-                      })
-
-                      if (!ctx) return
-
-                      // 清空输入框
-                      await page.evaluate((selector) => {
-                        const input = document.querySelector(selector) as HTMLInputElement
-                        if (input) input.value = ''
-                      }, inputSelector)
-
-                      // 输入验证码
-                      await page.type(inputSelector, ctx.msg)
-
-                      // 监听验证码验证接口
-                      const validatePromise = new Promise<boolean>((resolveValidate) => {
-                        const validateHandler = async (resp: any) => {
-                          if (resp.url().includes('validate_code')) {
-                            try {
-                              const validateBody = await resp.text()
-                              const validateJson = JSON.parse(validateBody)
-                              logger.debug('验证码验证响应:', validateJson)
-
-                              if (validateJson.data?.error_code === 1202) {
-                                // 验证码错误
-                                logger.warn('验证码错误')
-                                page.off('response', validateHandler)
-                                resolveValidate(false)
-                              } else if (validateJson.message === 'success' || !validateJson.data?.error_code) {
-                                // 验证成功
-                                logger.mark('验证码验证成功')
-                                page.off('response', validateHandler)
-                                resolveValidate(true)
-                              }
-                            } catch (err) {
-                              logger.debug('解析验证响应失败:', err)
-                            }
-                          }
-                        }
-                        page.on('response', validateHandler)
-
-                        // 5秒超时
-                        setTimeout(() => {
-                          page.off('response', validateHandler)
-                          resolveValidate(false)
-                        }, 5000)
-                      })
-
-                      // 点击"验证"按钮
-                      await page.evaluate(() => {
-                        const elements = Array.from(document.querySelectorAll('*'))
-                        const verifyBtn = elements.find((el) => el.textContent?.trim() === '验证')
-                        if (verifyBtn) {
-                          ;(verifyBtn as HTMLElement).click()
-                        }
-                      })
-
-                      logger.mark('已提交验证码，等待验证结果...')
-
-                      // 等待验证结果
-                      verifySuccess = await validatePromise
-
-                      if (!verifySuccess && verifyAttempts < maxAttempts) {
-                        // 还有重试机会
-                        const retryMsg = await e.reply('验证码错误，请重新发送正确的 6 位数验证码（剩余机会：1次）', {
-                          reply: true
-                        })
-                        msg_id.push(retryMsg.messageId)
-                      } else if (!verifySuccess && verifyAttempts >= maxAttempts) {
-                        // 没有机会了
-                        logger.warn('验证码错误次数过多，登录失败')
-                        clearTimeout(timer)
-                        if (gcInterval) clearInterval(gcInterval)
-                        await puppeteer.browser.close()
-                        // 撤回所有之前的消息
-                        await Promise.all(
-                          msg_id.map(async (id) => {
-                            await e.bot.recallMsg(e.contact, id)
-                          })
-                        )
-                        await e.reply('验证码错误，登录失败', { reply: true })
-                        resolve(true) // 返回true表示已处理完成，避免外层再次处理
-                        return
-                      }
-                    }
-
-                    if (verifySuccess) {
-                      logger.mark('2FA验证通过，等待最终登录确认...')
-                    }
-                  } catch (err) {
-                    logger.error('二次验证处理失败:', err)
-                    clearTimeout(timer)
-                    if (gcInterval) clearInterval(gcInterval)
-                    await puppeteer.browser.close()
-                    // 撤回所有之前的消息
-                    await Promise.all(
-                      msg_id.map(async (id) => {
-                        await e.bot.recallMsg(e.contact, id)
-                      })
-                    )
-                    await e.reply('二次验证处理失败，登录失败', { reply: true })
-                    resolve(true) // 返回true表示已处理完成
-                  }
-                })()
-              }
-            }
+            await e.bot.recallMsg(e.contact, id)
           } catch (error) {
-            logger.error('处理响应时出错:', error)
+            logger.debug('[抖音登录] 撤回消息失败:', error)
           }
         })
-      })
-    ])
+      )
+    }
+  }
+}
 
-    if (gcInterval) clearInterval(gcInterval)
+/** 登录会话的可变状态：cookie 会被每一步刷新，必须逐步传递下去 */
+interface LoginSession {
+  /** 当前会话 cookie */
+  cookie: string
+  /** 二维码令牌 */
+  token: string
+}
 
-    if (!loginResult) {
-      logger.warn('登录超时或失败')
-      await puppeteer.browser.close()
-      await e.reply('登录超时！二维码已失效！', { reply: true })
+/**
+ * 处理账号二次验证：发短信验证码 → 等用户回填 → 提交
+ * @param e 消息事件
+ * @param session 登录会话，验证过程中会刷新其中的 cookie
+ * @param verify 轮询下发的验证上下文
+ * @param tracker 消息登记器
+ * @returns 验证是否通过
+ */
+const handleSecondVerify = async (
+  e: Message,
+  session: LoginSession,
+  verify: DouyinPassportVerifyContext,
+  tracker: ReturnType<typeof createMessageTracker>
+): Promise<boolean> => {
+  if (!verify.encryptUid) {
+    await tracker.send('账号触发了二次验证，但服务端未下发验证上下文，请稍后重试')
+    return false
+  }
+
+  const smsWay = verify.verifyWays.find((way) => way.verifyWay === 'mobile_sms_verify')
+  if (verify.verifyWays.length > 0 && !smsWay) {
+    const ways = verify.verifyWays.map((way) => way.verifyWay).join('、')
+    await tracker.send(`账号触发了二次验证，但当前仅支持短信验证码，服务端给出的方式为：${ways}`)
+    return false
+  }
+
+  const sent = await sendPassportVerifyCode({ verify }, session.cookie, requestConfig())
+  if (!sent.success) {
+    await tracker.send(`短信验证码发送失败：${sent.message}`)
+    return false
+  }
+  session.cookie = sent.data.cookie
+
+  if (!sent.data.ok) {
+    await tracker.send(`短信验证码发送失败：${sent.data.message}`)
+    return false
+  }
+
+  const bizTraceId = sent.data.biz_trace_id
+  const target = sent.data.mobile || smsWay?.mobile || '扫码设备绑定的手机号'
+  await tracker.send(`此次登录需要二次验证\n6 位数验证码已发送至 ${target}\n请在 ${CODE_INPUT_TIMEOUT} 秒内直接回复该验证码`)
+
+  for (let attempt = 1; attempt <= CODE_MAX_ATTEMPTS; attempt++) {
+    const context = await karin.ctx(e, { time: CODE_INPUT_TIMEOUT, reply: false, throwOnTimeout: false })
+
+    if (!context) {
+      await tracker.send('等待验证码超时，登录已取消')
+      return false
+    }
+
+    const code = context.msg.trim()
+    if (!CODE_PATTERN.test(code)) {
+      if (attempt === CODE_MAX_ATTEMPTS) {
+        await tracker.send('输入格式不正确，登录已取消')
+        return false
+      }
+      await tracker.send(`请只发送 6 位数字验证码（剩余 ${CODE_MAX_ATTEMPTS - attempt} 次机会）`)
+      continue
+    }
+
+    const checked = await validatePassportVerifyCode({ verify, code, biz_trace_id: bizTraceId }, session.cookie, requestConfig())
+    if (!checked.success) {
+      await tracker.send(`验证失败：${checked.message}`)
+      return false
+    }
+    session.cookie = checked.data.cookie
+
+    if (checked.data.ok) {
+      logger.mark('[抖音登录] 二次验证通过')
+      await tracker.send('验证通过，正在完成登录…')
       return true
     }
-  } catch (err) {
-    logger.error('登录流程出错:', err)
-    if (gcInterval) clearInterval(gcInterval)
-    await puppeteer.browser.close()
-    await e.reply('登录过程出错，请查看控制台日志', { reply: true })
+
+    if (!checked.data.wrongCode || attempt === CODE_MAX_ATTEMPTS) {
+      await tracker.send(`验证失败：${checked.data.message}`)
+      return false
+    }
+
+    await tracker.send(`验证码错误，请重新发送（剩余 ${CODE_MAX_ATTEMPTS - attempt} 次机会）`)
   }
-  return true
+
+  return false
 }
 
 /**
- * 等待二维码出现并获取二维码信息
- * @param page puppeteer的页面对象
- * @returns 包含解码URL和原始图片的对象
+ * 保存登录凭证并重载 Amagi 客户端
+ * @param cookie 完整登录 cookie
  */
-const waitQrcode = async (page: Page): Promise<{ url: string | null; originalImage: string }> => {
-  const qrCodeSelector = 'img[aria-label="二维码"]'
-  try {
-    await page.waitForSelector(qrCodeSelector, { timeout: 60000 })
-  } catch {
-    await safeScreenshot(page, path.join(karinPathTemp, Root.pluginName, 'DouyinLoginQrcodeError.png'))
-    throw new Error('加载超时了，或者遇到验证码了。。。')
+const persistCookie = async (cookie: string): Promise<void> => {
+  const present = new Set(cookie.split(';').map((pair) => pair.split('=')[0].trim()))
+  const missing = REQUIRED_COOKIES.filter((name) => !present.has(name))
+  if (missing.length > 0) {
+    logger.warn(`[抖音登录] 以下 cookie 未在本次登录中下发：${missing.join(', ')}`)
   }
-  logger.debug('二维码加载完成')
-  await new Promise((resolve) => setTimeout(resolve, 1000))
 
-  // 获取原始二维码图片的 src
-  const images = await page.$$eval('img', (imgs) => {
-    return imgs.map((img) => ({
-      src: img.src,
-      ariaLabel: img.getAttribute('aria-label')
-    }))
-  })
-  const qrCodeImages = images.filter((img) => img.ariaLabel === '二维码')
-  if (qrCodeImages.length === 0) {
-    throw new Error('未找到二维码')
-  }
-  const originalImage = qrCodeImages[0].src
+  await Config.Modify('amagi', 'cookies.douyin', cookie)
+  const reloaded = reloadAmagiConfig()
+  logger.mark(`[抖音登录] 登录凭证已保存，Amagi Client ${reloaded ? '已重载' : '配置未变化'}`)
+}
 
-  // 直接从原始 src 下载图片进行解码
+/**
+ * 抖音扫码登录
+ *
+ * 协议层在 `@ikenxuan/amagi` 的 passport 接口里，这里只负责与用户的交互和状态流转，
+ * 全程不启动浏览器。
+ * @param e 消息事件
+ */
+export const douyinLogin = async (e: Message) => {
+  const tracker = createMessageTracker(e)
+
   try {
-    let imageBuffer: Buffer
-
-    if (originalImage.startsWith('data:image')) {
-      // base64 图片
-      const base64Data = originalImage.split(',')[1]
-      imageBuffer = Buffer.from(base64Data, 'base64')
-    } else {
-      // URL 图片，需要下载
-      const response = await fetch(originalImage)
-      imageBuffer = Buffer.from(await response.arrayBuffer())
+    const qrcode = await requestPassportQrcode(undefined, undefined, requestConfig())
+    if (!qrcode.success) {
+      await e.reply(`获取二维码失败：${qrcode.message}`, { reply: true })
+      return true
     }
 
-    // 使用 QRCodeScanner 解析二维码
-    const qrContent = scanSync(imageBuffer)
+    const session: LoginSession = { cookie: qrcode.data.cookie, token: qrcode.data.token }
+    logger.mark(`[抖音登录] 二维码已获取，有效期 ${Math.round(qrcode.data.expire_time / 1000)} 秒`)
 
-    if (qrContent) {
-      logger.mark('二维码解码成功:', qrContent)
-      return { url: qrContent, originalImage }
+    const rendered = await Render(e, 'douyin/qrcodeImg', { share_url: qrcode.data.content })
+    const base64Data = rendered[0]?.file
+    if (!base64Data) throw new Error('生成二维码图片失败')
+
+    fs.writeFileSync(
+      `${Common.tempDri.default}DouyinLoginQrcode.png`,
+      Buffer.from(base64Data.replace(/^base64:\/\//, ''), 'base64')
+    )
+
+    await tracker.send(rendered)
+
+    let deadline = Date.now() + SCAN_TIMEOUT
+    let scanned = false
+
+    while (Date.now() < deadline) {
+      const polled = await checkPassportQrcode({ token: session.token }, session.cookie, requestConfig())
+      if (!polled.success) {
+        await tracker.recallAll()
+        await e.reply(`轮询二维码状态失败：${polled.message}`, { reply: true })
+        return true
+      }
+
+      const result: DouyinPassportQrcodeStatus = polled.data
+      session.cookie = result.cookie
+
+      switch (result.status) {
+        case 'new':
+          break
+
+        case 'scanned':
+          if (!scanned) {
+            scanned = true
+            deadline = Date.now() + CONFIRM_TIMEOUT
+            await tracker.recallAll()
+            await tracker.send('二维码已扫描，请在手机上确认登录')
+          }
+          break
+
+        case 'verify': {
+          const passed = await handleSecondVerify(e, session, result.verify, tracker)
+          if (!passed) {
+            await tracker.recallAll()
+            return true
+          }
+          deadline = Date.now() + CONFIRM_TIMEOUT
+          break
+        }
+
+        case 'confirmed':
+          if (!result.logged_in) {
+            await tracker.recallAll()
+            await e.reply('已确认登录，但服务端未下发登录凭证，请稍后重试', { reply: true })
+            return true
+          }
+          await persistCookie(result.cookie)
+          await tracker.recallAll()
+          await e.reply('登录成功！用户登录凭证已保存至配置', { reply: true })
+          return true
+
+        case 'expired':
+          await tracker.recallAll()
+          await e.reply('二维码已失效，请重新发起登录', { reply: true })
+          return true
+
+        case 'risk':
+          logger.warn(`[抖音登录] 命中风控: ${result.message}`)
+          await tracker.recallAll()
+          await e.reply(`登录请求被抖音风控拦截：${result.message}\n请稍后再试`, { reply: true })
+          return true
+
+        case 'unknown':
+          logger.warn(`[抖音登录] 未知的轮询状态: ${result.message}`)
+          break
+      }
+
+      await sleep(result.interval)
     }
+
+    await tracker.recallAll()
+    await e.reply(scanned ? '等待手机确认超时，登录已取消' : '登录超时！二维码已失效！', { reply: true })
   } catch (error) {
-    logger.warn('二维码解码失败:', error)
+    logger.error('[抖音登录] 登录流程出错:', error)
+    await tracker.recallAll()
+    await e.reply('登录过程出错，请查看控制台日志', { reply: true })
   }
 
-  // 解码失败，返回 null 和原图
-  logger.warn('解码失败，将使用原始二维码图片')
-  return { url: null, originalImage }
+  return true
 }

--- a/packages/core/src/platform/douyin/login.ts
+++ b/packages/core/src/platform/douyin/login.ts
@@ -5,7 +5,6 @@ import {
   requestPassportQrcode,
   sendPassportVerifyCode,
   validatePassportVerifyCode,
-  type DouyinPassportQrcodeStatus,
   type DouyinPassportVerifyContext
 } from '@ikenxuan/amagi'
 import { karin, logger, type Message } from 'node-karin'
@@ -55,14 +54,14 @@ const createMessageTracker = (e: Message) => {
      * 发送并登记一条消息
      * @param message 消息内容
      */
-    async send (message: Parameters<Message['reply']>[0]) {
+    async send(message: Parameters<Message['reply']>[0]) {
       const sent = await e.reply(message, { reply: true })
       if (sent.messageId) messageIds.push(sent.messageId)
       return sent
     },
 
     /** 撤回目前登记的全部消息 */
-    async recallAll () {
+    async recallAll() {
       const pending = messageIds.splice(0, messageIds.length)
       await Promise.all(
         pending.map(async (id) => {
@@ -111,7 +110,7 @@ const handleSecondVerify = async (
     return false
   }
 
-  const sent = await sendPassportVerifyCode({ verify }, session.cookie, requestConfig())
+  const sent = await sendPassportVerifyCode({ verify, typeMode: 'strict' }, session.cookie, requestConfig())
   if (!sent.success) {
     await tracker.send(`短信验证码发送失败：${sent.message}`)
     return false
@@ -145,7 +144,11 @@ const handleSecondVerify = async (
       continue
     }
 
-    const checked = await validatePassportVerifyCode({ verify, code, biz_trace_id: bizTraceId }, session.cookie, requestConfig())
+    const checked = await validatePassportVerifyCode(
+      { verify, code, biz_trace_id: bizTraceId, typeMode: 'strict' },
+      session.cookie,
+      requestConfig()
+    )
     if (!checked.success) {
       await tracker.send(`验证失败：${checked.message}`)
       return false
@@ -196,7 +199,7 @@ export const douyinLogin = async (e: Message) => {
   const tracker = createMessageTracker(e)
 
   try {
-    const qrcode = await requestPassportQrcode(undefined, undefined, requestConfig())
+    const qrcode = await requestPassportQrcode({ typeMode: 'strict' }, undefined, requestConfig())
     if (!qrcode.success) {
       await e.reply(`获取二维码失败：${qrcode.message}`, { reply: true })
       return true
@@ -209,10 +212,7 @@ export const douyinLogin = async (e: Message) => {
     const base64Data = rendered[0]?.file
     if (!base64Data) throw new Error('生成二维码图片失败')
 
-    fs.writeFileSync(
-      `${Common.tempDri.default}DouyinLoginQrcode.png`,
-      Buffer.from(base64Data.replace(/^base64:\/\//, ''), 'base64')
-    )
+    fs.writeFileSync(`${Common.tempDri.default}DouyinLoginQrcode.png`, Buffer.from(base64Data.replace(/^base64:\/\//, ''), 'base64'))
 
     await tracker.send(rendered)
 
@@ -220,14 +220,14 @@ export const douyinLogin = async (e: Message) => {
     let scanned = false
 
     while (Date.now() < deadline) {
-      const polled = await checkPassportQrcode({ token: session.token }, session.cookie, requestConfig())
+      const polled = await checkPassportQrcode({ token: session.token, typeMode: 'strict' }, session.cookie, requestConfig())
       if (!polled.success) {
         await tracker.recallAll()
         await e.reply(`轮询二维码状态失败：${polled.message}`, { reply: true })
         return true
       }
 
-      const result: DouyinPassportQrcodeStatus = polled.data
+      const result = polled.data
       session.cookie = result.cookie
 
       switch (result.status) {

--- a/packages/core/src/platform/douyin/login.ts
+++ b/packages/core/src/platform/douyin/login.ts
@@ -14,7 +14,7 @@ import { Common, Render } from '@/module'
 import { reloadAmagiConfig } from '@/module/utils/amagiClient'
 import { Config } from '@/module/utils/Config'
 
-/** 等待用户扫码的时限，与消息可撤回窗口（2 分钟）对齐 */
+/** 等待用户扫码的时限上限，与消息可撤回窗口（2 分钟）对齐；二维码本身更早失效时以它为准 */
 const SCAN_TIMEOUT = 120_000
 
 /** 扫码后等待手机确认或完成二次验证的时限 */
@@ -212,7 +212,9 @@ export const douyinLogin = async (e: Message) => {
     }
 
     const session: LoginSession = { cookie: qrcode.data.cookie, token: qrcode.data.token }
-    logger.mark(`[抖音登录] 二维码已获取，有效期 ${Math.round(qrcode.data.expire_time / 1000)} 秒`)
+    // expire_time 是绝对 Unix 秒，剩余时长直接用 expires_in
+    const validFor = qrcode.data.expires_in
+    logger.mark(`[抖音登录] 二维码已获取，有效期 ${validFor} 秒`)
 
     const rendered = await Render(e, 'douyin/qrcodeImg', { share_url: qrcode.data.content })
     const base64Data = rendered[0]?.file
@@ -222,7 +224,8 @@ export const douyinLogin = async (e: Message) => {
 
     await tracker.send(rendered)
 
-    let deadline = Date.now() + SCAN_TIMEOUT
+    // 二维码实际只有约 60 秒有效期，等到 2 分钟才提示超时会让用户白等
+    let deadline = Date.now() + (validFor > 0 ? Math.min(validFor * 1000, SCAN_TIMEOUT) : SCAN_TIMEOUT)
     let scanned = false
 
     while (Date.now() < deadline) {

--- a/packages/core/src/platform/douyin/login.ts
+++ b/packages/core/src/platform/douyin/login.ts
@@ -269,6 +269,11 @@ export const douyinLogin = async (e: Message) => {
           await e.reply('二维码已失效，请重新发起登录', { reply: true })
           return true
 
+        case 'busy':
+          // 服务端限频，parser 已经把间隔翻倍，这里只记录不打扰用户
+          logger.debug(`[抖音登录] 轮询被限频，${result.interval} ms 后重试: ${result.message}`)
+          break
+
         case 'risk':
           logger.warn(`[抖音登录] 命中风控: ${result.message}`)
           await tracker.recallAll()

--- a/packages/core/test/douyin-login.test.ts
+++ b/packages/core/test/douyin-login.test.ts
@@ -1,0 +1,300 @@
+import { douyinPassport } from '@ikenxuan/amagi'
+import { describe, expect, it } from 'vitest'
+
+// 协议层实现在 @ikenxuan/amagi 的 passport 模块里，这里锁住 kkk 依赖的那部分行为
+const {
+  aBogus,
+  CookieJar,
+  makeAidSign,
+  makeSignAndQs,
+  parsePollResult,
+  parseQrcode,
+  parseSendCodeResult,
+  parseValidateCodeResult,
+  sm3Hex,
+  utcNoonTimestamp,
+  xor5Hex
+} = douyinPassport
+
+
+describe('CookieJar', () => {
+  it('按下发顺序覆盖同名 cookie，保留最后一次的值', () => {
+    const jar = new CookieJar()
+    jar.applySetCookie(['ttwid=first; Path=/; Domain=.douyin.com'])
+    jar.applySetCookie(['ttwid=second; Path=/; Domain=.douyin.com'])
+
+    expect(jar.get('ttwid')).toBe('second')
+    expect(jar.toString()).toBe('ttwid=second')
+  })
+
+  it('更新同名 cookie 不会产生重复项，也不会改变位置', () => {
+    const jar = new CookieJar('a=1; sessionid=old; b=2')
+    jar.applySetCookie('sessionid=new; Path=/; HttpOnly')
+
+    expect(jar.toString()).toBe('a=1; sessionid=new; b=2')
+    expect(jar.size).toBe(3)
+  })
+
+  it('合并多条 Set-Cookie 并保留全部登录凭证', () => {
+    const jar = new CookieJar('ttwid=abc')
+    jar.applySetCookie([
+      'sessionid=s1; Path=/; HttpOnly',
+      'sessionid_ss=s2; Path=/; Secure',
+      'sid_guard=s3%7C1700000000%7C; Path=/',
+      'uid_tt=u1; Path=/',
+      'uid_tt_ss=u2; Path=/'
+    ])
+
+    expect(jar.toJSON()).toEqual({
+      ttwid: 'abc',
+      sessionid: 's1',
+      sessionid_ss: 's2',
+      sid_guard: 's3%7C1700000000%7C',
+      uid_tt: 'u1',
+      uid_tt_ss: 'u2'
+    })
+    expect(jar.isLoggedIn()).toBe(true)
+  })
+
+  it('Max-Age=0 与过期时间视为删除指令', () => {
+    const jar = new CookieJar('a=1; b=2; c=3')
+    jar.applySetCookie(['a=; Max-Age=0; Path=/', 'b=x; Expires=Thu, 01 Jan 1970 00:00:00 GMT'])
+
+    expect(jar.has('a')).toBe(false)
+    expect(jar.has('b')).toBe(false)
+    expect(jar.get('c')).toBe('3')
+  })
+
+  it('未来的 Expires 不会误删 cookie', () => {
+    const jar = new CookieJar()
+    jar.applySetCookie('sessionid=alive; Expires=Tue, 01 Jan 2999 00:00:00 GMT; Path=/')
+
+    expect(jar.get('sessionid')).toBe('alive')
+  })
+
+  it('忽略空值与格式异常的输入', () => {
+    const jar = new CookieJar()
+    jar.merge(undefined).merge('').applySetCookie(null).applySetCookie(['nonsense', '=noname; Path=/'])
+
+    expect(jar.size).toBe(0)
+    expect(jar.isLoggedIn()).toBe(false)
+  })
+
+  it('ttwid 本身不构成登录态', () => {
+    expect(new CookieJar('ttwid=only').isLoggedIn()).toBe(false)
+  })
+})
+
+describe('parseQrcode', () => {
+  it('优先取 qrcode_index_url 作为二维码内容', () => {
+    const qrcode = parseQrcode({
+      data: { token: 'tk', qrcode_index_url: 'https://www.douyin.com/qr/x', expire_time: 300000 }
+    })
+
+    expect(qrcode).toEqual({ token: 'tk', content: 'https://www.douyin.com/qr/x', expireTime: 300000 })
+  })
+
+  it('缺少 index_url 时回退到 token', () => {
+    expect(parseQrcode({ data: { token: 'tk' } })?.content).toBe('tk')
+  })
+
+  it('响应异常时返回 null', () => {
+    expect(parseQrcode({})).toBeNull()
+    expect(parseQrcode({ data: {} })).toBeNull()
+    expect(parseQrcode({ message: 'error', data: { error_code: 2156 } })).toBeNull()
+  })
+})
+
+describe('parsePollResult', () => {
+  it('解析未扫码状态并采用服务端给出的轮询间隔', () => {
+    expect(parsePollResult({ data: { status: 'new', interval: 5000 } })).toEqual({ status: 'new', interval: 5000 })
+  })
+
+  it('间隔缺失或过小时回落到默认值', () => {
+    expect(parsePollResult({ data: { status: 'scanned' } })).toEqual({ status: 'scanned', interval: 3000 })
+    expect(parsePollResult({ data: { status: 'scanned', interval: 0 } })).toEqual({ status: 'scanned', interval: 3000 })
+  })
+
+  it('解析确认状态并取出跳转地址', () => {
+    const result = parsePollResult({
+      data: { status: 'confirmed', redirect_url: 'https://www.douyin.com/passport/sso/login/?code=1' }
+    })
+
+    expect(result).toEqual({
+      status: 'confirmed',
+      interval: 3000,
+      redirectUrl: 'https://www.douyin.com/passport/sso/login/?code=1'
+    })
+  })
+
+  it('redirect_url 缺失时回退到 redirect_urls 数组', () => {
+    const result = parsePollResult({ data: { status: 'confirmed', redirect_urls: ['https://a.example/1'] } })
+
+    expect(result.status).toBe('confirmed')
+    expect(result.status === 'confirmed' && result.redirectUrl).toBe('https://a.example/1')
+  })
+
+  it('解析过期状态', () => {
+    expect(parsePollResult({ data: { status: 'expired' } }).status).toBe('expired')
+  })
+
+  it('error_code 2046 识别为二次验证并提取验证上下文', () => {
+    const result = parsePollResult({
+      data: {
+        error_code: 2046,
+        encrypt_uid: 'euid',
+        verify_ticket: 'ticket',
+        std_verify_token: 'token',
+        std_verify_flow_id: 'flow',
+        std_verify_way: 'mobile_sms_verify',
+        verify_ways: [{ verify_way: 'mobile_sms_verify', mobile: '138****0000' }]
+      }
+    })
+
+    expect(result.status).toBe('verify')
+    if (result.status !== 'verify') return
+
+    expect(result.verify.encryptUid).toBe('euid')
+    expect(result.verify.verifyTicket).toBe('ticket')
+    expect(result.verify.stdParams).toEqual({
+      std_verify_token: 'token',
+      std_verify_flow_id: 'flow',
+      std_verify_way: 'mobile_sms_verify'
+    })
+    expect(result.verify.copywritingKey).toBe('qr_connect')
+    expect(result.verify.diversionTag).toBe('mfa')
+    expect(result.verify.verifyWays).toEqual([{ verifyWay: 'mobile_sms_verify', mobile: '138****0000' }])
+  })
+
+  it('account_flow=verify 同样识别为二次验证', () => {
+    expect(parsePollResult({ data: { account_flow: 'verify', encrypt_uid: 'euid' } }).status).toBe('verify')
+  })
+
+  it('风控错误码识别为 risk', () => {
+    const result = parsePollResult({ data: { error_code: 2156, description: '环境异常' } })
+
+    expect(result.status).toBe('risk')
+    expect(result.status === 'risk' && result.message).toBe('环境异常')
+  })
+
+  it('空响应与无法识别的状态归入 unknown', () => {
+    expect(parsePollResult({}).status).toBe('unknown')
+    expect(parsePollResult({ data: { status: 'whatever' } }).status).toBe('unknown')
+    expect(parsePollResult({ data: { status: 'whatever' } })).toMatchObject({ message: 'status=whatever' })
+  })
+})
+
+describe('parseSendCodeResult', () => {
+  it('识别发码成功并带出脱敏手机号', () => {
+    const result = parseSendCodeResult({ message: 'success', data: { mobile: '138****0000', retry_time: 60 } })
+
+    expect(result).toEqual({ ok: true, mobile: '138****0000', retryAfter: 60, message: '' })
+  })
+
+  it('error_code 为 0 也视为成功', () => {
+    expect(parseSendCodeResult({ data: { error_code: 0, mobile: '1' } }).ok).toBe(true)
+  })
+
+  it('限频错误给出可读提示', () => {
+    const result = parseSendCodeResult({ data: { error_code: 1206, retry_time: 30 } })
+
+    expect(result.ok).toBe(false)
+    expect(result.errorCode).toBe(1206)
+    expect(result.retryAfter).toBe(30)
+    expect(result.message).toBe('短信发送过于频繁')
+  })
+
+  it('空响应视为失败而不是成功', () => {
+    expect(parseSendCodeResult({}).ok).toBe(false)
+    expect(parseSendCodeResult({ data: {} }).ok).toBe(false)
+  })
+})
+
+describe('parseValidateCodeResult', () => {
+  it('返回 ticket 视为验证通过', () => {
+    expect(parseValidateCodeResult({ message: 'success', data: { ticket: 'tk' } })).toEqual({
+      ok: true,
+      wrongCode: false,
+      message: ''
+    })
+  })
+
+  it('error_code 1202 标记为验证码填错，允许重试', () => {
+    const result = parseValidateCodeResult({ data: { error_code: 1202, description: '验证码错误' } })
+
+    expect(result).toEqual({ ok: false, wrongCode: true, errorCode: 1202, message: '验证码错误' })
+  })
+
+  it('其他错误码不允许当作填错重试', () => {
+    const result = parseValidateCodeResult({ data: { error_code: 1204 } })
+
+    expect(result.ok).toBe(false)
+    expect(result.wrongCode).toBe(false)
+    expect(result.message).toBe('验证失败 error_code=1204')
+  })
+
+  it('空响应视为失败', () => {
+    expect(parseValidateCodeResult({}).ok).toBe(false)
+  })
+})
+
+/** xor5Hex 的逆运算，仅测试用 */
+const decodeXor5 = (hex: string): string => Buffer.from((hex.match(/../g) ?? []).map((byte) => parseInt(byte, 16) ^ 5)).toString('utf8')
+
+describe('签名基元', () => {
+  it('SM3 与国标测试向量一致', () => {
+    expect(sm3Hex('abc')).toBe('66c7f0f462eeedd9d1f2d46bdc10e4e24167c4875cf2f7a2297da02b8f4ba8e0')
+    expect(sm3Hex('abcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd')).toBe(
+      'debe9ff92275b8a138604889c18e5a4d6fdb70e5387e5765293dcba39c0c5732'
+    )
+  })
+
+  it('xor5Hex 与 SDK 的验证码编码一致', () => {
+    expect(xor5Hex('444684')).toBe('313131333d31')
+    expect(xor5Hex('mix_mode=1')).toBe('686c7d5a686a61603834')
+  })
+
+  it('sign 与 qs 只取排序后的前 10 个参数', () => {
+    const params = Object.fromEntries(Array.from({ length: 12 }, (_, index) => [`k${index}`, String(index)]))
+    const { sign, qs } = makeSignAndQs(params)
+
+    expect(sign).toMatch(/^[0-9a-f]{64}$/)
+    // qs 是参与签名的参数名列表异或 5 后的十六进制，解回来应当只剩排序后的前 10 个键
+    expect(decodeXor5(qs)).toBe('k0,k1,k10,k11,k2,k3,k4,k5,k6,k7')
+  })
+
+  it('相同输入的 sign 稳定，不同 body 会改变 sign', () => {
+    const params = { a: '1', b: '2' }
+
+    expect(makeSignAndQs(params).sign).toBe(makeSignAndQs(params).sign)
+    expect(makeSignAndQs(params, { c: '3' }).sign).not.toBe(makeSignAndQs(params).sign)
+  })
+
+  it('aid-sign 为 64 位十六进制且随路径变化', () => {
+    const ts = utcNoonTimestamp(new Date('2026-08-31T03:00:00Z'))
+
+    expect(makeAidSign('/passport/web/get_qrcode/', ts)).toMatch(/^[0-9a-f]{64}$/)
+    expect(makeAidSign('/passport/web/get_qrcode/', ts)).not.toBe(makeAidSign('/passport/web/check_qrconnect/', ts))
+  })
+
+  it('utcNoonTimestamp 取当天 UTC 正午', () => {
+    expect(utcNoonTimestamp(new Date('2026-08-31T23:59:59Z'))).toBe(Date.UTC(2026, 7, 31, 12) / 1000)
+  })
+})
+
+describe('aBogus', () => {
+  const ua = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36'
+
+  it('生成非空签名，且只使用签名字符表内的字符', () => {
+    const signature = aBogus('aid=6383&device_platform=web_app', ua)
+
+    expect(signature.length).toBeGreaterThan(80)
+    expect(signature).toMatch(/^[A-Za-z0-9/\-+=]+$/)
+  })
+
+  it('含随机因子，两次调用结果不同', () => {
+    const query = 'aid=6383&device_platform=web_app'
+
+    expect(aBogus(query, ua)).not.toBe(aBogus(query, ua))
+  })
+})

--- a/packages/core/test/douyin-login.test.ts
+++ b/packages/core/test/douyin-login.test.ts
@@ -1,3 +1,5 @@
+import { createECDH, createHmac, hkdfSync } from 'node:crypto'
+
 import { douyinPassport } from '@ikenxuan/amagi'
 import { describe, expect, it } from 'vitest'
 
@@ -12,6 +14,7 @@ const {
   parseSendCodeResult,
   parseValidateCodeResult,
   sm3Hex,
+  TicketGuard,
   utcNoonTimestamp,
   xor5Hex
 } = douyinPassport
@@ -296,5 +299,149 @@ describe('aBogus', () => {
     const query = 'aid=6383&device_platform=web_app'
 
     expect(aBogus(query, ua)).not.toBe(aBogus(query, ua))
+  })
+})
+
+
+describe('CookieJar 的本地会话状态', () => {
+  it('__amagi_ 前缀的条目不进 Cookie 请求头', () => {
+    const jar = new CookieJar('ttwid=abc; __amagi_tg_key=secret')
+    expect(jar.toString()).toBe('ttwid=abc')
+    expect(jar.toString()).not.toContain('secret')
+  })
+
+  it('serialize 保留本地会话状态，供两次调用之间传递', () => {
+    const jar = new CookieJar('ttwid=abc')
+    jar.set('__amagi_tg_ticket', 'hash.xxx')
+    expect(jar.serialize()).toBe('ttwid=abc; __amagi_tg_ticket=hash.xxx')
+  })
+
+  it('serialize 的结果能被重新解析回同一份状态', () => {
+    const jar = new CookieJar('ttwid=abc')
+    jar.set('__amagi_tg_ticket', 'hash.xxx')
+    const restored = new CookieJar(jar.serialize())
+    expect(restored.get('__amagi_tg_ticket')).toBe('hash.xxx')
+    expect(restored.toString()).toBe('ttwid=abc')
+  })
+})
+
+describe('TicketGuard', () => {
+  it('发布公钥时写入 client_data 与 web_domain 两条 cookie', () => {
+    const jar = new CookieJar()
+    new TicketGuard(jar).publishPublicKey()
+
+    const payload = JSON.parse(
+      Buffer.from(decodeURIComponent(jar.get('bd_ticket_guard_client_data') ?? ''), 'base64').toString('utf8')
+    )
+    expect(payload['bd-ticket-guard-version']).toBe(2)
+    expect(payload['bd-ticket-guard-iteration-version']).toBe(1)
+    expect(payload['bd-ticket-guard-web-version']).toBe(2)
+    // 未压缩的 P-256 公钥点：1 + 32 + 32 字节
+    expect(Buffer.from(payload['bd-ticket-guard-ree-public-key'], 'base64')).toHaveLength(65)
+    expect(jar.get('bd_ticket_guard_client_web_domain')).toBe('2')
+  })
+
+  it('私钥只生成一次，同一份 cookie 得到同一个公钥', () => {
+    const jar = new CookieJar()
+    const first = new TicketGuard(jar).reePublicKey
+    expect(new TicketGuard(jar).reePublicKey).toBe(first)
+    // 换一份 cookie 就是另一台设备
+    expect(new TicketGuard(new CookieJar()).reePublicKey).not.toBe(first)
+  })
+
+  it('私钥不会出现在 Cookie 请求头里', () => {
+    const jar = new CookieJar('ttwid=abc')
+    const guard = new TicketGuard(jar)
+    guard.publishPublicKey()
+    expect(jar.get('__amagi_tg_key')).toBeTruthy()
+    expect(jar.toString()).not.toContain('__amagi_tg_key')
+  })
+
+  it('未拿到票据时只声明公钥，不带签名', () => {
+    const guard = new TicketGuard(new CookieJar())
+    const headers = guard.headers('/passport/web/get_qrcode/')
+    expect(headers['bd-ticket-guard-ree-public-key']).toBeTruthy()
+    expect(headers['bd-ticket-guard-client-data']).toBeUndefined()
+    expect(headers['bd-ticket-guard-web-sign-type']).toBeUndefined()
+  })
+
+  it('缺字段的签发结果不写入状态', () => {
+    const guard = new TicketGuard(new CookieJar())
+    const partial = Buffer.from(JSON.stringify({ ticket: 'hash.x', ts_sign: 'ts.2.y' })).toString('base64')
+    expect(guard.applyServerData({ 'bd-ticket-guard-server-data': partial })).toBe(false)
+    expect(guard.state).toBeUndefined()
+  })
+
+  it('无法解析的签发结果不抛异常', () => {
+    const guard = new TicketGuard(new CookieJar())
+    expect(guard.applyServerData({ 'bd-ticket-guard-server-data': 'not-base64-json' })).toBe(false)
+    expect(guard.applyServerData({})).toBe(false)
+  })
+
+  it('拿到票据后产出可验证的 HMAC 签名，并按 ts_sign 选择 web-version', () => {
+    const jar = new CookieJar()
+    const guard = new TicketGuard(jar)
+    // 用一把临时密钥充当服务端，走与线上一致的 ECDH + HKDF 流程
+    const server = createECDH('prime256v1')
+    server.generateKeys()
+    const spki = Buffer.concat([
+      Buffer.from('3059301306072a8648ce3d020106082a8648ce3d030107034200', 'hex'),
+      server.getPublicKey()
+    ])
+    const cert = `pub.${spki.subarray(spki.length - 65).toString('base64')}`
+
+    const serverData = Buffer.from(
+      JSON.stringify({ ticket: 'hash.abc', ts_sign: 'ts.2.def', client_cert: cert })
+    ).toString('base64')
+    expect(guard.applyServerData({ 'bd-ticket-guard-server-data': serverData })).toBe(true)
+
+    const headers = guard.headers('/passport/web/check_qrconnect/', 1700000000)
+    expect(headers['bd-ticket-guard-web-version']).toBe('2')
+    expect(headers['bd-ticket-guard-web-sign-type']).toBe('1')
+
+    const clientData = JSON.parse(Buffer.from(headers['bd-ticket-guard-client-data'], 'base64').toString('utf8'))
+    expect(clientData).toMatchObject({
+      ts_sign: 'ts.2.def',
+      req_content: 'ticket,path,timestamp',
+      timestamp: 1700000000
+    })
+
+    // 服务端侧独立复算：ECDH -> HKDF -> HMAC
+    const shared = server.computeSecret(
+      Buffer.from(guard.reePublicKey, 'base64')
+    )
+    const key = Buffer.from(hkdfSync('sha256', shared, Buffer.alloc(32), Buffer.alloc(0), 32))
+    const expected = createHmac('sha256', key)
+      .update('ticket=hash.abc&path=/passport/web/check_qrconnect/&timestamp=1700000000')
+      .digest('base64')
+    expect(clientData.req_sign).toBe(expected)
+  })
+
+  it('ts.1 形态的票据回落到 web-version 1', () => {
+    const jar = new CookieJar()
+    jar.set('__amagi_tg_ticket', 'hash.abc')
+    jar.set('__amagi_tg_ts_sign', 'ts.1.def')
+    jar.set('__amagi_tg_ecdh', '00'.repeat(32))
+    expect(new TicketGuard(jar).headers('/x')['bd-ticket-guard-web-version']).toBe('1')
+  })
+})
+
+describe('轮询限频', () => {
+  it('error_code=7 判为可重试的 busy，并拉长轮询间隔', () => {
+    const result = parsePollResult({ data: { error_code: 7, description: '访问太频繁', interval: 3000 } })
+    expect(result.status).toBe('busy')
+    expect(result.interval).toBe(6000)
+    expect(result).toHaveProperty('message', '访问太频繁')
+  })
+
+  it('限频没给 interval 时用默认值退避', () => {
+    const result = parsePollResult({ data: { error_code: 7 } })
+    expect(result.status).toBe('busy')
+    expect(result.interval).toBe(6000)
+  })
+
+  it('限频不会被误判成风控', () => {
+    expect(parsePollResult({ data: { error_code: 2156 } }).status).toBe('risk')
+    expect(parsePollResult({ data: { error_code: 7 } }).status).not.toBe('risk')
   })
 })

--- a/packages/core/test/douyin-login.test.ts
+++ b/packages/core/test/douyin-login.test.ts
@@ -1,6 +1,6 @@
 import { createECDH, createHmac, hkdfSync } from 'node:crypto'
 
-import { douyinPassport } from '@ikenxuan/amagi'
+import { douyinPassport, isSmsCodeVerifyWay } from '@ikenxuan/amagi'
 import { describe, expect, it } from 'vitest'
 
 // 协议层实现在 @ikenxuan/amagi 的 passport 模块里，这里锁住 kkk 依赖的那部分行为
@@ -18,7 +18,6 @@ const {
   utcNoonTimestamp,
   xor5Hex
 } = douyinPassport
-
 
 describe('CookieJar', () => {
   it('按下发顺序覆盖同名 cookie，保留最后一次的值', () => {
@@ -302,7 +301,6 @@ describe('aBogus', () => {
   })
 })
 
-
 describe('CookieJar 的本地会话状态', () => {
   it('__amagi_ 前缀的条目不进 Cookie 请求头', () => {
     const jar = new CookieJar('ttwid=abc; __amagi_tg_key=secret')
@@ -330,9 +328,7 @@ describe('TicketGuard', () => {
     const jar = new CookieJar()
     new TicketGuard(jar).publishPublicKey()
 
-    const payload = JSON.parse(
-      Buffer.from(decodeURIComponent(jar.get('bd_ticket_guard_client_data') ?? ''), 'base64').toString('utf8')
-    )
+    const payload = JSON.parse(Buffer.from(decodeURIComponent(jar.get('bd_ticket_guard_client_data') ?? ''), 'base64').toString('utf8'))
     expect(payload['bd-ticket-guard-version']).toBe(2)
     expect(payload['bd-ticket-guard-iteration-version']).toBe(1)
     expect(payload['bd-ticket-guard-web-version']).toBe(2)
@@ -384,15 +380,10 @@ describe('TicketGuard', () => {
     // 用一把临时密钥充当服务端，走与线上一致的 ECDH + HKDF 流程
     const server = createECDH('prime256v1')
     server.generateKeys()
-    const spki = Buffer.concat([
-      Buffer.from('3059301306072a8648ce3d020106082a8648ce3d030107034200', 'hex'),
-      server.getPublicKey()
-    ])
+    const spki = Buffer.concat([Buffer.from('3059301306072a8648ce3d020106082a8648ce3d030107034200', 'hex'), server.getPublicKey()])
     const cert = `pub.${spki.subarray(spki.length - 65).toString('base64')}`
 
-    const serverData = Buffer.from(
-      JSON.stringify({ ticket: 'hash.abc', ts_sign: 'ts.2.def', client_cert: cert })
-    ).toString('base64')
+    const serverData = Buffer.from(JSON.stringify({ ticket: 'hash.abc', ts_sign: 'ts.2.def', client_cert: cert })).toString('base64')
     expect(guard.applyServerData({ 'bd-ticket-guard-server-data': serverData })).toBe(true)
 
     const headers = guard.headers('/passport/web/check_qrconnect/', 1700000000)
@@ -407,9 +398,7 @@ describe('TicketGuard', () => {
     })
 
     // 服务端侧独立复算：ECDH -> HKDF -> HMAC
-    const shared = server.computeSecret(
-      Buffer.from(guard.reePublicKey, 'base64')
-    )
+    const shared = server.computeSecret(Buffer.from(guard.reePublicKey, 'base64'))
     const key = Buffer.from(hkdfSync('sha256', shared, Buffer.alloc(32), Buffer.alloc(0), 32))
     const expected = createHmac('sha256', key)
       .update('ticket=hash.abc&path=/passport/web/check_qrconnect/&timestamp=1700000000')
@@ -443,5 +432,23 @@ describe('轮询限频', () => {
   it('限频不会被误判成风控', () => {
     expect(parsePollResult({ data: { error_code: 2156 } }).status).toBe('risk')
     expect(parsePollResult({ data: { error_code: 7 } }).status).not.toBe('risk')
+  })
+})
+
+describe('二次验证方式识别', () => {
+  it('两种下行短信收码方式都认', () => {
+    expect(isSmsCodeVerifyWay('mobile_sms_verify')).toBe(true)
+    expect(isSmsCodeVerifyWay('assist_mobile_sms_verify')).toBe(true)
+  })
+
+  it('上行短信不算收码方式', () => {
+    expect(isSmsCodeVerifyWay('mobile_up_sms_verify')).toBe(false)
+    expect(isSmsCodeVerifyWay('assist_mobile_up_sms_verify')).toBe(false)
+  })
+
+  it('其它验证方式一律不认', () => {
+    for (const way of ['face_verify', 'pwd_verify', 'qr_code_verify', '', 'mobile_sms_verify_x']) {
+      expect(isSmsCodeVerifyWay(way)).toBe(false)
+    }
   })
 })

--- a/packages/core/vite.config.ts
+++ b/packages/core/vite.config.ts
@@ -74,8 +74,6 @@ export default defineConfig({
         ...[/^node-karin/],
         // @karinjs/template-react 必须打进产物（与模板组件共用同一份 React），其余 @karinjs 包保持外部
         ...[/^@karinjs\/(?!template-react)/],
-        'fingerprint-injector',
-        // '@snapka/puppeteer',
         '@ikenxuan/watermark',
         '@ikenxuan/qrcode'
       ],

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -1,6 +1,19 @@
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
 import { defineConfig } from 'vitest/config'
 
+const root = path.dirname(fileURLToPath(import.meta.url))
+
 export default defineConfig({
+  resolve: {
+    alias: {
+      // 与 tsconfig 的 paths 保持一致：amagi 以源码形式被引用，其内部用的是 amagi/* 自别名
+      '@ikenxuan/amagi': path.resolve(root, '../amagi/packages/core/src/index.ts'),
+      amagi: path.resolve(root, '../amagi/packages/core/src'),
+      '@': path.resolve(root, 'src')
+    }
+  },
   test: {
     include: ['test/**/*.test.ts']
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -154,9 +154,6 @@ importers:
       '@ikenxuan/watermark':
         specifier: 1.3.1
         version: 1.3.1
-      fingerprint-injector:
-        specifier: ^2.1.88
-        version: 2.1.88
     devDependencies:
       '@heroui/react':
         specifier: 3.2.4
@@ -194,9 +191,6 @@ importers:
       '@phosphor-icons/react':
         specifier: ^2.1.10
         version: 2.1.10(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@snapka/puppeteer':
-        specifier: ^0.2.7
-        version: 0.2.7(supports-color@7.2.0)
       '@thesvg/icons':
         specifier: ^3.0.18
         version: 3.2.15
@@ -2148,11 +2142,6 @@ packages:
   '@primer/octicons@19.32.0':
     resolution: {integrity: sha512-a8QHSWZVOFusPWl8EzL7EyHnEtHCvfSqaHyR3fdb1XbetlyXfo4g+aZ2xEuEJH15848LGhcKn9x1PPztCUcgzA==}
 
-  '@puppeteer/browsers@2.13.2':
-    resolution: {integrity: sha512-5EUZSUIc37H6aIXyWO0Z4y8NlF8NnjgmqeQgOGiswAU7pY0HOo16ho4+alIWmSfdZnjqBRawMsP3I5YqLSn6kw==}
-    engines: {node: '>=18'}
-    hasBin: true
-
   '@quansync/fs@1.0.0':
     resolution: {integrity: sha512-4TJ3DFtlf1L5LDMaM6CanJ/0lckGNtJcMjQ1NAV6zDmA0tEHKZtxNKin8EgPaVX1YzljbxckyT2tJrpQKAtngQ==}
 
@@ -3338,27 +3327,9 @@ packages:
     resolution: {integrity: sha512-KxXvfapcixpz6rVEB6HPjOUZT22yN6v0vI0urQSk1L8MlEWPDFCZkhw2xmkyoTGYeFw7tWTZd7e3lVzRZRN/EA==}
     engines: {node: '>=18'}
 
-  '@sindresorhus/is@4.6.0':
-    resolution: {integrity: sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==}
-    engines: {node: '>=10'}
-
   '@sindresorhus/merge-streams@4.0.0':
     resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
     engines: {node: '>=18'}
-
-  '@snapka/browser-finder@0.1.12':
-    resolution: {integrity: sha512-PS6t3OiVom2u+TqcnDyWXx9EQBdMwdCgot9ZWv87R8aCwnuJYPy34xA/+maNgKf9EK5nE2c+9vLQ75V1fv8yyA==}
-
-  '@snapka/browsers@0.4.0':
-    resolution: {integrity: sha512-XQIVmV4zPTPv898gcDdsHbuAoHAaVKKCayl6KG1z/zV1/Ri5Ut+XM/74DA9dSRApFM2bPcr0esqeIPKjQeAsJA==}
-    engines: {node: '>=18'}
-    hasBin: true
-
-  '@snapka/puppeteer@0.2.7':
-    resolution: {integrity: sha512-siidYM+qzHP6nBi/V1cNrxxUjzeES4EzxgLmegZiOhafLBB9yAFGKMYtHHojJTBVAhykikXf8GM45tRq815VXA==}
-
-  '@snapka/types@0.1.5':
-    resolution: {integrity: sha512-DA8ZpY+HpWamrJU1mN/3oR6cZVOrm3tscsILXYOICaecTzvIDf51kjv5NNZkEfdRRjfLfmYKI6QObwjqD2fDug==}
 
   '@spectrum-icons/ui@3.7.1':
     resolution: {integrity: sha512-veQymocUYo5OciXQajSailOdbWe+k6+2ehfF8D4d0V923D4xOUadtT253xXZ5vEQjPat6Kyp2WDKeQNjd7kL1w==}
@@ -3585,9 +3556,6 @@ packages:
     resolution: {integrity: sha512-+3zbTks3TkWTIbuODIdYUQCT04dSyx765jrhT6BKD4K89sE/qsQ0BDBajYTGrUA9g99kJEKOpQKm+LKG0sFeQQ==}
     engines: {node: '>=18'}
 
-  '@tootallnate/quickjs-emscripten@0.23.0':
-    resolution: {integrity: sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==}
-
   '@ts-morph/common@0.27.0':
     resolution: {integrity: sha512-Wf29UqxWDpc+i61k3oIOzcUfQt79PIT9y/MWfAGlrkjg6lBC1hwDECLXPVJAhWjiGbfBCxZd65F/LIZF3+jeJQ==}
 
@@ -3800,9 +3768,6 @@ packages:
 
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
-
-  '@types/yauzl@2.10.3':
-    resolution: {integrity: sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==}
 
   '@typescript/vfs@1.6.4':
     resolution: {integrity: sha512-PJFXFS4ZJKiJ9Qiuix6Dz/OwEIqHD7Dme1UwZhTK11vR+5dqW2ACbdndWQexBzCx+CPuMe5WBYQWCsFyGlQLlQ==}
@@ -4136,17 +4101,9 @@ packages:
   add-stream@1.0.0:
     resolution: {integrity: sha512-qQLMr+8o0WC4FZGQTcJiKBVC59JylcPSrTtk6usvmIDFUOCKegapy1VHQwRbFMOFyb/inzUVqHs+eMYKDM1YeQ==}
 
-  adm-zip@0.6.0:
-    resolution: {integrity: sha512-XleryMhbuksdKtofnWZ9Sk+4CUTbms4Mb/EU32SZwToAyZ5RgVos/ki8n+yr0LWHOGKuakbXTuuYNHLQjhddgg==}
-    engines: {node: '>=14.0'}
-
   agent-base@6.0.2:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
     engines: {node: '>= 6.0.0'}
-
-  agent-base@7.1.4:
-    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
-    engines: {node: '>= 14'}
 
   ahooks@3.9.7:
     resolution: {integrity: sha512-S0lvzhbdlhK36RFBkGv+RbOM/dbbweym+BIHM/bwwuWVSVN5TuVErHPMWo4w0t1NDYg5KPp2iEf7Y7E5LASYiw==}
@@ -4231,10 +4188,6 @@ packages:
     resolution: {integrity: sha512-Q+JC7Whu8HhmTdBph/Tq59IoRtoy6KAm5zzPv00WdujX82lbAL8K7WVjne7vdCsAmbF4AYaDOPyO3k0kl8qIrw==}
     engines: {node: '>=0.10.0'}
 
-  ast-types@0.13.4:
-    resolution: {integrity: sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==}
-    engines: {node: '>=4'}
-
   ast-types@0.16.1:
     resolution: {integrity: sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==}
     engines: {node: '>=4'}
@@ -4260,14 +4213,6 @@ packages:
   axios@1.19.0:
     resolution: {integrity: sha512-ht/iuYZXEjFxLH/Hkezgd7m6JKlHHXEUSneaDz8uZe1Gj5QZtCnpyDsckvAiEnT89OEbCLmnte4R4sn7P0EKFw==}
 
-  b4a@1.8.1:
-    resolution: {integrity: sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==}
-    peerDependencies:
-      react-native-b4a: '*'
-    peerDependenciesMeta:
-      react-native-b4a:
-        optional: true
-
   babel-plugin-macros@3.1.0:
     resolution: {integrity: sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==}
     engines: {node: '>=10', npm: '>=6'}
@@ -4279,51 +4224,10 @@ packages:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
 
-  bare-events@2.9.1:
-    resolution: {integrity: sha512-Z0oHEHAFDZkffN8Qc39zNZjQlMDkPJRyyyZieU1VH7u8c5S+qHZ2S8ixdKIAxEjfHO7FJxXmJWgteOghVanIsg==}
-    peerDependencies:
-      bare-abort-controller: '*'
-    peerDependenciesMeta:
-      bare-abort-controller:
-        optional: true
-
-  bare-fs@4.7.4:
-    resolution: {integrity: sha512-y1kC+ffIx/tPLdTE693uNjHfzTfr+ravR5tvWlMXe25nELbkqV400S71qHDwbkAQ1FVEZobB1NFRzFbCCcyBCQ==}
-    engines: {bare: '>=1.16.0'}
-    peerDependencies:
-      bare-buffer: '*'
-    peerDependenciesMeta:
-      bare-buffer:
-        optional: true
-
-  bare-path@3.1.1:
-    resolution: {integrity: sha512-JprUlveX3QjApC1cTpsUOiscADftCGVWkzitbHsRqv84hzYwYHw2mbluddsq5TvI8mH/8Ov1f4BiMAdcB0oYnQ==}
-
-  bare-stream@2.13.3:
-    resolution: {integrity: sha512-Kc+brLqvEqGkjyfiwJmImAOqLZL7OsoLKuavx+hJjgVV3nLTOjloJyPMFxjUPerGGHrNH0fLU06jjykMLWrERQ==}
-    peerDependencies:
-      bare-abort-controller: '*'
-      bare-buffer: '*'
-      bare-events: '*'
-    peerDependenciesMeta:
-      bare-abort-controller:
-        optional: true
-      bare-buffer:
-        optional: true
-      bare-events:
-        optional: true
-
-  bare-url@2.4.6:
-    resolution: {integrity: sha512-iQxPClE07hETVpbRoX7JXX3v/ZQViCxe/SYCxylRLzdEx1xJAufPptfiOqR8tqiCtmbtMDANKWszzjLu1PMAZQ==}
-
   baseline-browser-mapping@2.11.7:
     resolution: {integrity: sha512-APw5YuIQAg6L9w4sHDI6j26DGFJI6RpYOhnkMPdC9lWbkKvsyPHzDsve1yd73lk21yz7Y09Kci8B2Pp9FonzWA==}
     engines: {node: '>=6.0.0'}
     hasBin: true
-
-  basic-ftp@5.3.1:
-    resolution: {integrity: sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==}
-    engines: {node: '>=10.0.0'}
 
   beautiful-mermaid@1.1.3:
     resolution: {integrity: sha512-TItrtrAyHp1vwFfFVYauWGrquouk/6SS21Aq3RsxindSYZODcN4xYrPZD6BiZRU+o5mKJzDPz9MUSMvELdylyg==}
@@ -4351,9 +4255,6 @@ packages:
     resolution: {integrity: sha512-JxV13hNrFxqjOc8alRbq9dK1MM79NEXYpma2B2J4wAtpWS5zIEIKqWPGCl7N4o7Uc7B7itylh7SuDujATRyyTw==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
-
-  buffer-crc32@0.2.13:
-    resolution: {integrity: sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==}
 
   buffer-equal-constant-time@1.0.1:
     resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
@@ -4439,11 +4340,6 @@ packages:
   chroma-js@3.2.0:
     resolution: {integrity: sha512-os/OippSlX1RlWWr+QDPcGUZs0uoqr32urfxESG9U93lhUfbnlyckte84Q8P1UQY/qth983AS1JONKmLS4T0nw==}
 
-  chromium-bidi@14.0.0:
-    resolution: {integrity: sha512-9gYlLtS6tStdRWzrtXaTMnqcM4dudNegMXJxkR0I/CXObHalYeYcAMPrL19eroNZHtJ8DQmu1E+ZNOYu/IXMXw==}
-    peerDependencies:
-      devtools-protocol: '*'
-
   citty@0.2.2:
     resolution: {integrity: sha512-+6vJA3L98yv+IdfKGZHBNiGW5KHn22e/JwID0Strsz8h4S/csAu/OuICwxrg44k5MRiZHWIo8XXuJgQTriRP4w==}
 
@@ -4466,10 +4362,6 @@ packages:
 
   cliui@6.0.0:
     resolution: {integrity: sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==}
-
-  cliui@8.0.1:
-    resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
-    engines: {node: '>=12'}
 
   clone-regexp@3.0.0:
     resolution: {integrity: sha512-ujdnoq2Kxb8s3ItNBtnYeXdm07FcU0u8ARAT1lQ2YdMwQC+cdiXX8KoqMVuglztILivceTtp4ivqGSmEmhBUJw==}
@@ -4866,10 +4758,6 @@ packages:
   dagre-d3-es@7.0.14:
     resolution: {integrity: sha512-P4rFMVq9ESWqmOgK+dlXvOtLwYg0i7u0HBGJER0LZDJT2VHIPAMZ/riPxqJceWMStH5+E61QxFra9kIS3AqdMg==}
 
-  data-uri-to-buffer@6.0.2:
-    resolution: {integrity: sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==}
-    engines: {node: '>= 14'}
-
   date-fns@4.4.0:
     resolution: {integrity: sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==}
 
@@ -4934,10 +4822,6 @@ packages:
   defu@6.1.7:
     resolution: {integrity: sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==}
 
-  degenerator@5.0.1:
-    resolution: {integrity: sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==}
-    engines: {node: '>= 14'}
-
   delaunator@4.0.1:
     resolution: {integrity: sha512-WNPWi1IRKZfCt/qIDMfERkDp93+iZEmOxN2yy4Jg+Xhv8SLk2UTqqbe1sfiipn0and9QrE914/ihdx82Y/Giag==}
 
@@ -4990,9 +4874,6 @@ packages:
 
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
-
-  devtools-protocol@0.0.1608973:
-    resolution: {integrity: sha512-Tpm17fxYzt+J7VrGdc1k8YdRqS3YV7se/M6KeemEqvUbq/n7At1rWVuXMxQgpWkdwSdIEKYbU//Bve+Shm4YNQ==}
 
   diff@8.0.4:
     resolution: {integrity: sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==}
@@ -5080,9 +4961,6 @@ packages:
     resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
     engines: {node: '>= 0.8'}
 
-  end-of-stream@1.4.5:
-    resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
-
   enhanced-resolve@5.24.4:
     resolution: {integrity: sha512-GVoi+ICHocoOIU7qVVM48wOJziRsqrsyqlI0Ce0LdowRn6v3bcH2zUa9kp85ncx0nwIb9/HOCOLS3fdThDG/XQ==}
     engines: {node: '>=10.13.0'}
@@ -5158,19 +5036,10 @@ packages:
     resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
     engines: {node: '>=12'}
 
-  escodegen@2.1.0:
-    resolution: {integrity: sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==}
-    engines: {node: '>=6.0'}
-    hasBin: true
-
   esprima@4.0.1:
     resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
     engines: {node: '>=4'}
     hasBin: true
-
-  estraverse@5.3.0:
-    resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
-    engines: {node: '>=4.0'}
 
   estree-util-attach-comments@3.0.0:
     resolution: {integrity: sha512-cKUwm/HUcTDsYh/9FgnuFqpfquUbwIqwKM26BVCGDPVgvaCl/nDCCjUfiLlx6lsEZ3Z4RFxNbOQ60pkaEwFxGw==}
@@ -5199,16 +5068,9 @@ packages:
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
 
-  esutils@2.0.3:
-    resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
-    engines: {node: '>=0.10.0'}
-
   etag@1.8.1:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
     engines: {node: '>= 0.6'}
-
-  events-universal@1.0.1:
-    resolution: {integrity: sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==}
 
   eventsource-parser@3.1.0:
     resolution: {integrity: sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==}
@@ -5258,16 +5120,8 @@ packages:
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
 
-  extract-zip@2.0.1:
-    resolution: {integrity: sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==}
-    engines: {node: '>= 10.17.0'}
-    hasBin: true
-
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
-
-  fast-fifo@1.3.2:
-    resolution: {integrity: sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==}
 
   fast-glob@3.3.3:
     resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
@@ -5278,9 +5132,6 @@ packages:
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
-
-  fd-slicer@1.1.0:
-    resolution: {integrity: sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -5328,22 +5179,6 @@ packages:
   find-up@4.1.0:
     resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
     engines: {node: '>=8'}
-
-  fingerprint-generator@2.1.88:
-    resolution: {integrity: sha512-rwYKE/UZTAnfu3DoBgFH+otrRewvkscG8TkiDY8xw7QBga0evHoL7H70HrtP/CBqjspVrfqE7ZYt7qDM3dYk+g==}
-    engines: {node: '>=16.0.0'}
-
-  fingerprint-injector@2.1.88:
-    resolution: {integrity: sha512-npQr/Nc00x3XfbT9TE6RqPLIaYbun63rCL8isGqZVp0mlWw2mAr0J81WsIW3ENZB2w/dkCA9QewA0ufoYMB0Qw==}
-    engines: {node: '>=16.0.0'}
-    peerDependencies:
-      playwright: ^1.22.2
-      puppeteer: '>= 9.x'
-    peerDependenciesMeta:
-      playwright:
-        optional: true
-      puppeteer:
-        optional: true
 
   follow-redirects@1.16.0:
     resolution: {integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==}
@@ -5529,9 +5364,6 @@ packages:
   fuzzysort@3.1.0:
     resolution: {integrity: sha512-sR9BNCjBg6LNgwvxlBd0sBABvQitkLzoVY9MYYROQVX/FvfJ4Mai9LsGhDgd8qYdds0bY77VzYd5iuB+v5rwQQ==}
 
-  generative-bayesian-network@2.1.88:
-    resolution: {integrity: sha512-kxbW6CCsiEAVdBYPont/6ZVOa47Pyfv5ldYFIvj8wmOx9uQOZ4c8wdR0jEf2pE6DeVuIAfmolm+91bYne6/3uA==}
-
   gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
@@ -5560,10 +5392,6 @@ packages:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
     engines: {node: '>= 0.4'}
 
-  get-stream@5.2.0:
-    resolution: {integrity: sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==}
-    engines: {node: '>=8'}
-
   get-stream@6.0.1:
     resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
     engines: {node: '>=10'}
@@ -5578,10 +5406,6 @@ packages:
   get-tsconfig@5.0.0-beta.5:
     resolution: {integrity: sha512-/6gFNr0N04nob252sTQxyFLi3eKFRqIg1I87YcqAMT1i6SQrSF6KujUEQrtrjMV0H/eejTCltLdDSTEMzHbnsQ==}
     engines: {node: '>=20.20.0'}
-
-  get-uri@6.0.5:
-    resolution: {integrity: sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==}
-    engines: {node: '>= 14'}
 
   get-value@2.0.6:
     resolution: {integrity: sha512-Ln0UQDlxH1BapMu3GPtf7CuYNwRZf2gwCuPqbyG6pB8WfmFpzqcy4xtAaAMUhnNqjMKTiCPZG2oMT3YSx8U2NA==}
@@ -5716,10 +5540,6 @@ packages:
   hastscript@9.0.1:
     resolution: {integrity: sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==}
 
-  header-generator@2.1.88:
-    resolution: {integrity: sha512-12GkTL1CDaPTQ6gkd8TPwxNtn7t3wSExnWU9qgWfEDh8IqpD1NAVcvzfHphIzULez8WP2DK9YQsDegajjDdTKQ==}
-    engines: {node: '>=16.0.0'}
-
   heic-decode@2.1.0:
     resolution: {integrity: sha512-0fB3O3WMk38+PScbHLVp66jcNhsZ/ErtQ6u2lMYu/YxXgbBtl+oKOhGQHa4RpvE68k8IzbWkABzHnyAIjR758A==}
     engines: {node: '>=8.0.0'}
@@ -5756,10 +5576,6 @@ packages:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
     engines: {node: '>= 0.8'}
 
-  http-proxy-agent@7.0.2:
-    resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
-    engines: {node: '>= 14'}
-
   http-proxy-middleware@4.2.0:
     resolution: {integrity: sha512-ZA+oNOoM+GLoFTIzhkJptVQov73Srep2LBqhF8hG8CIPKO3nam1jonXVQ/QUH8RbwsmaaVz2SOJdzBNBHNtKbw==}
     engines: {node: ^22.15.0 || ^24.0.0 || >=26.0.0}
@@ -5767,10 +5583,6 @@ packages:
   https-proxy-agent@5.0.1:
     resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
     engines: {node: '>= 6'}
-
-  https-proxy-agent@7.0.6:
-    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
-    engines: {node: '>= 14'}
 
   httpxy@0.5.5:
     resolution: {integrity: sha512-uDjmnPyp1q4Sgzf3w+J/Fc6UqcCEj0x4Wjp7OqK5dGhNeDgpyrAmnS6ey8QWrX3SWDon2DMKf9sBa5X9+CVyMA==}
@@ -6309,10 +6121,6 @@ packages:
   lodash.isboolean@3.0.3:
     resolution: {integrity: sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==}
 
-  lodash.isequal@4.5.0:
-    resolution: {integrity: sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==}
-    deprecated: This package is deprecated. Use require('node:util').isDeepStrictEqual instead.
-
   lodash.isinteger@4.0.4:
     resolution: {integrity: sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==}
 
@@ -6356,10 +6164,6 @@ packages:
 
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
-
-  lru-cache@7.18.3:
-    resolution: {integrity: sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==}
-    engines: {node: '>=12'}
 
   lru_map@0.4.1:
     resolution: {integrity: sha512-I+lBvqMMFfqaV8CJCISjI3wbjmwVu/VyOoU7+qtu9d7ioW5klMgsTTiUOUp+DJvfTTzKXoPbyC6YfgkNcyPSOg==}
@@ -6687,9 +6491,6 @@ packages:
     resolution: {integrity: sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==}
     engines: {node: '>= 18'}
 
-  mitt@3.0.1:
-    resolution: {integrity: sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==}
-
   mixin-deep@1.3.2:
     resolution: {integrity: sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==}
     engines: {node: '>=0.10.0'}
@@ -6741,10 +6542,6 @@ packages:
 
   neo-async@2.6.2:
     resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
-
-  netmask@2.1.1:
-    resolution: {integrity: sha512-eonl3sLUha+S1GzTPxychyhnUzKyeQkZ7jLjKrBagJgPla13F+uQ71HgpFefyHgqrjEbCPkDArxYsjY8/+gLKA==}
-    engines: {node: '>= 0.4.0'}
 
   next-themes@0.4.6:
     resolution: {integrity: sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==}
@@ -6874,10 +6671,6 @@ packages:
     resolution: {integrity: sha512-weP+BZ8MVNnlCm8c0Qdc1WSWq4Qn7I+9CJGm7Qali6g44e/PUzbjNqJX5NJ9ljlNMosfJvg1fKEGILklK9cwnw==}
     engines: {node: '>=18'}
 
-  ow@0.28.2:
-    resolution: {integrity: sha512-dD4UpyBh/9m4X2NVjA+73/ZPBRF+uF4zIMFvvQsabMiEK8x41L3rQ8EENOi35kyyoaJwNxEeJcP6Fj1H4U409Q==}
-    engines: {node: '>=12'}
-
   oxc-resolver@11.24.2:
     resolution: {integrity: sha512-FY91FiDBj7ls5MsFS9jN3tjz2o0/zsdSsymlakySaBwVJZorHhkWyICLZMKxlu1R9vYo+sd3z1jwb4J8x7bNDw==}
 
@@ -6915,10 +6708,6 @@ packages:
     resolution: {integrity: sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==}
     engines: {node: '>=6'}
 
-  p-limit@7.2.0:
-    resolution: {integrity: sha512-ATHLtwoTNDloHRFFxFJdHnG6n2WUeFjaR8XQMFdKIv0xkXjrER8/iG9iu265jOM95zXHAfv9oTkqhrfbIzosrQ==}
-    engines: {node: '>=20'}
-
   p-locate@3.0.0:
     resolution: {integrity: sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==}
     engines: {node: '>=6'}
@@ -6934,14 +6723,6 @@ packages:
   p-try@2.2.0:
     resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
     engines: {node: '>=6'}
-
-  pac-proxy-agent@7.2.0:
-    resolution: {integrity: sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==}
-    engines: {node: '>= 14'}
-
-  pac-resolver@7.0.1:
-    resolution: {integrity: sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==}
-    engines: {node: '>= 14'}
 
   package-manager-detector@1.8.0:
     resolution: {integrity: sha512-yQA4H19AmPEoMUeavPMDIe1higySl/gH/yaQrkT/s07Qp+7pp2hYz30N3z2l5BkjVkF9Ow6o0wjJamm2y7Sn0A==}
@@ -7006,9 +6787,6 @@ packages:
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
-
-  pend@1.2.0:
-    resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
 
   perfect-debounce@2.1.0:
     resolution: {integrity: sha512-LjgdTytVFXeUgtHZr9WYViYSM/g8MkcTPYDlPa3cDqMirHjKiSZPYd6DoL7pK8AJQr+uWkQvCjHNdiMqsrJs+g==}
@@ -7084,10 +6862,6 @@ packages:
     resolution: {integrity: sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==}
     engines: {node: '>=18'}
 
-  progress@2.0.3:
-    resolution: {integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==}
-    engines: {node: '>=0.4.0'}
-
   prompts@2.4.2:
     resolution: {integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==}
     engines: {node: '>= 6'}
@@ -7106,27 +6880,13 @@ packages:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
 
-  proxy-agent@6.5.0:
-    resolution: {integrity: sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==}
-    engines: {node: '>= 14'}
-
-  proxy-from-env@1.1.0:
-    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
-
   proxy-from-env@2.1.0:
     resolution: {integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==}
     engines: {node: '>=10'}
 
-  pump@3.0.4:
-    resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
-
   punycode.js@2.3.1:
     resolution: {integrity: sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==}
     engines: {node: '>=6'}
-
-  puppeteer-core@24.43.1:
-    resolution: {integrity: sha512-T5ScUMAsmhdNbgDR41AGESYeS6V9MSgetkSnVhhW+gXvzC42VesKCn5ld87gAZDJ6vLHL9GkRvY9WtQWSnwFbw==}
-    engines: {node: '>=18'}
 
   qrcode@1.5.4:
     resolution: {integrity: sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg==}
@@ -7730,10 +7490,6 @@ packages:
     resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
     engines: {node: '>= 6.0.0', npm: '>= 3.0.0'}
 
-  socks-proxy-agent@8.0.5:
-    resolution: {integrity: sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==}
-    engines: {node: '>= 14'}
-
   socks@2.8.9:
     resolution: {integrity: sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==}
     engines: {node: '>= 10.0.0', npm: '>= 3.0.0'}
@@ -7808,9 +7564,6 @@ packages:
   stdin-discarder@0.2.2:
     resolution: {integrity: sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==}
     engines: {node: '>=18'}
-
-  streamx@2.28.0:
-    resolution: {integrity: sha512-1Yowhzjf0ivGMrTIkY9hav5TxobO9qIVqUE41fiCGMGgc3CLlf4MY+9AHmZqBWgDTue0fY9zWjYFVyf6Diuobw==}
 
   string-convert@0.2.1:
     resolution: {integrity: sha512-u/1tdPl4yQnPBjnVrmdLo9gtuLvELKsAoRapekWggdiQNvvvum+jYF329d84NAa660KQw7pB2n36KrIKVoXa3A==}
@@ -7926,18 +7679,9 @@ packages:
     resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
     engines: {node: '>=6'}
 
-  tar-fs@3.1.3:
-    resolution: {integrity: sha512-/hU4AXnIdZu+Gvl1pk0oI5f5HxWsCJRtY2aFaJdk9VvyL48DWU6iU5WAIPG+wIi1YvWA6eTJvIviP/tMAZZNwQ==}
-
-  tar-stream@3.2.0:
-    resolution: {integrity: sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==}
-
   tar@7.5.22:
     resolution: {integrity: sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==}
     engines: {node: '>=18'}
-
-  teex@1.0.1:
-    resolution: {integrity: sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==}
 
   temp-dir@3.0.0:
     resolution: {integrity: sha512-nHc6S/bwIilKHNRgK/3jlhDoIHcp45YgyiwcAk46Tr0LfEqGBVpmiAyuiuxeVE44m3mXnEeVhaipLOEWmH+Njw==}
@@ -7946,9 +7690,6 @@ packages:
   tempfile@5.0.0:
     resolution: {integrity: sha512-bX655WZI/F7EoTDw9JvQURqAXiPHi8o8+yFxPF2lWYyz1aHnmMRuXWqL6YB6GmeO0o4DIYWHLgGNi/X64T+X4Q==}
     engines: {node: '>=14.18'}
-
-  text-decoder@1.2.7:
-    resolution: {integrity: sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==}
 
   throttle-debounce@5.0.2:
     resolution: {integrity: sha512-B71/4oyj61iNH0KeCamLuE2rmKuTO5byTOSVwECM5FA7TiAiAW+UqTKZ9ERueC4qvgSttUhdmq1mXC3kJqGX7A==}
@@ -8104,9 +7845,6 @@ packages:
     resolution: {integrity: sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==}
     engines: {node: '>= 18'}
 
-  typed-query-selector@2.12.2:
-    resolution: {integrity: sha512-EOPFbyIub4ngnEdqi2yOcNeDLaX/0jcE1JoAXQDDMIthap7FoN795lc/SHfIq2d416VufXpM8z/lD+WRm2gfOQ==}
-
   typedoc@0.28.20:
     resolution: {integrity: sha512-uSKqkh8Cr48vllnEy+jdaAgOeR6Y+QCBW7usgUsKj7gJEfR7stw9U/fE49LBnj2tPRKPY0c0EBJSWe9Appmplg==}
     engines: {node: '>= 18', pnpm: '>= 10'}
@@ -8250,10 +7988,6 @@ packages:
 
   v8n@1.5.1:
     resolution: {integrity: sha512-LdabyT4OffkyXFCe9UT+uMkxNBs5rcTVuZClvxQr08D5TUgo1OFKkoT65qYRCsiKBl/usHjpXvP4hHMzzDRj3A==}
-
-  vali-date@1.0.0:
-    resolution: {integrity: sha512-sgECfZthyaCKW10N0fm27cg8HYTFK5qMWgypqkXMQ4Wbl/zZKx7xZICgcoxIIE+WFAP/MBL2EFwC/YvLxw3Zeg==}
-    engines: {node: '>=0.10.0'}
 
   valibot@1.4.2:
     resolution: {integrity: sha512-gjdCvJ6d3RyHAneqxMYMW9QMCwYMb3jpOO0IyHZV1bnRHFBHrX3VkIILt5XYR0WhwHiH7Mty8ovuPZ/O3gamrg==}
@@ -8583,9 +8317,6 @@ packages:
   web-namespaces@2.0.1:
     resolution: {integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==}
 
-  webdriver-bidi-protocol@0.4.1:
-    resolution: {integrity: sha512-ARrjNjtWRRs2w4Tk7nqrf2gBI0QXWuOmMCx2hU+1jUt6d00MjMxURrhxhGbrsoiZKJrhTSTzbIrc554iKI10qw==}
-
   which-module@2.0.1:
     resolution: {integrity: sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==}
 
@@ -8611,10 +8342,6 @@ packages:
     resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}
     engines: {node: '>=8'}
 
-  wrap-ansi@7.0.0:
-    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
-    engines: {node: '>=10'}
-
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
@@ -8636,10 +8363,6 @@ packages:
 
   y18n@4.0.3:
     resolution: {integrity: sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==}
-
-  y18n@5.0.8:
-    resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
-    engines: {node: '>=10'}
 
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
@@ -8666,24 +8389,9 @@ packages:
     resolution: {integrity: sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==}
     engines: {node: '>=6'}
 
-  yargs-parser@21.1.1:
-    resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
-    engines: {node: '>=12'}
-
   yargs@15.4.1:
     resolution: {integrity: sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==}
     engines: {node: '>=8'}
-
-  yargs@17.7.3:
-    resolution: {integrity: sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==}
-    engines: {node: '>=12'}
-
-  yauzl@2.10.0:
-    resolution: {integrity: sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==}
-
-  yocto-queue@1.2.2:
-    resolution: {integrity: sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==}
-    engines: {node: '>=12.20'}
 
   yocto-spinner@1.2.2:
     resolution: {integrity: sha512-DODGl1wJjA/s5pnJFKau9lIYHT81lnhob1i3e1TjxZRxEhWRKl74nTbWE6H5KlkViQQTo/Z29YFdxzTZAMY3ng==}
@@ -10429,21 +10137,6 @@ snapshots:
     dependencies:
       object-assign: 4.1.1
 
-  '@puppeteer/browsers@2.13.2(supports-color@7.2.0)':
-    dependencies:
-      debug: 4.4.3(supports-color@7.2.0)
-      extract-zip: 2.0.1(supports-color@7.2.0)
-      progress: 2.0.3
-      proxy-agent: 6.5.0(supports-color@7.2.0)
-      semver: 7.8.5
-      tar-fs: 3.1.3
-      yargs: 17.7.3
-    transitivePeerDependencies:
-      - bare-abort-controller
-      - bare-buffer
-      - react-native-b4a
-      - supports-color
-
   '@quansync/fs@1.0.0':
     dependencies:
       quansync: 1.0.0
@@ -11595,33 +11288,7 @@ snapshots:
 
   '@simple-libs/stream-utils@1.2.0': {}
 
-  '@sindresorhus/is@4.6.0': {}
-
   '@sindresorhus/merge-streams@4.0.0': {}
-
-  '@snapka/browser-finder@0.1.12':
-    dependencies:
-      '@snapka/browsers': 0.4.0
-
-  '@snapka/browsers@0.4.0': {}
-
-  '@snapka/puppeteer@0.2.7(supports-color@7.2.0)':
-    dependencies:
-      '@snapka/browser-finder': 0.1.12
-      '@snapka/browsers': 0.4.0
-      '@snapka/types': 0.1.5
-      debug: 4.4.3(supports-color@7.2.0)
-      p-limit: 7.2.0
-      puppeteer-core: 24.43.1(supports-color@7.2.0)
-    transitivePeerDependencies:
-      - bare-abort-controller
-      - bare-buffer
-      - bufferutil
-      - react-native-b4a
-      - supports-color
-      - utf-8-validate
-
-  '@snapka/types@0.1.5': {}
 
   '@spectrum-icons/ui@3.7.1(@adobe/react-spectrum@3.47.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
@@ -11792,7 +11459,7 @@ snapshots:
       '@tailwindcss/node': 4.3.3
       '@tailwindcss/oxide': 4.3.3
       tailwindcss: 4.3.3
-      vite: 8.1.4(@types/node@24.13.3)(@vitejs/devtools@0.4.10)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
+      vite: 8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
 
   '@tailwindcss/vite@4.3.3(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))':
     dependencies:
@@ -11802,8 +11469,6 @@ snapshots:
       vite: 8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)
 
   '@thesvg/icons@3.2.15': {}
-
-  '@tootallnate/quickjs-emscripten@0.23.0': {}
 
   '@ts-morph/common@0.27.0':
     dependencies:
@@ -12049,11 +11714,6 @@ snapshots:
     dependencies:
       '@types/node': 24.13.3
 
-  '@types/yauzl@2.10.3':
-    dependencies:
-      '@types/node': 24.13.3
-    optional: true
-
   '@typescript/vfs@1.6.4(supports-color@7.2.0)(typescript@6.0.3)':
     dependencies:
       debug: 4.4.3(supports-color@7.2.0)
@@ -12126,7 +11786,7 @@ snapshots:
   '@vitejs/plugin-react@6.0.5(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))':
     dependencies:
       '@rolldown/pluginutils': 1.0.1
-      vite: 8.1.4(@types/node@24.13.3)(@vitejs/devtools@0.4.10)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
+      vite: 8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
 
   '@vitejs/plugin-react@6.0.5(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))':
     dependencies:
@@ -12355,15 +12015,11 @@ snapshots:
 
   add-stream@1.0.0: {}
 
-  adm-zip@0.6.0: {}
-
   agent-base@6.0.2(supports-color@7.2.0):
     dependencies:
       debug: 4.4.3(supports-color@7.2.0)
     transitivePeerDependencies:
       - supports-color
-
-  agent-base@7.1.4: {}
 
   ahooks@3.9.7(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
     dependencies:
@@ -12499,10 +12155,6 @@ snapshots:
 
   assign-symbols@1.0.0: {}
 
-  ast-types@0.13.4:
-    dependencies:
-      tslib: 2.8.1
-
   ast-types@0.16.1:
     dependencies:
       tslib: 2.8.1
@@ -12527,8 +12179,6 @@ snapshots:
       - debug
       - supports-color
 
-  b4a@1.8.1: {}
-
   babel-plugin-macros@3.1.0:
     dependencies:
       '@babel/runtime': 7.29.7
@@ -12539,38 +12189,7 @@ snapshots:
 
   balanced-match@4.0.4: {}
 
-  bare-events@2.9.1: {}
-
-  bare-fs@4.7.4:
-    dependencies:
-      bare-events: 2.9.1
-      bare-path: 3.1.1
-      bare-stream: 2.13.3(bare-events@2.9.1)
-      bare-url: 2.4.6
-      fast-fifo: 1.3.2
-    transitivePeerDependencies:
-      - bare-abort-controller
-      - react-native-b4a
-
-  bare-path@3.1.1: {}
-
-  bare-stream@2.13.3(bare-events@2.9.1):
-    dependencies:
-      b4a: 1.8.1
-      streamx: 2.28.0
-      teex: 1.0.1
-    optionalDependencies:
-      bare-events: 2.9.1
-    transitivePeerDependencies:
-      - react-native-b4a
-
-  bare-url@2.4.6:
-    dependencies:
-      bare-path: 3.1.1
-
   baseline-browser-mapping@2.11.7: {}
-
-  basic-ftp@5.3.1: {}
 
   beautiful-mermaid@1.1.3:
     dependencies:
@@ -12611,8 +12230,6 @@ snapshots:
       electron-to-chromium: 1.5.398
       node-releases: 2.0.51
       update-browserslist-db: 1.2.3(browserslist@4.28.7)
-
-  buffer-crc32@0.2.13: {}
 
   buffer-equal-constant-time@1.0.1: {}
 
@@ -12685,12 +12302,6 @@ snapshots:
 
   chroma-js@3.2.0: {}
 
-  chromium-bidi@14.0.0(devtools-protocol@0.0.1608973):
-    dependencies:
-      devtools-protocol: 0.0.1608973
-      mitt: 3.0.1
-      zod: 3.25.76
-
   citty@0.2.2:
     optional: true
 
@@ -12713,12 +12324,6 @@ snapshots:
       string-width: 4.2.3
       strip-ansi: 6.0.1
       wrap-ansi: 6.2.0
-
-  cliui@8.0.1:
-    dependencies:
-      string-width: 4.2.3
-      strip-ansi: 6.0.1
-      wrap-ansi: 7.0.0
 
   clone-regexp@3.0.0:
     dependencies:
@@ -13131,8 +12736,6 @@ snapshots:
       d3: 7.9.0
       lodash-es: 4.18.1
 
-  data-uri-to-buffer@6.0.2: {}
-
   date-fns@4.4.0: {}
 
   dayjs@1.11.21: {}
@@ -13175,12 +12778,6 @@ snapshots:
   define-lazy-prop@3.0.0: {}
 
   defu@6.1.7: {}
-
-  degenerator@5.0.1:
-    dependencies:
-      ast-types: 0.13.4
-      escodegen: 2.1.0
-      esprima: 4.0.1
 
   delaunator@4.0.1: {}
 
@@ -13232,8 +12829,6 @@ snapshots:
   devlop@1.1.0:
     dependencies:
       dequal: 2.0.3
-
-  devtools-protocol@0.0.1608973: {}
 
   diff@8.0.4: {}
 
@@ -13316,10 +12911,6 @@ snapshots:
   empathic@2.0.1: {}
 
   encodeurl@2.0.0: {}
-
-  end-of-stream@1.4.5:
-    dependencies:
-      once: 1.4.0
 
   enhanced-resolve@5.24.4:
     dependencies:
@@ -13413,17 +13004,7 @@ snapshots:
 
   escape-string-regexp@5.0.0: {}
 
-  escodegen@2.1.0:
-    dependencies:
-      esprima: 4.0.1
-      estraverse: 5.3.0
-      esutils: 2.0.3
-    optionalDependencies:
-      source-map: 0.6.1
-
   esprima@4.0.1: {}
-
-  estraverse@5.3.0: {}
 
   estree-util-attach-comments@3.0.0:
     dependencies:
@@ -13464,15 +13045,7 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.9
 
-  esutils@2.0.3: {}
-
   etag@1.8.1: {}
-
-  events-universal@1.0.1:
-    dependencies:
-      bare-events: 2.9.1
-    transitivePeerDependencies:
-      - bare-abort-controller
 
   eventsource-parser@3.1.0: {}
 
@@ -13568,19 +13141,7 @@ snapshots:
 
   extend@3.0.2: {}
 
-  extract-zip@2.0.1(supports-color@7.2.0):
-    dependencies:
-      debug: 4.4.3(supports-color@7.2.0)
-      get-stream: 5.2.0
-      yauzl: 2.10.0
-    optionalDependencies:
-      '@types/yauzl': 2.10.3
-    transitivePeerDependencies:
-      - supports-color
-
   fast-deep-equal@3.1.3: {}
-
-  fast-fifo@1.3.2: {}
 
   fast-glob@3.3.3:
     dependencies:
@@ -13595,10 +13156,6 @@ snapshots:
   fastq@1.20.1:
     dependencies:
       reusify: 1.1.0
-
-  fd-slicer@1.1.0:
-    dependencies:
-      pend: 1.2.0
 
   fdir@6.5.0(picomatch@4.0.5):
     optionalDependencies:
@@ -13643,17 +13200,6 @@ snapshots:
     dependencies:
       locate-path: 5.0.0
       path-exists: 4.0.0
-
-  fingerprint-generator@2.1.88:
-    dependencies:
-      generative-bayesian-network: 2.1.88
-      header-generator: 2.1.88
-      tslib: 2.8.1
-
-  fingerprint-injector@2.1.88:
-    dependencies:
-      fingerprint-generator: 2.1.88
-      tslib: 2.8.1
 
   follow-redirects@1.16.0(debug@4.4.3(supports-color@7.2.0)):
     optionalDependencies:
@@ -13756,7 +13302,7 @@ snapshots:
       next: 16.3.1(@babel/core@7.29.7(supports-color@7.2.0))(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(babel-plugin-macros@3.1.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       react: 19.2.8
       rolldown: 1.2.1
-      vite: 8.1.4(@types/node@24.13.3)(@vitejs/devtools@0.4.10)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
+      vite: 8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -13823,11 +13369,6 @@ snapshots:
 
   fuzzysort@3.1.0: {}
 
-  generative-bayesian-network@2.1.88:
-    dependencies:
-      adm-zip: 0.6.0
-      tslib: 2.8.1
-
   gensync@1.0.0-beta.2: {}
 
   get-caller-file@2.0.5: {}
@@ -13856,10 +13397,6 @@ snapshots:
       dunder-proto: 1.0.1
       es-object-atoms: 1.1.2
 
-  get-stream@5.2.0:
-    dependencies:
-      pump: 3.0.4
-
   get-stream@6.0.1: {}
 
   get-stream@9.0.1:
@@ -13874,14 +13411,6 @@ snapshots:
   get-tsconfig@5.0.0-beta.5:
     dependencies:
       resolve-pkg-maps: 1.0.0
-
-  get-uri@6.0.5(supports-color@7.2.0):
-    dependencies:
-      basic-ftp: 5.3.1
-      data-uri-to-buffer: 6.0.2
-      debug: 4.4.3(supports-color@7.2.0)
-    transitivePeerDependencies:
-      - supports-color
 
   get-value@2.0.6: {}
 
@@ -14110,13 +13639,6 @@ snapshots:
       property-information: 7.2.0
       space-separated-tokens: 2.0.2
 
-  header-generator@2.1.88:
-    dependencies:
-      browserslist: 4.28.7
-      generative-bayesian-network: 2.1.88
-      ow: 0.28.2
-      tslib: 2.8.1
-
   heic-decode@2.1.0:
     dependencies:
       libheif-js: 1.19.8
@@ -14149,13 +13671,6 @@ snapshots:
       statuses: 2.0.2
       toidentifier: 1.0.1
 
-  http-proxy-agent@7.0.2(supports-color@7.2.0):
-    dependencies:
-      agent-base: 7.1.4
-      debug: 4.4.3(supports-color@7.2.0)
-    transitivePeerDependencies:
-      - supports-color
-
   http-proxy-middleware@4.2.0(supports-color@7.2.0):
     dependencies:
       debug: 4.4.3(supports-color@7.2.0)
@@ -14169,13 +13684,6 @@ snapshots:
   https-proxy-agent@5.0.1(supports-color@7.2.0):
     dependencies:
       agent-base: 6.0.2(supports-color@7.2.0)
-      debug: 4.4.3(supports-color@7.2.0)
-    transitivePeerDependencies:
-      - supports-color
-
-  https-proxy-agent@7.0.6(supports-color@7.2.0):
-    dependencies:
-      agent-base: 7.1.4
       debug: 4.4.3(supports-color@7.2.0)
     transitivePeerDependencies:
       - supports-color
@@ -14599,8 +14107,6 @@ snapshots:
 
   lodash.isboolean@3.0.3: {}
 
-  lodash.isequal@4.5.0: {}
-
   lodash.isinteger@4.0.4: {}
 
   lodash.isnumber@3.0.3: {}
@@ -14639,8 +14145,6 @@ snapshots:
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
-
-  lru-cache@7.18.3: {}
 
   lru_map@0.4.1: {}
 
@@ -15252,8 +14756,6 @@ snapshots:
     dependencies:
       minipass: 7.1.3
 
-  mitt@3.0.1: {}
-
   mixin-deep@1.3.2:
     dependencies:
       for-in: 1.0.2
@@ -15295,8 +14797,6 @@ snapshots:
   negotiator@1.0.0: {}
 
   neo-async@2.6.2: {}
-
-  netmask@2.1.1: {}
 
   next-themes@0.4.6(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
     dependencies:
@@ -15445,14 +14945,6 @@ snapshots:
       string-width: 7.2.0
       strip-ansi: 7.2.0
 
-  ow@0.28.2:
-    dependencies:
-      '@sindresorhus/is': 4.6.0
-      callsites: 3.1.0
-      dot-prop: 6.0.1
-      lodash.isequal: 4.5.0
-      vali-date: 1.0.0
-
   oxc-resolver@11.24.2:
     optionalDependencies:
       '@oxc-resolver/binding-android-arm-eabi': 11.24.2
@@ -15530,10 +15022,6 @@ snapshots:
     dependencies:
       p-try: 2.2.0
 
-  p-limit@7.2.0:
-    dependencies:
-      yocto-queue: 1.2.2
-
   p-locate@3.0.0:
     dependencies:
       p-limit: 2.3.0
@@ -15545,24 +15033,6 @@ snapshots:
   p-timeout@7.0.1: {}
 
   p-try@2.2.0: {}
-
-  pac-proxy-agent@7.2.0(supports-color@7.2.0):
-    dependencies:
-      '@tootallnate/quickjs-emscripten': 0.23.0
-      agent-base: 7.1.4
-      debug: 4.4.3(supports-color@7.2.0)
-      get-uri: 6.0.5(supports-color@7.2.0)
-      http-proxy-agent: 7.0.2(supports-color@7.2.0)
-      https-proxy-agent: 7.0.6(supports-color@7.2.0)
-      pac-resolver: 7.0.1
-      socks-proxy-agent: 8.0.5(supports-color@7.2.0)
-    transitivePeerDependencies:
-      - supports-color
-
-  pac-resolver@7.0.1:
-    dependencies:
-      degenerator: 5.0.1
-      netmask: 2.1.1
 
   package-manager-detector@1.8.0: {}
 
@@ -15620,8 +15090,6 @@ snapshots:
   path-type@4.0.0: {}
 
   pathe@2.0.3: {}
-
-  pend@1.2.0: {}
 
   perfect-debounce@2.1.0:
     optional: true
@@ -15705,8 +15173,6 @@ snapshots:
     dependencies:
       parse-ms: 4.0.0
 
-  progress@2.0.3: {}
-
   prompts@2.4.2:
     dependencies:
       kleur: 3.0.3
@@ -15729,46 +15195,9 @@ snapshots:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
 
-  proxy-agent@6.5.0(supports-color@7.2.0):
-    dependencies:
-      agent-base: 7.1.4
-      debug: 4.4.3(supports-color@7.2.0)
-      http-proxy-agent: 7.0.2(supports-color@7.2.0)
-      https-proxy-agent: 7.0.6(supports-color@7.2.0)
-      lru-cache: 7.18.3
-      pac-proxy-agent: 7.2.0(supports-color@7.2.0)
-      proxy-from-env: 1.1.0
-      socks-proxy-agent: 8.0.5(supports-color@7.2.0)
-    transitivePeerDependencies:
-      - supports-color
-
-  proxy-from-env@1.1.0: {}
-
   proxy-from-env@2.1.0: {}
 
-  pump@3.0.4:
-    dependencies:
-      end-of-stream: 1.4.5
-      once: 1.4.0
-
   punycode.js@2.3.1: {}
-
-  puppeteer-core@24.43.1(supports-color@7.2.0):
-    dependencies:
-      '@puppeteer/browsers': 2.13.2(supports-color@7.2.0)
-      chromium-bidi: 14.0.0(devtools-protocol@0.0.1608973)
-      debug: 4.4.3(supports-color@7.2.0)
-      devtools-protocol: 0.0.1608973
-      typed-query-selector: 2.12.2
-      webdriver-bidi-protocol: 0.4.1
-      ws: 8.21.1
-    transitivePeerDependencies:
-      - bare-abort-controller
-      - bare-buffer
-      - bufferutil
-      - react-native-b4a
-      - supports-color
-      - utf-8-validate
 
   qrcode@1.5.4:
     dependencies:
@@ -16634,14 +16063,6 @@ snapshots:
 
   smart-buffer@4.2.0: {}
 
-  socks-proxy-agent@8.0.5(supports-color@7.2.0):
-    dependencies:
-      agent-base: 7.1.4
-      debug: 4.4.3(supports-color@7.2.0)
-      socks: 2.8.9
-    transitivePeerDependencies:
-      - supports-color
-
   socks@2.8.9:
     dependencies:
       ip-address: 10.3.1
@@ -16702,15 +16123,6 @@ snapshots:
   std-env@4.2.0: {}
 
   stdin-discarder@0.2.2: {}
-
-  streamx@2.28.0:
-    dependencies:
-      events-universal: 1.0.1
-      fast-fifo: 1.3.2
-      text-decoder: 1.2.7
-    transitivePeerDependencies:
-      - bare-abort-controller
-      - react-native-b4a
 
   string-convert@0.2.1: {}
 
@@ -16811,29 +16223,6 @@ snapshots:
 
   tapable@2.3.3: {}
 
-  tar-fs@3.1.3:
-    dependencies:
-      pump: 3.0.4
-      tar-stream: 3.2.0
-    optionalDependencies:
-      bare-fs: 4.7.4
-      bare-path: 3.1.1
-    transitivePeerDependencies:
-      - bare-abort-controller
-      - bare-buffer
-      - react-native-b4a
-
-  tar-stream@3.2.0:
-    dependencies:
-      b4a: 1.8.1
-      bare-fs: 4.7.4
-      fast-fifo: 1.3.2
-      streamx: 2.28.0
-    transitivePeerDependencies:
-      - bare-abort-controller
-      - bare-buffer
-      - react-native-b4a
-
   tar@7.5.22:
     dependencies:
       '@isaacs/fs-minipass': 4.0.1
@@ -16842,24 +16231,11 @@ snapshots:
       minizlib: 3.1.0
       yallist: 5.0.0
 
-  teex@1.0.1:
-    dependencies:
-      streamx: 2.28.0
-    transitivePeerDependencies:
-      - bare-abort-controller
-      - react-native-b4a
-
   temp-dir@3.0.0: {}
 
   tempfile@5.0.0:
     dependencies:
       temp-dir: 3.0.0
-
-  text-decoder@1.2.7:
-    dependencies:
-      b4a: 1.8.1
-    transitivePeerDependencies:
-      - react-native-b4a
 
   throttle-debounce@5.0.2: {}
 
@@ -17020,8 +16396,6 @@ snapshots:
       media-typer: 1.1.1
       mime-types: 3.0.2
 
-  typed-query-selector@2.12.2: {}
-
   typedoc@0.28.20(typescript@6.0.3):
     dependencies:
       '@gerrit0/mini-shiki': 3.23.0
@@ -17150,8 +16524,6 @@ snapshots:
   uuid@14.0.1: {}
 
   v8n@1.5.1: {}
-
-  vali-date@1.0.0: {}
 
   valibot@1.4.2(typescript@6.0.3):
     optionalDependencies:
@@ -17462,6 +16834,21 @@ snapshots:
       tsx: 4.23.1
       yaml: 2.9.0
 
+  vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0):
+    dependencies:
+      lightningcss: 1.33.0
+      picomatch: 4.0.5
+      postcss: 8.5.26
+      rolldown: 1.1.5
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      '@types/node': 24.13.3
+      esbuild: 0.28.1
+      fsevents: 2.3.3
+      jiti: 2.7.0
+      tsx: 4.23.1
+      yaml: 2.9.0
+
   vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0):
     dependencies:
       lightningcss: 1.33.0
@@ -17518,8 +16905,6 @@ snapshots:
 
   web-namespaces@2.0.1: {}
 
-  webdriver-bidi-protocol@0.4.1: {}
-
   which-module@2.0.1: {}
 
   which@2.0.2:
@@ -17543,12 +16928,6 @@ snapshots:
       string-width: 4.2.3
       strip-ansi: 6.0.1
 
-  wrap-ansi@7.0.0:
-    dependencies:
-      ansi-styles: 4.3.0
-      string-width: 4.2.3
-      strip-ansi: 6.0.1
-
   wrappy@1.0.2: {}
 
   ws@8.21.1: {}
@@ -17559,8 +16938,6 @@ snapshots:
       powershell-utils: 0.1.0
 
   y18n@4.0.3: {}
-
-  y18n@5.0.8: {}
 
   yallist@3.1.1: {}
 
@@ -17577,8 +16954,6 @@ snapshots:
       camelcase: 5.3.1
       decamelize: 1.2.0
 
-  yargs-parser@21.1.1: {}
-
   yargs@15.4.1:
     dependencies:
       cliui: 6.0.0
@@ -17592,23 +16967,6 @@ snapshots:
       which-module: 2.0.1
       y18n: 4.0.3
       yargs-parser: 18.1.3
-
-  yargs@17.7.3:
-    dependencies:
-      cliui: 8.0.1
-      escalade: 3.2.0
-      get-caller-file: 2.0.5
-      require-directory: 2.1.1
-      string-width: 4.2.3
-      y18n: 5.0.8
-      yargs-parser: 21.1.1
-
-  yauzl@2.10.0:
-    dependencies:
-      buffer-crc32: 0.2.13
-      fd-slicer: 1.1.0
-
-  yocto-queue@1.2.2: {}
 
   yocto-spinner@1.2.2:
     dependencies:


### PR DESCRIPTION
> [!IMPORTANT]
> 依赖上游 **ikenxuan/amagi#185**。submodule `packages/amagi` 暂时指向那条分支，上游合并后需要把指针改回 `main` 再合这个 PR。
>
> 替代已关闭的 #351 / #352。

### Summary

- 移除抖音扫码登录对 Puppeteer/Chromium 的依赖，改为纯 HTTP
- 协议层下沉到 `@ikenxuan/amagi`，本仓库只留 Karin 侧交互编排，与现在 B 站登录的分工一致
- 支持扫码状态轮询、手机确认、短信二次验证（`error_code=2046` / `account_flow=verify`）
- 登录 Cookie 持久化到现有配置并重载 Amagi Client
- 安装体积与运行内存下降：不再下载 Chromium，也不再为一次登录起一个浏览器进程

`douyinLogin(e: Message)` 签名不变，二维码仍走 `Render(e, 'douyin/qrcodeImg', ...)`，`admin.ts` 一行没动。

### Implementation

`login.ts` 从 588 行缩到一个状态机，只做交互：

```
requestPassportQrcode ──> checkPassportQrcode ──┬─ new       ──> 继续轮询
                                                ├─ scanned   ──> 撤回二维码，提示手机确认
                                                ├─ verify    ──> 发码 ─> karin.ctx 收码 ─> 验码 ─> 回到轮询
                                                ├─ confirmed ──> 写配置 + reload Amagi
                                                ├─ expired / risk ──> 提示并结束
                                                └─ unknown   ──> 记日志后继续轮询
```

签名、CookieJar、环境指纹、SSO 跳转、响应解析全在 amagi 的 `douyinFetcher` 里，这边只持有一个随每步刷新的 `cookie` 字符串。

**timeout / retry**：等待扫码 120 秒（与消息可撤回窗口对齐），扫码或验证成功后各续 180 秒；验证码走 `karin.ctx(e, { time: 90, throwOnTimeout: false })` 的原生超时，不再用 `Promise.race` 兜，没有悬挂 Promise；只收 6 位数字，最多 3 次，仅 `error_code=1202`（验证码错误）允许重试；轮询是 `while` + `await sleep(interval)`，没有 `setInterval`；全程发出的消息统一登记，任意分支退出前都会撤回。

**代理**：登录请求把 `Config.amagi` 的 `timeout` 与 `proxy` 透传给 amagi 的 `requestConfig`，与其它抖音请求走同一条出口。

### Dependency changes

删除（`packages/core`）：

- `@snapka/puppeteer` `^0.2.7`
- `fingerprint-injector` `^2.1.88`

连带从 lockfile 移除 `@puppeteer/browsers`、`@snapka/browsers`、`@snapka/browser-finder`、`@snapka/types`、`@tootallnate/quickjs-emscripten`、`@types/yauzl` 等传递依赖，`pnpm-lock.yaml` 净减 660 行。同步清掉 `vite.config.ts` 里 `fingerprint-injector` 的 external 声明。

新增依赖：**无**。

装 karin-plugin-kkk 不会再为了抖音登录下载 Chromium。

### Credits

Passport login flow referenced from:
https://github.com/dmmdekkd/DouyinDataAPI

协议实现与出处说明在 amagi 那个 PR 里。

### Test

```
pnpm install    # pnpm 11.18.0，lockfile 只减少 puppeteer 相关条目
pnpm build      # core + web 均构建成功
pnpm lint       # oxlint 无输出
pnpm vitest run # 3 个测试文件 / 37 个用例全部通过
tsc --noEmit    # login.ts 无报错（仓库其余 55 个报错是 main 上就有的项目引用问题）
```

新增 `packages/core/test/douyin-login.test.ts`，从 `@ikenxuan/amagi` 的 `douyinPassport` 取协议构件，全部离线可跑：

- CookieJar：同名覆盖、不产生重复项、多条 Set-Cookie 合并、`Max-Age=0` 与过期删除、未来 `Expires` 不误删、畸形输入、`ttwid` 不算登录态
- `parseQrcode` / `parsePollResult` / `parseSendCodeResult` / `parseValidateCodeResult` 的全部分支，含空响应与畸形响应
- 签名基元：SM3 国标测试向量、xor5 编码、`sign`/`qs` 只取排序后前 10 个参数、`aid-sign` 随路径变化

`vitest.config.ts` 补了 `@ikenxuan/amagi` / `amagi` / `@` 三个 alias，与 tsconfig 的 paths 对齐，否则以源码形式引用 amagi 时它内部的自别名解析不了。

真实联调（integration，不进 CI）：取码返回 `error_code 0` 与有效 token，轮询返回 `status: "new"`。

### 已知限制

- 二次验证只做了短信。服务端若只给扫脸 / 上行短信 / 密码验证，会明确提示不支持而不是静默失败
- 二维码过期不自动续码，提示用户重新发起
- 扫码确认之后那一段与 2FA 分支需要真机扫码，未做端到端实测
